### PR TITLE
Remove __noSuchMethod__ since bug 683218 is landing.

### DIFF
--- a/js/jsfunfuzz/gen-grammar.js
+++ b/js/jsfunfuzz/gen-grammar.js
@@ -701,7 +701,6 @@ var incDecOps = [
 
 var specialProperties = [
   "__iterator__", "__count__",
-  "__noSuchMethod__",
   "__parent__", "__proto__", "constructor", "prototype",
   "wrappedJSObject",
   "arguments", "caller", "callee",

--- a/js/shared/testing-functions.js
+++ b/js/shared/testing-functions.js
@@ -122,9 +122,6 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     // Generate an LCOV trace (but throw away the returned string)
     { w: 1,  v: function(d, b) { return "void " + prefix + "getLcovInfo" + "();"; } },
     { w: 1,  v: function(d, b) { return "void " + prefix + "getLcovInfo" + "(" + fGlobal(d, b) + ");"; } },
-
-    // Enable the deprecated, non-standard __noSuchMethod__ feature
-    { w: 1,  v: function(d, b) { return prefix + "enableNoSuchMethod();"; } },
   ];
 
   // Functions only in the SpiderMonkey shell


### PR DESCRIPTION
Bug 683218 removes `__noSuchMethod__`.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=683218