### PR TITLE
Add absolute_import from __future__ throughout.

### DIFF
--- a/autobisect-js/autoBisect.py
+++ b/autobisect-js/autoBisect.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import absolute_import
+
 import math
 import tempfile
 import os

--- a/autobisect-js/findCsetsIntersection.py
+++ b/autobisect-js/findCsetsIntersection.py
@@ -11,6 +11,8 @@
 # (first go to knownBrokenEarliestWorking.py and comment out configuration-specific ignore ranges,
 # this file does not yet support those.)
 
+from __future__ import absolute_import
+
 import os
 import sys
 from optparse import OptionParser

--- a/autobisect-js/knownBrokenEarliestWorking.py
+++ b/autobisect-js/knownBrokenEarliestWorking.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import absolute_import
+
 import os
 import platform
 import sys

--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,7 @@
 
 # bot.py ensures a build is available, then forks a bunch of fuzz-reduce processes
 
+from __future__ import absolute_import
 
 import multiprocessing
 import os

--- a/detect/detect_assertions.py
+++ b/detect/detect_assertions.py
@@ -5,6 +5,8 @@
 #   * Obj-C exceptions caught by Mozilla code
 # (FuzzManager's AssertionHelper.py handles fatal assertions of all flavors.)
 
+from __future__ import absolute_import
+
 import findIgnoreLists
 import re
 

--- a/detect/detect_leaks.py
+++ b/detect/detect_leaks.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import sys
 import findIgnoreLists

--- a/detect/detect_malloc_errors.py
+++ b/detect/detect_malloc_errors.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 # Look for "szone_error" (Tiger), "malloc_error_break" (Leopard), "MallocHelp" (?)
 # which are signs of malloc being unhappy (double free, out-of-memory, etc).
 

--- a/detect/detectors.py
+++ b/detect/detectors.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 
 import os, sys, platform
 

--- a/detect/findIgnoreLists.py
+++ b/detect/findIgnoreLists.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 
 THIS_SCRIPT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))

--- a/dom/automation/bot.py
+++ b/dom/automation/bot.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import sys
 

--- a/dom/automation/buildBrowser.py
+++ b/dom/automation/buildBrowser.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import sys
 import optparse

--- a/dom/automation/domInteresting.py
+++ b/dom/automation/domInteresting.py
@@ -17,6 +17,7 @@ bot.py --> loopdomfuzz.py --> domInteresting.py --> runbrowser.py --> automation
 
 """
 
+from __future__ import absolute_import
 
 import sys
 import shutil

--- a/dom/automation/echoServer.py
+++ b/dom/automation/echoServer.py
@@ -9,6 +9,7 @@ An HTTP echo server that uses threads to handle multiple clients at a time.
 Entering any line of input at the terminal will exit the server.
 """
 
+from __future__ import absolute_import
 from __future__ import division
 
 import base64

--- a/dom/automation/list_reftests.py
+++ b/dom/automation/list_reftests.py
@@ -2,6 +2,8 @@
 
 # Based on js/src/tests/manifest.py
 
+from __future__ import absolute_import
+
 import os, re
 from subprocess import *
 

--- a/dom/automation/loopdomfuzz.py
+++ b/dom/automation/loopdomfuzz.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import datetime
 import os
 import platform

--- a/dom/automation/old-dom-retest.py
+++ b/dom/automation/old-dom-retest.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import shutil
 import tempfile

--- a/dom/automation/randomPrefs.py
+++ b/dom/automation/randomPrefs.py
@@ -1,5 +1,7 @@
 # Random prefs (added by loopdomfuzz.py) to be combined with constant-prefs.js (added by domInteresting.py)
 
+from __future__ import absolute_import
+
 import os
 import random
 import re

--- a/dom/automation/retestLocalW.py
+++ b/dom/automation/retestLocalW.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import re
 import subprocess

--- a/dom/automation/runbrowser.py
+++ b/dom/automation/runbrowser.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import sys
 import shutil

--- a/dom/automation/shell_compiles_browser_dies.py
+++ b/dom/automation/shell_compiles_browser_dies.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import subprocess
 import sys

--- a/js/buildOptions.py
+++ b/js/buildOptions.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import argparse
 import hashlib
 import os

--- a/js/compareJIT.py
+++ b/js/compareJIT.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import sys
 from optparse import OptionParser

--- a/js/compileShell.py
+++ b/js/compileShell.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import absolute_import
+
 import copy
 import ctypes
 import multiprocessing

--- a/js/inspectShell.py
+++ b/js/inspectShell.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import absolute_import
+
 import os
 import platform
 import sys

--- a/js/jsInteresting.py
+++ b/js/jsInteresting.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import sys
 

--- a/js/loopjsfunfuzz.py
+++ b/js/loopjsfunfuzz.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import json
 import os
 import subprocess

--- a/js/pinpoint.py
+++ b/js/pinpoint.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import platform
 import re

--- a/js/shellFlags.py
+++ b/js/shellFlags.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import multiprocessing
 import os
 import random

--- a/loopBot.py
+++ b/loopBot.py
@@ -5,6 +5,8 @@
 
 # Since this script updates the fuzzing repo, it should be very simple, and use subprocess.call() rather than import
 
+from __future__ import absolute_import
+
 import os
 import sys
 import subprocess

--- a/util/LockDir.py
+++ b/util/LockDir.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 
 

--- a/util/crashesat.py
+++ b/util/crashesat.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import sys
 from optparse import OptionParser

--- a/util/createCollector.py
+++ b/util/createCollector.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 import sys
 

--- a/util/downloadBuild.py
+++ b/util/downloadBuild.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import ConfigParser
 import os
 import platform

--- a/util/exportForFuzzManager.py
+++ b/util/exportForFuzzManager.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import json
 import os
 import re

--- a/util/fileManipulation.py
+++ b/util/fileManipulation.py
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import absolute_import
 
 def firstLine(s):
     """Return the first line of any series of text with / without line breaks."""

--- a/util/forkJoin.py
+++ b/util/forkJoin.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import multiprocessing
 import os
 import sys

--- a/util/hgCmds.py
+++ b/util/hgCmds.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import absolute_import
+
 import ConfigParser
 import os
 import re

--- a/util/linkJS.py
+++ b/util/linkJS.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import os
 
 

--- a/util/lithOps.py
+++ b/util/lithOps.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import absolute_import
+
 import os
 import sys
 import shutil

--- a/util/multi.py
+++ b/util/multi.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+
 import subprocess
 import os
 import sys

--- a/util/oomReaper.py
+++ b/util/oomReaper.py
@@ -7,6 +7,8 @@
 #   * Cause OS X to kernel panic
 # I decided not to use 'psutil' or 'syrupy' and instead just parse |ps| output.
 
+from __future__ import absolute_import
+
 import os
 import signal
 import subprocess

--- a/util/reposUpdate.py
+++ b/util/reposUpdate.py
@@ -9,6 +9,8 @@
 #
 # Assumes that the repositories are located in ../../trees/*.
 
+from __future__ import absolute_import
+
 from copy import deepcopy
 import logging
 import os

--- a/util/s3cache.py
+++ b/util/s3cache.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import absolute_import
+
 import os
 import shutil
 import sys

--- a/util/subprocesses.py
+++ b/util/subprocesses.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import absolute_import
+
 import ctypes
 import errno
 import os


### PR DESCRIPTION
Let's get the ball rolling on making our code more Python3-friendly.

I don't think any of our files were deliberately named after existing modules when we created them a long time ago, but it shouldn't hurt to add these __future__lines.

I just added them to all files, while going through them, some files might not be used anymore, but let's save those for later.