### PR TITLE
Fix code coverage for Python 2.7 64-bit and 3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 image:
-    - Visual Studio 2015
+    - Visual Studio 2017
 environment:
     matrix:
         - PYTHON: "C:\\Python27"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,9 +17,10 @@ install:
     - "%PYTHON%\\python.exe -m pip install --upgrade flake8 pylint codecov"
     - "%PYTHON%\\python.exe -m pip install --upgrade pytest-flake8 pytest-pylint pytest-cov"
     - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+    - "choco install codecov"
 build: off
 test_script:
-    - "%PYTHON%\\python.exe -m pytest"
+    - "%PYTHON%\\python.exe -m pytest --cov-report xml"
 on_success:
-    - "%PYTHON%\\python.exe -m codecov -X gcov"
+    - "codecov -f coverage.xml"
 skip_branch_with_pr: true


### PR DESCRIPTION
Adapted from [Lithium PR #56](https://github.com/MozillaSecurity/lithium/pull/56), also moves to Visual Studio 2017.

I will land this after getting the codecov report for this PR to see that everything seems to work as expected.