### PR TITLE
Bump gczeal maximum number, see bug 1287869.

### DIFF
--- a/js/shared/testing-functions.js
+++ b/js/shared/testing-functions.js
@@ -13,7 +13,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
 
   function enableGCZeal()
   {
-    var level = rnd(16);
+    var level = rnd(17);
     if (browser && level == 9) level = 0; // bug 815241
     var period = numberOfAllocs();
     return prefix + "gczeal" + "(" + level + ", " + period + ");";

--- a/js/shellFlags.py
+++ b/js/shellFlags.py
@@ -85,8 +85,9 @@ def randomFlagSet(shellPath):
     #    args.append("--ion-sink=on")  # --ion-sink=on landed in bug 1093674
 
     if shellSupportsFlag(shellPath, '--gc-zeal=0') and chance(.9):
-        # Focus testing on CheckHeapOnMovingGC (15), see https://hg.mozilla.org/mozilla-central/rev/69ea294ab4b6
-        gczealValue = 15 if chance(0.5) else random.randint(0, 15)
+        # Focus testing on CheckNursery (16), see:
+        #     https://hg.mozilla.org/mozilla-central/rev/bdbb5822afe1
+        gczealValue = 16 if chance(0.5) else random.randint(0, 16)
         args.append("--gc-zeal=" + str(gczealValue))  # --gc-zeal= landed in bug 1101602
 
     if shellSupportsFlag(shellPath, '--enable-small-chunk-size') and chance(.1):


### PR DESCRIPTION
The maximum number for gczeal was bumped to 16 in bug 1287869.

See a previous number bump in #40. It is an almost identical change so I will merge this right away.