### PR TITLE
Fixed bug preventing last list item from being considered in Random.choose

### DIFF
--- a/js/shared/random.js
+++ b/js/shared/random.js
@@ -83,7 +83,7 @@ var Random = {
     }
     var n = this.number(total);
     for (var i = 0; i < list.length; i++) {
-      if (n <= list[i][0]) {
+      if (n < list[i][0]) {
         if (flat == true) {
           return list[i][1];
         } else {


### PR DESCRIPTION
Fixes a bug reported by "hehe" via IRC.  The last index in an array won't be considered when selecting a random item via Random.choose.