### PR TITLE
Update funfuzz to work with lithium 0.2.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,6 +16,7 @@ install:
     - "git.exe --version"
     - "%PYTHON%\\python.exe -m pip install --upgrade flake8 pylint"
     - "%PYTHON%\\python.exe -m pip install --upgrade pytest-flake8 pytest-pylint"
+    - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
 build: off
 test_script:
     - "%PYTHON%\\python.exe -m pytest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ install:
 before_script:
     - pip install --upgrade flake8 pylint
     - pip install --upgrade pytest-flake8 pytest-pylint
+    - pip install -r requirements.txt
 script:
     - python -m pytest

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Most of the code other than testcase generation is written in Python: restarting
 
 ## Setup
 
-Check out the **[lithium](https://github.com/MozillaSecurity/lithium/)** and **[FuzzManager](https://github.com/MozillaSecurity/FuzzManager)** repositories side-by-side by this one.
+Install the required pip packages using `pip install -r requirements.txt`.
 
 Some parts of the fuzzer will only activate if the Python scripts can find your mozilla-central tree:
 ```

--- a/autobisect-js/autoBisect.py
+++ b/autobisect-js/autoBisect.py
@@ -21,12 +21,11 @@ import sys
 import time
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
+from lithium.interestingness.utils import rel_or_abs_import
+
 import knownBrokenEarliestWorking as kbew
 
 path0 = os.path.dirname(os.path.abspath(__file__))
-path1 = os.path.abspath(os.path.join(path0, os.pardir, os.pardir, 'lithium', 'interestingness'))
-sys.path.append(path1)
-import ximport
 path2 = os.path.abspath(os.path.join(path0, os.pardir, 'js'))
 sys.path.append(path2)
 import compileShell
@@ -313,7 +312,7 @@ def internalTestAndLabel(options):
 
 def externalTestAndLabel(options, interestingness):
     """Make use of interestingness scripts to decide whether the changeset is good or bad."""
-    conditionScript = ximport.importRelativeOrAbsolute(interestingness[0])
+    conditionScript = rel_or_abs_import(interestingness[0])
     conditionArgPrefix = interestingness[1:]
 
     def inner(shellFilename, hgHash):

--- a/js/compareJIT.py
+++ b/js/compareJIT.py
@@ -24,8 +24,8 @@ import subprocesses as sps
 import lithOps
 import createCollector
 
-# From FuzzManager (in sys.path thanks to import createCollector above)
-import FTB.Signatures.CrashInfo as CrashInfo
+# no-name-in-module pylint error exists for Python 3 only because FuzzManager is not Python 3-compatible yet
+import FTB.Signatures.CrashInfo as CrashInfo  # pylint: disable=no-name-in-module
 from FTB.ProgramConfiguration import ProgramConfiguration
 
 
@@ -111,7 +111,7 @@ def compareLevel(jsEngine, flags, infilename, logPrefix, options, showDetailedDi
         oom = jsInteresting.oomed(r.err)
         r.err = ignoreSomeOfStderr(r.err)
 
-        if (r.rc == 1 or r.rc == 2) and (anyLineContains(r.out, '[[script] scriptArgs*]') or (
+        if (r.return_code == 1 or r.return_code == 2) and (anyLineContains(r.out, '[[script] scriptArgs*]') or (
                 anyLineContains(r.err, '[scriptfile] [scriptarg...]'))):
             print("Got usage error from:")
             print("  %s" % sps.shellify(command))
@@ -127,7 +127,7 @@ def compareLevel(jsEngine, flags, infilename, logPrefix, options, showDetailedDi
                 f.write('\n'.join(r.issues + [sps.shellify(command), "compareJIT found a more serious bug"]) + '\n')
             print("  %s" % sps.shellify(command))
             return (r.lev, r.crashInfo)
-        elif r.lev != jsInteresting.JS_FINE or r.rc != 0:
+        elif r.lev != jsInteresting.JS_FINE or r.return_code != 0:
             print("%s | %s" % (infilename, jsInteresting.summaryString(
                 r.issues + ["compareJIT is not comparing output, because the shell exited strangely"],
                 r.lev, r.runinfo.elapsedtime)))

--- a/js/inspectShell.py
+++ b/js/inspectShell.py
@@ -10,20 +10,9 @@ from __future__ import absolute_import, print_function
 
 import os
 import platform
-import sys
 
-path0 = os.path.dirname(os.path.abspath(__file__))
-path1 = os.path.abspath(os.path.join(path0, os.pardir, 'util'))
-sys.path.append(path1)
 import subprocesses as sps
-
-path2 = os.path.abspath(os.path.join(path0, os.pardir, os.pardir, 'lithium', 'interestingness'))
-sys.path.append(path2)
-if not os.path.exists(path2):
-    print("Please check out Lithium and FuzzManager side-by-side with funfuzz. "
-          "Links in https://github.com/MozillaSecurity/funfuzz/#setup")
-    sys.exit(2)
-import envVars
+from lithium.interestingness.utils import env_with_path
 
 RUN_NSPR_LIB = ''
 RUN_PLDS_LIB = ''
@@ -138,7 +127,7 @@ def testBinary(shellPath, args, useValgrind):
     testCmd = (constructVgCmdList() if useValgrind else []) + [shellPath] + args
     sps.vdump('The testing command is: ' + sps.shellify(testCmd))
     out, rCode = sps.captureStdout(testCmd, combineStderr=True, ignoreStderr=True,
-                                   ignoreExitCode=True, env=envVars.envWithPath(
+                                   ignoreExitCode=True, env=env_with_path(
                                        os.path.dirname(os.path.abspath(shellPath))))
     sps.vdump('The exit code is: ' + str(rCode))
     return out, rCode
@@ -160,7 +149,7 @@ def testIsHardFpShellARM(s):
     """Test if the ARM shell is compiled with hardfp support."""
     readelfBin = '/usr/bin/readelf'
     if os.path.exists(readelfBin):
-        newEnv = envVars.envWithPath(os.path.dirname(os.path.abspath(s)))
+        newEnv = env_with_path(os.path.dirname(os.path.abspath(s)))
         readelfOutput = sps.captureStdout([readelfBin, '-A', s], env=newEnv)[0]
         return 'Tag_ABI_VFP_args: VFP registers' in readelfOutput
     else:

--- a/js/inspectShell.py
+++ b/js/inspectShell.py
@@ -10,7 +10,11 @@ from __future__ import absolute_import, print_function
 
 import os
 import platform
+import sys
 
+path0 = os.path.dirname(os.path.abspath(__file__))
+path1 = os.path.abspath(os.path.join(path0, os.pardir, 'util'))
+sys.path.append(path1)
 import subprocesses as sps
 from lithium.interestingness.utils import env_with_path
 

--- a/js/pinpoint.py
+++ b/js/pinpoint.py
@@ -18,9 +18,9 @@ import sys
 from jsInteresting import JS_OVERALL_MISMATCH, JS_VG_AMISS
 from inspectShell import testJsShellOrXpcshell
 
-# Note that the python executable invoking lithiumpy and autobisectpy have to have pip requirements installed
+from lithium.interestingness.utils import file_contains_str
+
 p0 = os.path.dirname(os.path.abspath(__file__))
-lithiumpy = os.path.abspath(os.path.join(p0, os.pardir, os.pardir, 'lithium', 'lithium', 'lithium.py'))
 autobisectpy = os.path.abspath(os.path.join(p0, os.pardir, 'autobisect-js', 'autoBisect.py'))
 
 p1 = os.path.abspath(os.path.join(p0, os.pardir, 'util'))
@@ -28,10 +28,6 @@ sys.path.append(p1)
 import fileManipulation
 from lithOps import LITH_FINISHED, LITH_PLEASE_CONTINUE, runLithium
 import subprocesses as sps
-
-p2 = os.path.abspath(os.path.join(p0, os.pardir, os.pardir, 'lithium', 'interestingness'))
-sys.path.append(p2)
-from fileIngredients import fileContainsStr
 
 
 def pinpoint(itest, logPrefix, jsEngine, engineFlags, infilename,
@@ -48,7 +44,7 @@ def pinpoint(itest, logPrefix, jsEngine, engineFlags, infilename,
 
     print()
     print("Done running Lithium on the part in between DDBEGIN and DDEND. To reproduce, run:")
-    print(sps.shellify([lithiumpy, "--strategy=check-only"] + lithArgs))
+    print(sps.shellify([sys.executable, "-u", "-m", "lithium", "--strategy=check-only"] + lithArgs))
     print()
 
     if bisectRepo is not "none" and targetTime >= 3 * 60 * 60 and buildOptionsStr is not None:
@@ -84,7 +80,7 @@ def strategicReduction(logPrefix, infilename, lithArgs, targetTime, lev):
         """Lithium reduction commands accepting various strategies."""
         reductionCount[0] += 1
         fullLithArgs = [x for x in (strategy + lithArgs) if x]  # Remove empty elements
-        print(sps.shellify([lithiumpy] + fullLithArgs))
+        print(sps.shellify([sys.executable, "-u", "-m", "lithium"] + fullLithArgs))
 
         desc = '-chars' if strategy == '--char' else '-lines'
         (lithResult, lithDetails) = runLithium(
@@ -159,7 +155,7 @@ def strategicReduction(logPrefix, infilename, lithArgs, targetTime, lev):
         lithResult, lithDetails = lithReduceCmd(['--chunksize=2'])
 
     isLevOverallMismatchAsmJsAvailable = (lev == JS_OVERALL_MISMATCH) and \
-        fileContainsStr(infilename, 'isAsmJSCompilationAvailable')
+        file_contains_str(infilename, 'isAsmJSCompilationAvailable')
     # Step 5 (not always run): Run character reduction within interesting lines.
     if lithResult == LITH_FINISHED and origNumOfLines <= 50 and targetTime is None and \
             lev >= JS_OVERALL_MISMATCH and not isLevOverallMismatchAsmJsAvailable:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/MozillaSecurity/FuzzManager.git
+git+https://github.com/nth10sd/lithium.git@renameDirs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/MozillaSecurity/FuzzManager.git
-git+https://github.com/nth10sd/lithium.git@renameDirs
+git+https://github.com/MozillaSecurity/lithium.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/MozillaSecurity/FuzzManager.git
-git+https://github.com/nth10sd/lithium.git@renameDirs
+git+https://github.com/MozillaSecurity/funfuzz.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/MozillaSecurity/FuzzManager.git
-git+https://github.com/MozillaSecurity/funfuzz.git
+git+https://github.com/nth10sd/lithium.git@renameDirs

--- a/util/crashesat.py
+++ b/util/crashesat.py
@@ -9,16 +9,11 @@
 from __future__ import absolute_import, print_function
 
 import os
-import sys
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
 import subprocesses as sps
-
-path0 = os.path.dirname(os.path.abspath(__file__))
-path1 = os.path.abspath(os.path.join(path0, os.pardir, os.pardir, 'lithium', 'interestingness'))
-sys.path.append(path1)
-import timedRun
-import fileIngredients
+import lithium.interestingness.timed_run as timed_run
+from lithium.interestingness.utils import file_contains
 
 
 def parseOptions(arguments):
@@ -43,18 +38,18 @@ def interesting(cliArgs, tempPrefix):
     (regexEnabled, crashSig, timeout, args) = parseOptions(cliArgs)
 
     # Examine stack for crash signature, this is needed if crashSig is specified.
-    runinfo = timedRun.timed_run(args, timeout, tempPrefix)
-    if runinfo.sta == timedRun.CRASHED:
+    runinfo = timed_run.timed_run(args, timeout, tempPrefix)
+    if runinfo.sta == timed_run.CRASHED:
         sps.grabCrashLog(args[0], runinfo.pid, tempPrefix, True)
 
     timeString = " (%.3f seconds)" % runinfo.elapsedtime
 
     crashLogName = tempPrefix + "-crash.txt"
 
-    if runinfo.sta == timedRun.CRASHED:
+    if runinfo.sta == timed_run.CRASHED:
         if os.path.exists(crashLogName):
             # When using this script, remember to escape characters, e.g. "\(" instead of "(" !
-            found, _foundSig = fileIngredients.fileContains(crashLogName, crashSig, regexEnabled)
+            found, _foundSig = file_contains(crashLogName, crashSig, regexEnabled)
             if found:
                 print("Exit status: %s%s" % (runinfo.msg, timeString))
                 return True

--- a/util/createCollector.py
+++ b/util/createCollector.py
@@ -9,17 +9,7 @@
 from __future__ import absolute_import, print_function
 
 import os
-import sys
 
-
-THIS_SCRIPT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
-
-fuzzManagerPath = os.path.abspath(os.path.join(THIS_SCRIPT_DIRECTORY, os.pardir, os.pardir, 'FuzzManager'))
-if not os.path.exists(fuzzManagerPath):
-    print("Please check out Lithium and FuzzManager side-by-side with funfuzz. "
-          "Links in https://github.com/MozillaSecurity/funfuzz/#setup")
-    sys.exit(2)
-sys.path.append(fuzzManagerPath)
 from Collector.Collector import Collector
 
 

--- a/util/lithOps.py
+++ b/util/lithOps.py
@@ -16,13 +16,7 @@ import tempfile
 
 import subprocesses as sps
 
-p0 = os.path.dirname(os.path.abspath(__file__))
-lithiumpy = os.path.join(p0, os.pardir, os.pardir, "lithium", "lithium", "lithium.py")
-if not os.path.exists(lithiumpy):
-    print("Please check out Lithium and FuzzManager side-by-side with funfuzz. "
-          "Links in https://github.com/MozillaSecurity/funfuzz/#setup")
-    sys.exit(2)
-runlithiumpy = [sys.executable, "-u", lithiumpy]
+runlithiumpy = [sys.executable, "-u", "-m", "lithium"]
 
 # Status returns for runLithium and many_timed_runs
 (HAPPY, NO_REPRO_AT_ALL, NO_REPRO_EXCEPT_BY_URL, LITH_NO_REPRO,

--- a/util/reposUpdate.py
+++ b/util/reposUpdate.py
@@ -28,7 +28,7 @@ THIS_SCRIPT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 REPO_PARENT_PATH = os.path.abspath(os.path.join(THIS_SCRIPT_DIRECTORY, os.pardir, os.pardir))
 
 # Add your repository here. Note that Valgrind does not have a hg repository.
-REPOS = ['gecko-dev', 'FuzzManager', 'lithium', 'octo'] + \
+REPOS = ['gecko-dev', 'octo'] + \
     ['mozilla-' + x for x in ['inbound', 'central', 'beta', 'release']]
 
 if sps.isWin:


### PR DESCRIPTION
This seems to be the minimal set of changes necessary to make funfuzz work with Lithium 0.2.0 (currently in [PR #49 over there](https://github.com/MozillaSecurity/lithium/pull/49))

Some changes were adapted from one of [truber's commits](https://github.com/MozillaSecurity/domfuzz/commit/7e462aa842c161db87d29f05275b1d2d89ec3e1c) in domfuzz.