### PR TITLE
gdb SpiderMonkey unwinder does not work with latest versions of gdb

### DIFF
--- a/util/gdb-quick.txt
+++ b/util/gdb-quick.txt
@@ -1,9 +1,11 @@
 set pagination 0
 set backtrace limit 250
 
+#SpiderMonkey unwinder is disabled until issues with gdb are fixed
+#https://hg.mozilla.org/integration/mozilla-inbound/rev/9861363aaea9
 # https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Hacking_Tips#Printing_the_JS_stack_%28from_gdb%29
-echo \n\nenable unwinder .* SpiderMonkey\n\n
-enable unwinder .* SpiderMonkey
+#echo \n\nenable unwinder .* SpiderMonkey\n\n
+#enable unwinder .* SpiderMonkey
 
 # nbp mentioned over IRC to first run `backtrace 0` in order to work around a "gdb issue"
 echo \n\nbacktrace 0\n\n

--- a/util/gdb-quick.txt
+++ b/util/gdb-quick.txt
@@ -1,11 +1,11 @@
 set pagination 0
 set backtrace limit 250
 
-#SpiderMonkey unwinder is disabled until issues with gdb are fixed
-#https://hg.mozilla.org/integration/mozilla-inbound/rev/9861363aaea9
+# SpiderMonkey unwinder is disabled until issues with gdb are fixed
+# https://hg.mozilla.org/integration/mozilla-inbound/rev/9861363aaea9
 # https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Hacking_Tips#Printing_the_JS_stack_%28from_gdb%29
-#echo \n\nenable unwinder .* SpiderMonkey\n\n
-#enable unwinder .* SpiderMonkey
+# echo \n\nenable unwinder .* SpiderMonkey\n\n
+# enable unwinder .* SpiderMonkey
 
 # nbp mentioned over IRC to first run `backtrace 0` in order to work around a "gdb issue"
 echo \n\nbacktrace 0\n\n


### PR DESCRIPTION
This commit comments the "enable unwinder" command in the gdb-quick.txt file.
The used python script does not work with the latest versions of gdb.
