### PR TITLE
Care about submitting crashes and assertion failures even in the pres…

### DIFF
--- a/js/jsInteresting.py
+++ b/js/jsInteresting.py
@@ -115,7 +115,12 @@ class ShellResult:
         crashInfo = CrashInfo.CrashInfo.fromRawCrashData(out, err, pc, auxCrashData=auxCrashData)
 
         createCollector.printCrashInfo(crashInfo)
-        if not isinstance(crashInfo, CrashInfo.NoCrashInfo):
+        # We only care about crashes and assertion failures on shells with no symbols
+        # Note that looking out for the Assertion failure message is highly SpiderMonkey-specific
+        if not isinstance(crashInfo, CrashInfo.NoCrashInfo) or \
+                'Assertion failure: ' in str(crashInfo.rawStderr) or \
+                'Segmentation fault' in str(crashInfo.rawStderr) or \
+                'Bus error' in str(crashInfo.rawStderr):
             lev = max(lev, JS_NEW_ASSERT_OR_CRASH)
 
         match = options.collector.search(crashInfo)


### PR DESCRIPTION
…ence of NoCrashInfo, i.e. in the absence of more crash information.

Jason/truber, if you want, please suggest a cleaner (yet clear) way if possible.

I thought of doing:

```
if isinstance(crashInfo, CrashInfo.NoCrashInfo) and (big blob of assertion/crash in stderr):
    lev = max(lev, JS_NEW_ASSERT_OR_CRASH)
else:
    lev = max(lev, JS_NEW_ASSERT_OR_CRASH)
```

but not sure if this is necessarily cleaner and/or clearer.