### PR TITLE
Fix #150 - Remove testing with 32-bit Python in AppVeyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,9 +2,6 @@ image:
     - Visual Studio 2017
 environment:
     matrix:
-        - PYTHON: "C:\\Python27"
-        - PYTHON: "C:\\Python35"
-        - PYTHON: "C:\\Python36"
         - PYTHON: "C:\\Python27-x64"
         - PYTHON: "C:\\Python35-x64"
         - PYTHON: "C:\\Python36-x64"


### PR DESCRIPTION
Details in #150. @jschwartzentruber, do you think this makes sense?