### PR TITLE
Fix #69 - getRepoHashAndId should use striped input data, thanks to @…

### DIFF
--- a/util/hgCmds.py
+++ b/util/hgCmds.py
@@ -83,6 +83,7 @@ def getRepoHashAndId(repoDir, repoRev='parents() and default'):
     if not onDefault:
         updateDefault = raw_input('Not on default tip! ' +
                                   'Would you like to (a)bort, update to (d)efault, or (u)se this rev: ')
+        updateDefault = updateDefault.strip()
         if updateDefault == 'a':
             print 'Aborting...'
             sys.exit(0)


### PR DESCRIPTION
…lovesuae for reporting this.

At some point, we should probably raw_input with some logic that is more elegant, but this should do as a spotfix for now.

@jschwartzentruber does this sound good?