### PR TITLE
make fuzzPriv.enableAccessibility() enable accessibility in the main …

### DIFF
--- a/dom/extension/components/domfuzzhelperobserver.js
+++ b/dom/extension/components/domfuzzhelperobserver.js
@@ -53,6 +53,7 @@ DOMFuzzHelperObserver.prototype = {
       messageManager.addMessageListener("DOMFuzzHelper.quitApplicationSoon", this);
       messageManager.addMessageListener("DOMFuzzHelper.quitWithLeakCheck", this);
       messageManager.addMessageListener("DOMFuzzHelper.getProfileDirectory", this);
+      messageManager.addMessageListener("DOMFuzzHelper.enableAccessibility", this);
       messageManager.addMessageListener("DOMFuzzHelper.getBinDirectory", this);
 
       messageManager.loadFrameScript("chrome://domfuzzhelper/content/fuzzPriv.js", true);
@@ -101,6 +102,17 @@ DOMFuzzHelperObserver.prototype = {
 
       case "DOMFuzzHelper.getBinDirectory":
         return getBinDirectory();
+
+      case "DOMFuzzHelper.enableAccessibility":
+        try {
+          Components.classes["@mozilla.org/accessibilityService;1"]
+            .getService(Components.interfaces.nsIAccessibleRetrieval);
+          dump("Enabled accessibility!\n");
+        } catch(e) {
+          dump("Couldn't enable accessibility: " + e + "\n");
+        }
+
+        break;
 
       default:
         dumpln("Unrecognized message sent to domfuzzhelperobserver.js");

--- a/dom/extension/content/fuzzPriv.js
+++ b/dom/extension/content/fuzzPriv.js
@@ -147,13 +147,8 @@ function runSoon(f)
 
 function enableAccessibility()
 {
-  try {
-    Components.classes["@mozilla.org/accessibilityService;1"]
-      .getService(Components.interfaces.nsIAccessibleRetrieval);
-    dump("Enabled accessibility!\n");
-  } catch(e) {
-    dump("Couldn't enable accessibility: " + e + "\n");
-  }
+	dumpln("fuzzPriv.enableAccessibility");
+        sendAsyncMessage('DOMFuzzHelper.enableAccessibility', {});
 }
 
 function sendMemoryPressureNotification()


### PR DESCRIPTION
…process

 It may be interesting to test the case accessibility is only enabled in
one child process at some point, but for now the common case that it is
enabled in both the parent and child processes.  So for now always test
the configuration where accessibility is enabled in all processes
rendering content.