### PR TITLE
Bump gczeal maximum number, see bug 1272604.

### DIFF
--- a/js/shared/testing-functions.js
+++ b/js/shared/testing-functions.js
@@ -12,7 +12,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
 
   function enableGCZeal()
   {
-    var level = rnd(15);
+    var level = rnd(16);
     if (browser && level == 9) level = 0; // bug 815241
     var period = numberOfAllocs();
     return prefix + "gczeal" + "(" + level + ", " + period + ");";

--- a/js/shellFlags.py
+++ b/js/shellFlags.py
@@ -85,7 +85,8 @@ def randomFlagSet(shellPath):
     #    args.append("--ion-sink=on")  # --ion-sink=on landed in bug 1093674
 
     if shellSupportsFlag(shellPath, '--gc-zeal=0') and chance(.9):
-        gczealValue = 14 if chance(0.5) else random.randint(0, 14)  # Focus test compacting GC (14)
+        # Focus testing on CheckHeapOnMovingGC (15), see https://hg.mozilla.org/mozilla-central/rev/69ea294ab4b6
+        gczealValue = 15 if chance(0.5) else random.randint(0, 15)
         args.append("--gc-zeal=" + str(gczealValue))  # --gc-zeal= landed in bug 1101602
 
     if shellSupportsFlag(shellPath, '--enable-small-chunk-size') and chance(.1):


### PR DESCRIPTION
The maximum number for gczeal was bumped to 15 in [bug 1272604](https://bugzilla.mozilla.org/show_bug.cgi?id=1272604).

@jruderman: is the change to "rnd(16)" correct? It will then generate numbers 0 to 15 IIRC..