### PR TITLE
[autoBisect] Support sed 4.3+ in Ubuntu 17.04

### DIFF
--- a/autobisect-js/knownBrokenEarliestWorking.py
+++ b/autobisect-js/knownBrokenEarliestWorking.py
@@ -7,6 +7,7 @@
 import os
 import platform
 import sys
+from distutils.version import StrictVersion
 
 path0 = os.path.dirname(os.path.abspath(__file__))
 path1 = os.path.abspath(os.path.join(path0, os.pardir, 'util'))
@@ -120,6 +121,8 @@ def earliestKnownWorkingRev(options, flags, skipRevs):
 
     required = []
 
+    if sps.isLinux and StrictVersion(sps.verCheck('sed').split()[3]) >= StrictVersion('4.3'):
+        required.append('ebcbf47a83e7')  # m-c 328765 Fx53, 1st w/ working builds using sed 4.3+ found on Ubuntu 17.04 onwards
     if options.disableProfiling:
         required.append('800a887c705e')  # m-c 324836 Fx53, 1st w/ --disable-profiling, see bug 1321065
     if options.buildWithClang and sps.isWin:

--- a/util/subprocesses.py
+++ b/util/subprocesses.py
@@ -538,6 +538,11 @@ def vdump(inp):
         print 'DEBUG -', inp
 
 
+def verCheck(prog):
+    """Runs the program with --version and returns the result."""
+    return subprocess.check_output([prog, '--version'])
+
+
 ###########
 #  Tests  #
 ###########


### PR DESCRIPTION
Ubuntu 17.04 includes sed 4.4, and [m-c ebcbf47a83e7](https://hg.mozilla.org/mozilla-central/rev/ebcbf47a83e7) is a changeset that adds support for sed 4.3+, so update the earliest known rev.