### PR TITLE
Remove support for mozilla-aurora and ESR branches

### DIFF
--- a/js/buildOptions.py
+++ b/js/buildOptions.py
@@ -329,16 +329,14 @@ def generateRandomConfigurations(parser, randomizer):
 
 def getRandomValidRepo(treeLocation):
     validRepos = []
-    for repo in ['mozilla-central', 'mozilla-aurora', 'mozilla-esr45']:
+    for repo in ['mozilla-central', 'mozilla-beta']:
         if os.path.isfile(sps.normExpUserPath(os.path.join(
                 treeLocation, repo, '.hg', 'hgrc'))):
             validRepos.append(repo)
 
     # After checking if repos are valid, reduce chances that non-mozilla-central repos are chosen
-    if 'mozilla-aurora' in validRepos and chance(0.5):
-        validRepos.remove('mozilla-aurora')
-    if 'mozilla-esr45' in validRepos and chance(0.9):
-        validRepos.remove('mozilla-esr45')
+    if 'mozilla-beta' in validRepos and chance(0.5):
+        validRepos.remove('mozilla-beta')
 
     return os.path.realpath(sps.normExpUserPath(
         os.path.join(treeLocation, random.choice(validRepos))))

--- a/js/buildOptions.py
+++ b/js/buildOptions.py
@@ -150,7 +150,7 @@ def addParserOptions():
                         'Defaults to "%(default)s".')
 
     # If adding a new compile option, be mindful of repository randomization.
-    # e.g. it may be in mozilla-central but not in mozilla-aurora/beta/esr45
+    # e.g. it may be in mozilla-central but not in mozilla-beta
 
     return parser, randomizer
 

--- a/js/jsfunfuzz/avoid-known-bugs.js
+++ b/js/jsfunfuzz/avoid-known-bugs.js
@@ -66,76 +66,6 @@ function whatToTestSpidermonkeyTrunk(code)
   };
 }
 
-function whatToTestSpidermonkeyMozilla45(code)
-{
-  /* jshint laxcomma: true */
-  // regexps can't match across lines, so replace whitespace with spaces.
-  var codeL = code.replace(/\s/g, " ");
-
-  return {
-
-    allowParse: true,
-
-    allowExec: unlikelyToHang(code)
-      && (jsshell || code.indexOf("nogeckoex") == -1)
-    ,
-
-    allowIter: true,
-
-    // Ideally we'd detect whether the shell was compiled with --enable-more-deterministic
-    // Ignore both within-process & across-process, e.g. nestTest mismatch & compareJIT
-    expectConsistentOutput: true
-       && (gcIsQuiet || code.indexOf("gc") == -1)
-       && code.indexOf("/*NODIFF*/") == -1                // Ignore diff testing on these labels
-       && code.indexOf(".script") == -1                   // Debugger; see bug 1237464
-       && code.indexOf(".parameterNames") == -1           // Debugger; see bug 1237464
-       && code.indexOf(".environment") == -1              // Debugger; see bug 1237464
-       && code.indexOf(".onNewGlobalObject") == -1        // Debugger; see bug 1238246
-       && code.indexOf(".takeCensus") == -1               // Debugger; see bug 1247863
-       && code.indexOf(".findScripts") == -1              // Debugger; see bug 1250863
-       && code.indexOf("Date") == -1                      // time marches on
-       && code.indexOf("backtrace") == -1                 // shows memory addresses
-       && code.indexOf("drainAllocationsLog") == -1       // drainAllocationsLog returns an object with a timestamp, see bug 1066313
-       && code.indexOf("dumpObject") == -1                // shows heap addresses
-       && code.indexOf("dumpHeap") == -1                  // shows heap addresses
-       && code.indexOf("dumpStringRepresentation") == -1  // shows memory addresses
-       && code.indexOf("evalInWorker") == -1              // causes diffs in --no-threads vs --ion-offthread-compile=off
-       && code.indexOf("getBacktrace") == -1              // getBacktrace returns memory addresses which differs depending on flags
-       && code.indexOf("getLcovInfo") == -1
-       && code.indexOf("load") == -1                      // load()ed regression test might output dates, etc
-       && code.indexOf("offThreadCompileScript") == -1    // causes diffs in --no-threads vs --ion-offthread-compile=off
-       && code.indexOf("oomAfterAllocations") == -1
-       && code.indexOf("oomAtAllocation") == -1
-       && code.indexOf("printProfilerEvents") == -1       // causes diffs in --ion-eager vs --baseline-eager
-       && code.indexOf("validategc") == -1
-       && code.indexOf("inIon") == -1                     // may become true after several iterations, or return a string with --no-ion
-       && code.indexOf("inJit") == -1                     // may become true after several iterations, or return a string with --no-baseline
-       && code.indexOf("random") == -1
-       && code.indexOf("timeout") == -1                   // time runs and crawls
-    ,
-
-    expectConsistentOutputAcrossIter: true
-    // within-process, e.g. ignore the following items for nestTest mismatch
-       && code.indexOf("options") == -1             // options() is per-cx, and the js shell doesn't create a new cx for each sandbox/compartment
-    ,
-
-    expectConsistentOutputAcrossJITs: true
-    // across-process (e.g. running js shell with different run-time options) e.g. compareJIT
-        && code.indexOf("'strict") == -1                 // see bug 743425
-        && code.indexOf("disassemble") == -1             // see bug 1237403 (related to asm.js)
-        && code.indexOf(".length") == -1                 // bug 1027846
-        && code.indexOf("preventExtensions") == -1       // bug 1085299
-        && code.indexOf("Math.round") == -1              // see bug 1236114 - ESR45 only
-        && code.indexOf("with") == -1                    // see bug 1245187 - ESR45 only
-        && code.indexOf("Number.MAX_VALUE") == -1        // see bug 1246200 - ESR45 only
-        && code.indexOf("bailAfter") == -1               // see bug 1256324 - ESR45 only, bailAfter does not exist in ESR45
-        && code.indexOf("arguments") == -1               // see bug 1263811 - ESR45 only
-        && code.indexOf("sourceIsLazy") == -1            // see bug 1286407
-        && !( codeL.match(/\/.*[\u0000\u0080-\uffff]/))  // doesn't stay valid utf-8 after going through python (?)
-
-  };
-}
-
 function whatToTestJavaScriptCore(code)
 {
   return {
@@ -165,8 +95,6 @@ function whatToTestGeneric(code)
 var whatToTest;
 if (engine == ENGINE_SPIDERMONKEY_TRUNK)
   whatToTest = whatToTestSpidermonkeyTrunk;
-else if (engine == ENGINE_SPIDERMONKEY_MOZILLA45)
-  whatToTest = whatToTestSpidermonkeyMozilla45;
 else if (engine == ENGINE_JAVASCRIPTCORE)
   whatToTest = whatToTestJavaScriptCore;
 else

--- a/js/jsfunfuzz/detect-engine.js
+++ b/js/jsfunfuzz/detect-engine.js
@@ -3,7 +3,6 @@
 
 var ENGINE_UNKNOWN = 0;
 var ENGINE_SPIDERMONKEY_TRUNK = 1;
-var ENGINE_SPIDERMONKEY_MOZILLA45 = 3;
 var ENGINE_JAVASCRIPTCORE = 4;
 
 var engine = ENGINE_UNKNOWN;
@@ -21,8 +20,6 @@ if (jsshell) {
     // particular #ifdef, e.g. JS_GC_ZEAL, or controlled by --fuzzing-safe.
     if (typeof wasmIsSupported == "function") {
       engine = ENGINE_SPIDERMONKEY_TRUNK;
-    } else {
-      engine = ENGINE_SPIDERMONKEY_MOZILLA45;
     }
 
     // Avoid accidentally waiting for user input that will never come.
@@ -100,7 +97,5 @@ if (engine == ENGINE_UNKNOWN)
   printImportant("Targeting an unknown JavaScript engine!");
 else if (engine == ENGINE_SPIDERMONKEY_TRUNK)
   printImportant("Targeting SpiderMonkey / Gecko (trunk).");
-else if (engine == ENGINE_SPIDERMONKEY_MOZILLA45)
-  printImportant("Targeting SpiderMonkey / Gecko (ESR45 branch).");
 else if (engine == ENGINE_JAVASCRIPTCORE)
   printImportant("Targeting JavaScriptCore / WebKit.");

--- a/js/jsfunfuzz/gen-grammar.js
+++ b/js/jsfunfuzz/gen-grammar.js
@@ -271,7 +271,7 @@ var statementMakers = Random.weighted([
   //{ w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" + makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
 ]);
 
-if (typeof oomTest == "function" && engine != ENGINE_SPIDERMONKEY_MOZILLA45) {
+if (typeof oomTest == "function") {
   statementMakers = statementMakers.concat([
     function(d, b) { return "oomTest(" + makeFunction(d - 1, b) + ")"; },
   ]);
@@ -1316,7 +1316,7 @@ if (typeof XPCNativeWrapper == "function") {
   ]);
 }
 
-if (typeof oomTest == "function" && engine != ENGINE_SPIDERMONKEY_MOZILLA45) {
+if (typeof oomTest == "function") {
   functionMakers = functionMakers.concat([
     function(d, b) { return "oomTest"; }
   ]);

--- a/js/loopjsfunfuzz.py
+++ b/js/loopjsfunfuzz.py
@@ -61,7 +61,7 @@ def parseOpts(args):
 
     options.knownPath = os.path.expanduser(args[1])
     # FIXME: findIgnoreLists.py should probably check this automatically.
-    reposWithKnownLists = ['mozilla-central', 'mozilla-esr45', 'ionmonkey', 'jscore', 'v8']
+    reposWithKnownLists = ['mozilla-central', 'ionmonkey', 'jscore', 'v8']
     if options.knownPath not in reposWithKnownLists:
         sps.vdump('Known bugs for the ' + options.knownPath + ' repository does not exist. Using the list for mozilla-central instead.')
         options.knownPath = 'mozilla-central'

--- a/util/reposUpdate.py
+++ b/util/reposUpdate.py
@@ -20,16 +20,12 @@ import subprocesses as sps
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-ESR_NOW = 45
-ESR_NEXT = ESR_NOW + 7
-
 THIS_SCRIPT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 REPO_PARENT_PATH = os.path.abspath(os.path.join(THIS_SCRIPT_DIRECTORY, os.pardir, os.pardir))
 
 # Add your repository here. Note that Valgrind does not have a hg repository.
 REPOS = ['gecko-dev', 'lithium', 'FuzzManager'] + \
-    ['mozilla-' + x for x in ['inbound', 'central', 'aurora', 'beta', 'release',
-                              'esr' + str(ESR_NOW), 'esr' + str(ESR_NEXT)]]
+    ['mozilla-' + x for x in ['inbound', 'central', 'beta', 'release']]
 
 if sps.isWin:
     # Assumes Git was installed from https://msysgit.github.io/


### PR DESCRIPTION
mozilla-aurora is going to die, let's remove it. We are no longer fuzzing ESR much, if any, we should only fuzz mozilla-central and mozilla-beta.

We also need to start moving to octo, and having some of these old code removed will simplify things.