### PR TITLE
Add support for --ion-aa=[flow-sensitive|flow-insensitive], r=truber

### DIFF
--- a/autobisect-js/knownBrokenEarliestWorking.py
+++ b/autobisect-js/knownBrokenEarliestWorking.py
@@ -116,6 +116,9 @@ def earliestKnownWorkingRev(options, flags, skipRevs):
 
     if options.buildWithClang and sps.isWin:
         required.append('3b26d191d84e')  # m-c 316445 Fx52, 1st w/ reliable Clang 3.9.0 builds on Windows
+    if '--ion-aa=flow-sensitive' in flags or '--ion-aa=flow-insensitive' in flags:
+        # m-c 295435 Fx49, 1st w/--ion-aa=[flow-sensitive|flow-insensitive], see bug 1255008
+        required.append('c0c1d923c292')
     if "--ion-pgo=on" in flags:
         required.append('b0a0ff5fa705')  # m-c 272274 Fx45, 1st w/--ion-pgo=on, see bug 1209515
     if options.buildWithAsan:

--- a/js/shellFlags.py
+++ b/js/shellFlags.py
@@ -43,6 +43,13 @@ def randomFlagSet(shellPath):
     if shellSupportsFlag(shellPath, '--fuzzing-safe'):
         args.append("--fuzzing-safe")  # --fuzzing-safe landed in bug 885361
 
+    # Landed in m-c changeset c0c1d923c292, see bug 1255008
+    if shellSupportsFlag(shellPath, '--ion-aa=flow-sensitive'):
+        if chance(.4):
+            args.append('--ion-aa=flow-sensitive')
+        elif shellSupportsFlag(shellPath, '--ion-aa=flow-insensitive') and chance(.4):
+            args.append('--ion-aa=flow-insensitive')
+
     # See bug 932517, which had landed to fix this issue. Keeping this around for archives:
     #   Original breakage in m-c rev 269359 : https://hg.mozilla.org/mozilla-central/rev/a0ccab2a6e28
     #   Fix in m-c rev 269896: https://hg.mozilla.org/mozilla-central/rev/3bb8446a6d8d


### PR DESCRIPTION
Hannes Vershore mentioned over email that this flag combination is now ready for fuzzing, so let's land this as a start and see if anything on the m-c tree immediately breaks.