### PR TITLE
Activate flake8 for Python 3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,11 +3,11 @@ image:
 environment:
     matrix:
         - PYTHON: "C:\\Python27"
-        # - PYTHON: "C:\\Python35"
-        # - PYTHON: "C:\\Python36"
+        - PYTHON: "C:\\Python35"
+        - PYTHON: "C:\\Python36"
         - PYTHON: "C:\\Python27-x64"
-        # - PYTHON: "C:\\Python35-x64"
-        # - PYTHON: "C:\\Python36-x64"
+        - PYTHON: "C:\\Python35-x64"
+        - PYTHON: "C:\\Python36-x64"
 install:
     - "%PYTHON%\\python.exe -m pip install --upgrade setuptools pip"
     - "%PYTHON%\\python.exe -m pip install --upgrade virtualenv"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 language: python
 python:
     - "2.7"
-    # - "3.5"
-    # - "3.6"
-    # - "nightly"
+    - "3.5"
+    - "3.6"
+    - "nightly"
 before_install:
     - pip install --upgrade setuptools pip
     - pip install --upgrade virtualenv

--- a/js/buildOptions.py
+++ b/js/buildOptions.py
@@ -230,9 +230,10 @@ def computeShellType(buildOptions):
     if buildOptions.patchFile:
         # We take the name before the first dot, so Windows (hopefully) does not get confused.
         fileName.append(os.path.basename(buildOptions.patchFile).split('.')[0])
+        with open(os.path.abspath(buildOptions.patchFile), "rb") as f:
+            readResult = f.read()
         # Append the patch hash, but this is not equivalent to Mercurial's hash of the patch.
-        fileName.append(hashlib.sha512(file(os.path.abspath(buildOptions.patchFile), 'rb').read())
-                        .hexdigest()[:12])
+        fileName.append(hashlib.sha512(readResult).hexdigest()[:12])
 
     assert '' not in fileName, 'fileName "' + repr(fileName) + '" should not have empty elements.'
     return '-'.join(fileName)

--- a/js/compileShell.py
+++ b/js/compileShell.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import ctypes
+import io
 import multiprocessing
 import os
 import shutil
@@ -576,7 +577,7 @@ def extractVersions(objdir):
 
     def fixateVer(pcfile):
         """Returns the current version number (47.0a2)."""
-        with open(pcfile, 'rb') as f:
+        with io.open(pcfile, mode='rb', encoding="utf-8", errors="replace") as f:
             for line in f:
                 if line.startswith('Version: '):
                     # Sample line: 'Version: 47.0a2'

--- a/js/compileShell.py
+++ b/js/compileShell.py
@@ -6,7 +6,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import ctypes
@@ -167,7 +167,8 @@ def ensureCacheDir():
     # Expand long Windows paths (overcome legacy MS-DOS 8.3 stuff)
     # This has to occur after the shell-cache directory is created
     if sps.isWin:  # adapted from http://stackoverflow.com/a/3931799
-        winTmpDir = unicode(cacheDir)
+        utext = unicode if sys.version_info.major == 2 else str  # noqa pylint: disable=redefined-builtin,invalid-name
+        winTmpDir = utext(cacheDir)
         GetLongPathName = ctypes.windll.kernel32.GetLongPathNameW
         unicodeBuffer = ctypes.create_unicode_buffer(GetLongPathName(winTmpDir, 0, 0))
         GetLongPathName(winTmpDir, unicodeBuffer, len(unicodeBuffer))

--- a/util/forkJoin.py
+++ b/util/forkJoin.py
@@ -28,13 +28,13 @@ def forkJoin(logDir, numProcesses, fun, *someArgs):
     # Fork a bunch of processes
     print("Forking %d children..." % numProcesses)
     ps = []
-    for i in xrange(numProcesses):
+    for i in range(numProcesses):
         p = multiprocessing.Process(target=redirectOutputAndCallFun, args=[logDir, i, fun, someArgs], name="Parallel process " + str(i))
         p.start()
         ps.append(p)
 
     # Wait for them all to finish, and splat their outputs
-    for i in xrange(numProcesses):
+    for i in range(numProcesses):
         p = ps[i]
         print("=== Waiting for child #%d (%d) to finish... ===" % (i, p.pid))
         p.join()

--- a/util/hgCmds.py
+++ b/util/hgCmds.py
@@ -17,6 +17,12 @@ import subprocess
 import subprocesses as sps
 
 
+try:
+    input = raw_input  # pylint: disable=redefined-builtin
+except NameError:
+    pass
+
+
 def destroyPyc(repoDir):
     # This is roughly equivalent to ['hg', 'purge', '--all', '--include=**.pyc'])
     # but doesn't run into purge's issues (incompatbility with -R, requiring an hg extension)
@@ -86,8 +92,8 @@ def getRepoHashAndId(repoDir, repoRev='parents() and default'):
     hgIdFull = sps.captureStdout(hgLogTmplList)[0]
     onDefault = bool(hgIdFull)
     if not onDefault:
-        updateDefault = raw_input("Not on default tip! "
-                                  "Would you like to (a)bort, update to (d)efault, or (u)se this rev: ")
+        updateDefault = input("Not on default tip! "
+                              "Would you like to (a)bort, update to (d)efault, or (u)se this rev: ")
         updateDefault = updateDefault.strip()
         if updateDefault == 'a':
             print("Aborting...")

--- a/util/subprocesses.py
+++ b/util/subprocesses.py
@@ -503,7 +503,7 @@ def shellify(cmd):
     okUnquotedRE = re.compile(r"""^[a-zA-Z0-9\-\_\.\,\/\=\~@\+]*$""")
     okQuotedRE = re.compile(r"""^[a-zA-Z0-9\-\_\.\,\/\=\~@\{\}\|\(\)\+ ]*$""")
     ssc = []
-    for i in xrange(len(cmd)):
+    for i in range(len(cmd)):
         item = cmd[i]
         if okUnquotedRE.match(item):
             ssc.append(item)

--- a/util/subprocesses.py
+++ b/util/subprocesses.py
@@ -101,7 +101,7 @@ def captureStdout(inputCmd, ignoreStderr=False, combineStderr=False, ignoreExitC
             cwd=currWorkingDir,
             env=env)
         (stdout, stderr) = p.communicate()
-    except OSError, e:
+    except OSError as e:
         raise Exception(repr(e.strerror) + ' error calling: ' + shellify(cmd))
     if p.returncode != 0:
         oomErrorOutput = stdout if combineStderr else stderr

--- a/util/tooltool/tooltool.py
+++ b/util/tooltool/tooltool.py
@@ -650,7 +650,7 @@ def fetch_files(manifest_file, base_urls, filenames=[], cache_folder=None,
                 try:
                     if not os.path.exists(cache_folder):
                         log.info("Creating cache in %s...", cache_folder)
-                        os.makedirs(cache_folder, 0700)
+                        os.makedirs(cache_folder, 0o700)
                     shutil.copy(os.path.join(os.getcwd(), localfile.filename),
                                 os.path.join(cache_folder, localfile.digest))
                     log.info("Local cache %s updated with %s", cache_folder, localfile.filename)

--- a/util/tooltool/tooltool.py
+++ b/util/tooltool/tooltool.py
@@ -23,6 +23,9 @@
 # in which the manifest file resides and it should be called
 # 'manifest.tt'
 
+
+from __future__ import print_function
+
 import hashlib
 import httplib
 import json
@@ -305,7 +308,7 @@ class Manifest(object):
         if fmt == 'json':
             rv = json.dump(
                 self.file_records, output_file, indent=0, cls=FileRecordJSONEncoder)
-            print >> output_file, ''
+            print("", file=output_file)
             return rv
 
     def dumps(self, fmt='json'):
@@ -361,9 +364,9 @@ def list_manifest(manifest_file):
         log.error("failed to load manifest file at '%s': %s", manifest_file, e)
         return False
     for f in manifest.file_records:
-        print "%s\t%s\t%s" % ("P" if f.present() else "-",
+        print("%s\t%s\t%s" % ("P" if f.present() else "-",
                               "V" if f.present() and f.validate() else "-",
-                              f.filename)
+                              f.filename))
     return True
 
 


### PR DESCRIPTION
These are the remaining changes needed for funfuzz to be forward-compatible with Python 3.