### PR TITLE
[pylint-03] Activate pylint for Python 3, though it is still not fully supported yet

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,5 +20,5 @@ install:
 build: off
 test_script:
     - "%PYTHON%\\python.exe -m flake8 --count %APPVEYOR_BUILD_FOLDER%"
-    - If NOT "%PYTHON%"=="%PYTHON:Python27=%" ( %PYTHON%\\python.exe -m pylint %APPVEYOR_BUILD_FOLDER% )
+    - "%PYTHON%\\python.exe -m pylint %APPVEYOR_BUILD_FOLDER%"
 skip_branch_with_pr: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ script:
     - flake8 --count ${TRAVIS_BUILD_DIR}
     # Do not run pylint on nightly Python versions as they may not be compatible
     - |
-        if [[ ( $TRAVIS_PYTHON_VERSION == '2.7' ) && ( $TRAVIS_PYTHON_VERSION != "nightly" ) ]]; then
+        if [[ $TRAVIS_PYTHON_VERSION != "nightly" ]]; then
             pylint ${TRAVIS_BUILD_DIR}
         fi

--- a/autobisect-js/autoBisect.py
+++ b/autobisect-js/autoBisect.py
@@ -687,8 +687,8 @@ def getHgwebMozillaOrg(branchName):
 
 
 def getIdFromTboxUrl(url):
-    """Return numeric ID from treeherder at https://archive.mozilla.org/pub/mozilla.org/firefox/treeherder-builds/ ."""
-    return filter(None, url.split('/'))[-1]
+    """Return numeric ID from treeherder at https://archive.mozilla.org/pub/firefox/tinderbox-builds/ ."""
+    return [i for i in url.split("/") if i][-1]
 
 
 def getOneBuild(isJsShell, url, buildType):

--- a/util/downloadBuild.py
+++ b/util/downloadBuild.py
@@ -68,7 +68,7 @@ def parseOptions():
 
     parser.set_defaults(
         compileType='dbg',
-        downloadFolder=os.getcwdu(),
+        downloadFolder=os.getcwdu() if sys.version_info.major == 2 else os.getcwd(),  # pylint: disable=no-member
         repoName='mozilla-central',
         enableJsShell=False,
         wantTests=False,

--- a/util/hgCmds.py
+++ b/util/hgCmds.py
@@ -127,7 +127,9 @@ def isRepoValid(repo):
     return os.path.isfile(sps.normExpUserPath(os.path.join(repo, '.hg', 'hgrc')))
 
 
-def patchHgRepoUsingMq(patchFile, workingDir=os.getcwdu()):
+def patchHgRepoUsingMq(patchFile, workingDir=None):
+    workingDir = workingDir or (
+        os.getcwdu() if sys.version_info.major == 2 else os.getcwd())  # pylint: disable=no-member
     # We may have passed in the patch with or without the full directory.
     patchAbsPath = os.path.abspath(sps.normExpUserPath(patchFile))
     pname = os.path.basename(patchAbsPath)

--- a/util/subprocesses.py
+++ b/util/subprocesses.py
@@ -79,8 +79,10 @@ def getFreeSpace(folder, mulVar):
 
 
 def captureStdout(inputCmd, ignoreStderr=False, combineStderr=False, ignoreExitCode=False,
-                  currWorkingDir=os.getcwdu(), env='NOTSET', verbosity=False):
+                  currWorkingDir=None, env='NOTSET', verbosity=False):
     """Capture standard output, return the output as a string, along with the return value."""
+    currWorkingDir = currWorkingDir or (
+        os.getcwdu() if sys.version_info.major == 2 else os.getcwd())  # pylint: disable=no-member
     if env == 'NOTSET':
         vdump(shellify(inputCmd))
         env = os.environ
@@ -519,12 +521,14 @@ def shellify(cmd):
 
 
 def timeSubprocess(command, ignoreStderr=False, combineStderr=False, ignoreExitCode=False,
-                   cwd=os.getcwdu(), env=os.environ, vb=False):
+                   cwd=None, env=os.environ, vb=False):
     """
     Calculate how long a captureStdout command takes and prints it.
 
     Return the stdout and return value that captureStdout passes on.
     """
+    cwd = cwd or (
+        os.getcwdu() if sys.version_info.major == 2 else os.getcwd())  # pylint: disable=no-member
     print("Running `%s` now.." % shellify(command))
     startTime = time.time()
     stdOutput, retVal = captureStdout(command, ignoreStderr=ignoreStderr,

--- a/util/tooltool/tooltool.py
+++ b/util/tooltool/tooltool.py
@@ -30,7 +30,7 @@
 from __future__ import print_function
 
 import hashlib
-import httplib
+import httplib  # pylint: disable=import-error
 import json
 import logging
 import optparse  # pylint: disable=deprecated-module
@@ -41,8 +41,8 @@ import tarfile
 import tempfile
 import threading
 import time
-import urllib2
-import urlparse
+import urllib2  # pylint: disable=import-error
+import urlparse  # pylint: disable=import-error
 import zipfile
 
 from subprocess import PIPE


### PR DESCRIPTION
We should turn on pylint for Python 3 to ensure future code has some form of Python 3-compliance.

Note that even after this PR lands, it will still be some ways before Python 3 is fully supported. (e.g. MozillaBuild 3 needs to be installed on Windows, which [will be released by the end of the month](https://bugzilla.mozilla.org/show_bug.cgi?id=1381614)) Also downloadBuild/tooltool.py needs to be removed/upgraded.