### PR TITLE
Fix #148 - Stop testing the version function.

### DIFF
--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -29,9 +29,6 @@ if (jsshell) {
 
     // Avoid accidentally waiting for user input that will never come.
     readline = function(){};
-
-    // 170: make "yield" and "let" work. 180: better for..in behavior.
-    version(180);
   } else if (typeof XPCNativeWrapper == "function") {
     // e.g. xpcshell or firefox
     engine = ENGINE_SPIDERMONKEY_TRUNK;

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -907,7 +907,8 @@ var exprMakers =
   function(d, b) { return "(void options('strict'))"; },
 
   // Spidermonkey: versions
-  function(d, b) { return "(void version(" + Random.index([170, 180, 185]) + "))"; },
+  // Commenting out because this version function has been removed as of m-c rev 392455 (Fx59) - 589914e65db7
+  //function(d, b) { return "(void version(" + Random.index([170, 180, 185]) + "))"; },
 
   // More special Spidermonkey shell functions
   // (Note: functions without returned objects or visible side effects go in testing-functions.js, in order to allow presence/absence differential testing.)
@@ -1572,12 +1573,6 @@ function makeComprehension(d, b)
 function makeForInLHS(d, b)
 {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
-
-// JS 1.7 only (removed in JS 1.8)
-//
-//  if (version() == 170 && rnd(4) === 0)
-//    return cat(["[", makeLValue(d, b), ", ", makeLValue(d, b), "]"]);
-
   return makeLValue(d, b);
 }
 

--- a/src/funfuzz/js/shell_flags.py
+++ b/src/funfuzz/js/shell_flags.py
@@ -67,6 +67,7 @@ def randomFlagSet(shellPath):  # pylint: disable=invalid-name,missing-param-doc,
     # Anything in-between involving let probably needs "-e 'version(185);'" to see if we can bypass breakage
     # if shellSupportsFlag(shellPath, "--execute='version(185);'"):
     #     args.append("--execute='version(185);'")
+    # Note that the version function was removed in m-c rev 392455 (Fx59) - 589914e65db7
 
     # Note for future: --wasm-check-bce is only useful for x86 and ARM32
 


### PR DESCRIPTION
We'll need to issue a new version for this, + pick up all the changes in master since then. This should at least unbreak some parts of jsfunfuzz.

There is more breakage ahead that needs to be fixed, see #146 and #147, but I'll need to do an audit next quarter + discuss w/ the js team at the next All Hands as to future plans.

As for tests, this involves jsfunfuzz only (all js changes) - the upcoming tests PR only involves Python and so should be distinct from each other.