### PR TITLE
Minor bug fixes and new features

### DIFF
--- a/util/downloadBuild.py
+++ b/util/downloadBuild.py
@@ -404,8 +404,8 @@ def main():
     options = parseOptions()
     # On Windows, is a path surrounded with quotes ends with '\', the last quote is considered escaped and will be
     # part of the option. This is not what the user expects, so remove any trailing quotes from paths:
-    options.remoteDir = options.remoteDir.rstrip('"');
-    options.downloadFolder = options.downloadFolder.rstrip('"');
+    options.remoteDir = options.remoteDir and options.remoteDir.rstrip('"');
+    options.downloadFolder = options.downloadFolder and options.downloadFolder.rstrip('"');
     if options.remoteDir is not None:
         print downloadBuild(options.remoteDir, options.downloadFolder, jsShell=options.enableJsShell, wantTests=options.wantTests)
     else:

--- a/util/downloadBuild.py
+++ b/util/downloadBuild.py
@@ -402,7 +402,7 @@ def defaultBuildType(repoName, arch, debug):
 
 def main():
     options = parseOptions()
-    # On Windows, is a path surrounded with quotes ends with '\', the last quote is considered escaped and will be
+    # On Windows, if a path surrounded by quotes ends with '\', the last quote is considered escaped and will be
     # part of the option. This is not what the user expects, so remove any trailing quotes from paths:
     options.remoteDir = options.remoteDir and options.remoteDir.rstrip('"');
     options.downloadFolder = options.downloadFolder and options.downloadFolder.rstrip('"');

--- a/util/downloadBuild.py
+++ b/util/downloadBuild.py
@@ -20,7 +20,6 @@ useCurl = False
 # Another bug for Windows??
 wgetMaybeNCC = ['--no-check-certificate']
 
-
 def readFromURL(url):
     '''
     Reads in a URL and returns its contents as a list.
@@ -403,7 +402,10 @@ def defaultBuildType(repoName, arch, debug):
 
 def main():
     options = parseOptions()
-    if options.downloadFolder[-1] == '"': options.downloadFolder = options.downloadFolder[:-1];
+    # On Windows, is a path surrounded with quotes ends with '\', the last quote is considered escaped and will be
+    # part of the option. This is not what the user expects, so remove any trailing quotes from paths:
+    options.remoteDir = options.remoteDir.rstrip('"');
+    options.downloadFolder = options.downloadFolder.rstrip('"');
     if options.remoteDir is not None:
         print downloadBuild(options.remoteDir, options.downloadFolder, jsShell=options.enableJsShell, wantTests=options.wantTests)
     else:

--- a/util/downloadBuild.py
+++ b/util/downloadBuild.py
@@ -65,6 +65,7 @@ def parseOptions():
         downloadFolder=os.getcwdu(),
         repoName='mozilla-central',
         enableJsShell=False,
+        wantTests=False,
     )
 
     parser.add_option('-c', '--compiletype', dest='compileType',
@@ -85,6 +86,8 @@ def parseOptions():
                            'from. The default is to grab the latest from mozilla-central.')
     parser.add_option('-s', '--enable-jsshell', dest='enableJsShell', action='store_true',
                       help='Sets the compile type to be fuzzed. Defaults to "%default".')
+    parser.add_option('-t', '--want-tests', dest='wantTests', action='store_true',
+                      help='Download tests. Defaults to "%default".')
 
     options, args = parser.parse_args()
     assert options.compileType in ['dbg', 'opt']
@@ -251,7 +254,7 @@ def downloadBuild(httpDir, targetDir, jsShell=False, wantSymbols=True, wantTests
                 downloadURL(stackwalkUrl, stackwalk)
                 os.chmod(stackwalk, stat.S_IRWXU)
                 gotApp = True
-            if remotefn.endswith('.win32.zip'):
+            if remotefn.endswith('.win32.zip') or remotefn.endswith('.win64.zip'):
                 print 'Downloading application...',
                 dlAction = downloadURL(remotefn, localfn)
                 print 'extracting...',
@@ -349,13 +352,13 @@ def getBuildList(buildType, earliestBuild='default', latestBuild='default'):
     return buildDirs
 
 
-def downloadLatestBuild(buildType, workingDir, getJsShell=False):
+def downloadLatestBuild(buildType, workingDir, getJsShell=False, wantTests=False):
     '''
     Downloads the latest build based on machine type, e.g. mozilla-central-macosx64-debug.
     '''
     # Try downloading the latest build first.
     for buildURL in reversed(getBuildList(buildType)):
-        if downloadBuild(buildURL, workingDir, jsShell=getJsShell):
+        if downloadBuild(buildURL, workingDir, jsShell=getJsShell, wantTests=False):
             return buildURL
     raise Exception("No complete builds found.")
 
@@ -400,8 +403,9 @@ def defaultBuildType(repoName, arch, debug):
 
 def main():
     options = parseOptions()
+    if options.downloadFolder[-1] == '"': options.downloadFolder = options.downloadFolder[:-1];
     if options.remoteDir is not None:
-        print downloadBuild(options.remoteDir, options.downloadFolder, jsShell=options.enableJsShell)
+        print downloadBuild(options.remoteDir, options.downloadFolder, jsShell=options.enableJsShell, wantTests=options.wantTests)
     else:
         buildType = defaultBuildType(options.repoName, options.arch, (options.compileType == 'dbg'))
         downloadLatestBuild(buildType, options.downloadFolder,

--- a/util/subprocesses.py
+++ b/util/subprocesses.py
@@ -24,6 +24,13 @@ isWin = (platform.system() == 'Windows')
 isWin64 = ('PROGRAMFILES(X86)' in os.environ)
 # Note that sys.getwindowsversion will be inaccurate from Win8+ onwards: http://stackoverflow.com/q/19128219
 isWinVistaOrHigher = isWin and (sys.getwindowsversion()[0] >= 6)
+# This refers to the Win-specific "MozillaBuild" environment in which Python is running, which is
+# spawned from the MozillaBuild script for 64-bit compilers, e.g. start-msvc10-x64.bat
+if os.environ.get('MOZ_MSVCBITS'):
+    isMozBuild64 = isWin and '64' in os.environ['MOZ_MSVCBITS']  # For MozillaBuild 2.0.0
+elif os.environ.get('MOZ_TOOLS'):
+    isMozBuild64 = (os.name == 'nt') and ('x64' in os.environ['MOZ_TOOLS'].split(os.sep)[-1])  # For MozillaBuild 1.x
+# else do not set; the script is running stand-alone and the isMozBuild64 variable should not be needed.
 
 noMinidumpMsg = r'''
 WARNING: Minidumps are not being generated, so all crashes will be uninteresting.

--- a/util/subprocesses.py
+++ b/util/subprocesses.py
@@ -24,12 +24,6 @@ isWin = (platform.system() == 'Windows')
 isWin64 = ('PROGRAMFILES(X86)' in os.environ)
 # Note that sys.getwindowsversion will be inaccurate from Win8+ onwards: http://stackoverflow.com/q/19128219
 isWinVistaOrHigher = isWin and (sys.getwindowsversion()[0] >= 6)
-# This refers to the Win-specific "MozillaBuild" environment in which Python is running, which is
-# spawned from the MozillaBuild script for 64-bit compilers, e.g. start-msvc10-x64.bat
-if os.environ.get('MOZ_MSVCBITS'):
-    isMozBuild64 = isWin and '64' in os.environ['MOZ_MSVCBITS']  # For MozillaBuild 2.0.0
-else:
-    isMozBuild64 = (os.name == 'nt') and ('x64' in os.environ['MOZ_TOOLS'].split(os.sep)[-1])  # For MozillaBuild 1.x
 
 noMinidumpMsg = r'''
 WARNING: Minidumps are not being generated, so all crashes will be uninteresting.


### PR DESCRIPTION
* The downloadBuild.py script was unable to download win64 builds. Now it is.
* The downloadBuild.py script now has an option to download tests; it no longer downloads them by default. THIS CHANGES THE DEFAULT BEHAVIOR, YOU MAY WISH TO CHANGE THAT BACK.
* The subprocesses.py script required setting some environment variables for no apparent reason, so I removed them to allow the script to work if they are not set.