### PR TITLE
First wave of Python 3 fixes

### DIFF
--- a/src/funfuzz/autobisectjs/autobisectjs.py
+++ b/src/funfuzz/autobisectjs/autobisectjs.py
@@ -9,7 +9,7 @@
 May be replaced in the future, with a better version that supports both Firefox and SpiderMonkey.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import math
 import tempfile

--- a/src/funfuzz/autobisectjs/autobisectjs.py
+++ b/src/funfuzz/autobisectjs/autobisectjs.py
@@ -849,7 +849,7 @@ def testBuildOrNeighbour(options, preferredIndex, urls, buildType, testedIDs):  
 
     if idNum is None:
         result, reason = None, None
-    elif idNum in testedIDs.keys():
+    elif idNum in list(testedIDs):
         print("Retrieving previous test result: ", end=" ")
         result, reason = testedIDs[idNum][2:4]
     else:

--- a/src/funfuzz/autobisectjs/autobisectjs.py
+++ b/src/funfuzz/autobisectjs/autobisectjs.py
@@ -618,7 +618,7 @@ def ensureCacheDirHasCorrectIdNum(cacheFolder):  # pylint: disable=missing-param
     """Ensure that the cache folder is named with the correct numeric ID."""
     srcUrlPath = sps.normExpUserPath(os.path.join(cacheFolder, 'build', 'download', 'source-url.txt'))
     if os.path.isfile(srcUrlPath):
-        with open(srcUrlPath, 'rb') as f:
+        with open(srcUrlPath, 'r') as f:
             fContents = f.read().splitlines()
 
         idNumFolderName = cacheFolder.split('-')[-1]
@@ -747,7 +747,7 @@ def getTimestampAndHashFromTboxFiles(folder):  # pylint: disable=missing-param-d
     downloadDir = sps.normExpUserPath(os.path.join(folder, 'build', 'download'))
     for fn in os.listdir(downloadDir):
         if fn.startswith('firefox-') and fn.endswith('.txt') and '_info' not in fn:
-            with open(os.path.join(downloadDir, fn), 'rb') as f:
+            with open(os.path.join(downloadDir, fn), 'r') as f:
                 fContents = f.read().splitlines()
             break
     assert len(fContents) == 2, 'Contents of the .txt file should only have 2 lines'
@@ -798,7 +798,7 @@ def outputTboxBisectionResults(options, interestingList, testedBuildsDict):  # p
 
 def readIncompleteBuildTxtFile(txtFile, idNum):  # pylint: disable=missing-raises-doc,missing-param-doc,missing-type-doc
     """Read the INCOMPLETE_NOTE text file indicating that this particular build is incomplete."""
-    with open(txtFile, 'rb') as f:
+    with open(txtFile, 'r') as f:
         contentsF = f.read()
         if 'is incomplete.' not in contentsF:
             print("Contents of %s is: %r" % (txtFile, contentsF))
@@ -872,7 +872,7 @@ def writeIncompleteBuildTxtFile(url, cacheFolder, txtFile, num):  # pylint: disa
             os.path.isdir(sps.normExpUserPath(os.path.join(cacheFolder, 'build', 'download'))):
         sps.rmTreeIncludingReadOnly(sps.normExpUserPath(os.path.join(cacheFolder, 'build')))
     assert not os.path.isfile(txtFile), 'incompleteBuild.txt should not be present.'
-    with open(txtFile, 'wb') as f:
+    with open(txtFile, 'w') as f:
         f.write('This build with numeric ID ' + num + ' is incomplete.')
     assert num == getIdFromTboxUrl(url), 'The numeric ID ' + num + \
         ' has to be the one we downloaded from ' + url

--- a/src/funfuzz/autobisectjs/find_intersecting_changesets.py
+++ b/src/funfuzz/autobisectjs/find_intersecting_changesets.py
@@ -11,7 +11,7 @@ Usage: python -m funfuzz.autobisectjs.find_intersecting_changesets -R ~/trees/mo
 (first go to known_broken_earliest_working and comment out configuration-specific ignore ranges,
 this file does not yet support those.)"""
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 from optparse import OptionParser  # pylint: disable=deprecated-module

--- a/src/funfuzz/autobisectjs/find_intersecting_changesets.py
+++ b/src/funfuzz/autobisectjs/find_intersecting_changesets.py
@@ -16,6 +16,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
+from past.builtins import range  # pylint: disable=redefined-builtin
+
 from . import known_broken_earliest_working as kbew
 from ..util import subprocesses as sps
 

--- a/src/funfuzz/autobisectjs/known_broken_earliest_working.py
+++ b/src/funfuzz/autobisectjs/known_broken_earliest_working.py
@@ -7,7 +7,7 @@
 """Known broken changeset ranges of SpiderMonkey are specified in this file.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 # pylint issue 73 https://git.io/vQAhf
 from distutils.version import StrictVersion  # pylint: disable=import-error,no-name-in-module

--- a/src/funfuzz/bot.py
+++ b/src/funfuzz/bot.py
@@ -8,7 +8,7 @@
 
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import multiprocessing
 import os

--- a/src/funfuzz/bot.py
+++ b/src/funfuzz/bot.py
@@ -162,7 +162,7 @@ def printMachineInfo():  # pylint: disable=invalid-name
     hgrc_path = os.path.join(path0, '.hg', 'hgrc')
     if os.path.isfile(hgrc_path):
         print("The hgrc of this repository is:")
-        with open(hgrc_path, 'rb') as f:
+        with open(hgrc_path, 'r') as f:
             hgrc_contents = f.readlines()
         for line in hgrc_contents:
             print(line.rstrip())

--- a/src/funfuzz/js/build_options.py
+++ b/src/funfuzz/js/build_options.py
@@ -16,6 +16,8 @@ import platform
 import random
 import sys
 
+from past.builtins import range  # pylint: disable=redefined-builtin
+
 from ..util import hg_helpers
 from ..util import subprocesses as sps
 

--- a/src/funfuzz/js/build_options.py
+++ b/src/funfuzz/js/build_options.py
@@ -7,7 +7,7 @@
 """Allows specification of build configuration parameters.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import argparse
 import hashlib

--- a/src/funfuzz/js/build_options.py
+++ b/src/funfuzz/js/build_options.py
@@ -237,7 +237,7 @@ def computeShellType(build_options):  # pylint: disable=invalid-name,missing-par
     if build_options.patchFile:
         # We take the name before the first dot, so Windows (hopefully) does not get confused.
         fileName.append(os.path.basename(build_options.patchFile).split('.')[0])
-        with open(os.path.abspath(build_options.patchFile), "rb") as f:
+        with open(os.path.abspath(build_options.patchFile), "r") as f:
             readResult = f.read()  # pylint: disable=invalid-name
         # Append the patch hash, but this is not equivalent to Mercurial's hash of the patch.
         fileName.append(hashlib.sha512(readResult).hexdigest()[:12])

--- a/src/funfuzz/js/compare_jit.py
+++ b/src/funfuzz/js/compare_jit.py
@@ -7,7 +7,7 @@
 """Test comparing the output of SpiderMonkey using various flags (usually JIT-related).
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import sys

--- a/src/funfuzz/js/compare_jit.py
+++ b/src/funfuzz/js/compare_jit.py
@@ -16,6 +16,7 @@ from optparse import OptionParser  # pylint: disable=deprecated-module
 # These pylint errors exist because FuzzManager is not Python 3-compatible yet
 import FTB.Signatures.CrashInfo as CrashInfo  # pylint: disable=import-error,no-name-in-module
 from FTB.ProgramConfiguration import ProgramConfiguration  # pylint: disable=import-error
+from past.builtins import range  # pylint: disable=redefined-builtin
 
 from . import js_interesting
 from . import pinpoint

--- a/src/funfuzz/js/compare_jit.py
+++ b/src/funfuzz/js/compare_jit.py
@@ -125,7 +125,7 @@ def compareLevel(jsEngine, flags, infilename, logPrefix, options, showDetailedDi
                                js_interesting.summaryString(r.issues + ["compare_jit found a more serious bug"],
                                                             r.lev,
                                                             r.runinfo.elapsedtime)))
-            with open(logPrefix + "-summary.txt", 'wb') as f:
+            with open(logPrefix + "-summary.txt", 'w') as f:
                 f.write('\n'.join(r.issues + [sps.shellify(command), "compare_jit found a more serious bug"]) + '\n')
             print("  %s" % sps.shellify(command))
             return (r.lev, r.crashInfo)
@@ -189,7 +189,7 @@ def compareLevel(jsEngine, flags, infilename, logPrefix, options, showDetailedDi
                                              os.path.basename(infilename)])
                 (summary, issues) = summarizeMismatch(mismatchErr, mismatchOut, prefix0, prefix)
                 summary = "  " + sps.shellify(commands[0]) + "\n  " + sps.shellify(command) + "\n\n" + summary
-                with open(logPrefix + "-summary.txt", 'wb') as f:
+                with open(logPrefix + "-summary.txt", 'w') as f:
                     f.write(rerunCommand + "\n\n" + summary)
                 print("%s | %s" % (infilename, js_interesting.summaryString(
                     issues, js_interesting.JS_OVERALL_MISMATCH, r.runinfo.elapsedtime)))

--- a/src/funfuzz/js/compile_shell.py
+++ b/src/funfuzz/js/compile_shell.py
@@ -578,7 +578,7 @@ def compileJs(shell):  # pylint: disable=invalid-name,missing-param-doc,missing-
 
 def createBustedFile(filename, e):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc
     """Create a .busted file with the exception message and backtrace included."""
-    with open(filename, 'wb') as f:
+    with open(filename, 'w') as f:
         f.write("Caught exception %s (%s)\n" % (repr(e), str(e)))
         f.write("Backtrace:\n")
         f.write(traceback.format_exc() + "\n")
@@ -614,7 +614,7 @@ def envDump(shell, log):  # pylint: disable=invalid-name,missing-param-doc,missi
     elif sps.isWin:
         fmconf_os = 'windows'
 
-    with open(log, 'ab') as f:
+    with open(log, "a") as f:
         f.write('# Information about shell:\n# \n')
 
         f.write('# Create another shell in shell-cache like this one:\n')

--- a/src/funfuzz/js/compile_shell.py
+++ b/src/funfuzz/js/compile_shell.py
@@ -579,18 +579,11 @@ def compileJs(shell):  # pylint: disable=invalid-name,missing-param-doc,missing-
 def createBustedFile(filename, e):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc
     """Create a .busted file with the exception message and backtrace included."""
     with open(filename, 'w') as f:
-        f.write("Caught exception %s (%s)\n" % (repr(e), str(e)))
+        f.write("Caught exception %r (%s)\n" % (e, e))
         f.write("Backtrace:\n")
         f.write(traceback.format_exc() + "\n")
-    try:
-        print("Compilation failed (%s) (details in %s)" % (e.decode("utf-8", errors="replace"),
-                                                           filename.decode("utf-8", errors="replace")))
-    except AttributeError:
-        # e may not have .decode especially when trying to run 32-bit binaries on WSL (which it cannot)
-        # The output seems to show 'Exec format error'
-        # FIXME: When we test this function, we should test whether e does have .decode or not.  # pylint: disable=fixme
-        # See https://github.com/MozillaSecurity/funfuzz/issues/143
-        print("Compilation failed (%s) (details in %s)" % (e, filename.decode("utf-8", errors="replace")))
+
+    print("Compilation failed (%s) (details in %s)" % (e, filename))
 
 
 def envDump(shell, log):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc

--- a/src/funfuzz/js/inspect_shell.py
+++ b/src/funfuzz/js/inspect_shell.py
@@ -7,7 +7,7 @@
 """Allows inspection of the SpiderMonkey shell to ensure that it is compiled as intended with specified configurations.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import platform

--- a/src/funfuzz/js/inspect_shell.py
+++ b/src/funfuzz/js/inspect_shell.py
@@ -72,7 +72,7 @@ def archOfBinary(binary):  # pylint: disable=inconsistent-return-statements,inva
     # pylint: disable=missing-raises-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
     """Test if a binary is 32-bit or 64-bit."""
     unsplit_file_type = sps.captureStdout(['file', binary])[0]
-    filetype = unsplit_file_type.split(':', 1)[1]
+    filetype = unsplit_file_type.decode("utf-8", errors="replace").split(':', 1)[1]
     if sps.isWin:
         assert 'MS Windows' in filetype
         return '32' if 'Intel 80386 32-bit' in filetype else '64'
@@ -150,7 +150,7 @@ def queryBuildConfiguration(s, parameter):  # pylint: disable=invalid-name,missi
     """Test if a binary is compiled with specified parameters, in getBuildConfiguration()."""
     ans = testBinary(s, ['-e', 'print(getBuildConfiguration()["' + parameter + '"])'],
                      False)[0]
-    return ans.find('true') != -1
+    return ans.decode("utf-8", errors="replace").find('true') != -1
 
 
 def testIsHardFpShellARM(s):  # pylint: disable=invalid-name,missing-param-doc,missing-raises-doc,missing-return-doc

--- a/src/funfuzz/js/js_interesting.py
+++ b/src/funfuzz/js/js_interesting.py
@@ -18,6 +18,7 @@ import lithium.interestingness.timed_run as timed_run
 # These pylint errors exist because FuzzManager is not Python 3-compatible yet
 import FTB.Signatures.CrashInfo as CrashInfo  # pylint: disable=import-error,no-name-in-module
 from FTB.ProgramConfiguration import ProgramConfiguration  # pylint: disable=import-error
+from past.builtins import range  # pylint: disable=redefined-builtin
 
 from . import inspect_shell
 from ..util import create_collector

--- a/src/funfuzz/js/js_interesting.py
+++ b/src/funfuzz/js/js_interesting.py
@@ -242,7 +242,7 @@ def ulimitSet():  # pylint: disable=invalid-name
         resource.setrlimit(resource.RLIMIT_AS, (2 * GB, 2 * GB))
 
     # Limit corefiles to 0.5 GB.
-    halfGB = int(GB / 2)  # pylint: disable=invalid-name,old-division
+    halfGB = int(GB // 2)  # pylint: disable=invalid-name
     resource.setrlimit(resource.RLIMIT_CORE, (halfGB, halfGB))
 
 

--- a/src/funfuzz/js/js_interesting.py
+++ b/src/funfuzz/js/js_interesting.py
@@ -7,7 +7,7 @@
 """Check whether a testcase causes an interesting result in a shell.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import sys

--- a/src/funfuzz/js/loop.py
+++ b/src/funfuzz/js/loop.py
@@ -172,7 +172,7 @@ def many_timed_runs(targetTime, wtmpDir, args, collector):  # pylint: disable=in
             filenameToReduce = logPrefix + "-reduced.js"  # pylint: disable=invalid-name
             [before, after] = file_manipulation.fuzzSplice(fuzzjs)
 
-            with open(logPrefix + '-out.txt', 'rb') as f:
+            with open(logPrefix + '-out.txt', 'r') as f:
                 newfileLines = before + [  # pylint: disable=invalid-name
                     l.replace('/*FRC-', '/*') for l in file_manipulation.linesStartingWith(f, "/*FRC-")] + after
             file_manipulation.writeLinesToFile(newfileLines, logPrefix + "-orig.js")
@@ -251,7 +251,7 @@ def jitCompareLines(jsfunfuzzOutputFilename, marker):  # pylint: disable=invalid
         "wasmIsSupported = function() { return true; };\n",
         "// DDBEGIN\n"
     ]
-    with open(jsfunfuzzOutputFilename, 'rb') as f:
+    with open(jsfunfuzzOutputFilename, 'r') as f:
         for line in f:
             if line.startswith(marker):
                 sline = line[len(marker):]

--- a/src/funfuzz/js/loop.py
+++ b/src/funfuzz/js/loop.py
@@ -7,7 +7,7 @@
 """Allows the funfuzz harness to run continuously.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import json
 import os

--- a/src/funfuzz/js/loop.py
+++ b/src/funfuzz/js/loop.py
@@ -302,6 +302,6 @@ assert mightUseDivision("eval('//x'); a / b;")
 
 
 if __name__ == "__main__":
-    # FIXME: Replace os.getcwdu() prior to moving to Python 3  # pylint: disable=fixme
     # pylint: disable=no-member
-    many_timed_runs(None, sps.createWtmpDir(os.getcwdu()), sys.argv[1:], create_collector.createCollector("jsfunfuzz"))
+    many_timed_runs(None, sps.createWtmpDir(os.getcwdu() if sys.version_info.major == 2 else os.getcwd()),
+                    sys.argv[1:], create_collector.createCollector("jsfunfuzz"))

--- a/src/funfuzz/js/loop.py
+++ b/src/funfuzz/js/loop.py
@@ -153,7 +153,7 @@ def many_timed_runs(targetTime, wtmpDir, args, collector):  # pylint: disable=in
             engineFlags = shell_flags.randomFlagSet(options.jsEngine)  # pylint: disable=invalid-name
             js_interesting_args.extend(engineFlags)
         # pylint: disable=old-division
-        js_interesting_args.extend(['-e', 'maxRunTime=' + str(options.timeout * (1000 / 2))])
+        js_interesting_args.extend(['-e', 'maxRunTime=' + str(options.timeout * (1000 // 2))])
         js_interesting_args.extend(['-f', fuzzjs])
         js_interesting_options = js_interesting.parseOptions(js_interesting_args)
 

--- a/src/funfuzz/js/pinpoint.py
+++ b/src/funfuzz/js/pinpoint.py
@@ -7,7 +7,7 @@
 """Enables the funfuzz harness to use autobisectjs to discover the regressing changeset.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import platform

--- a/src/funfuzz/js/pinpoint.py
+++ b/src/funfuzz/js/pinpoint.py
@@ -60,7 +60,7 @@ def pinpoint(itest, logPrefix, jsEngine, engineFlags, infilename,  # pylint: dis
             subprocess.call(autobisectCmd, stdout=open(autoBisectLogFilename, "w"), stderr=subprocess.STDOUT)
             print("Done running autobisect. Log: %s" % autoBisectLogFilename)
 
-            with open(autoBisectLogFilename, 'rb') as f:
+            with open(autoBisectLogFilename, 'r') as f:
                 lines = f.readlines()
                 autoBisectLog = file_manipulation.truncateMid(lines, 50, ["..."])  # pylint: disable=invalid-name
     else:
@@ -105,7 +105,7 @@ def strategicReduction(logPrefix, infilename, lithArgs, targetTime, lev):  # pyl
     hasTryItOut = False  # pylint: disable=invalid-name
     hasTryItOutRegex = re.compile(r'count=[0-9]+; tryItOut\("')  # pylint: disable=invalid-name
 
-    with open(infilename, 'rb') as f:
+    with open(infilename, 'r') as f:
         for line in file_manipulation.linesWith(f, '; tryItOut("'):
             # Checks if testcase came from jsfunfuzz or compare_jit.
             # Do not use .match here, it only matches from the start of the line:
@@ -119,12 +119,12 @@ def strategicReduction(logPrefix, infilename, lithArgs, targetTime, lev):  # pyl
 
         tryItOutAndCountRegex = re.compile(r'"\);\ncount=([0-9]+); tryItOut\("',  # pylint: disable=invalid-name
                                            re.MULTILINE)
-        with open(infilename, 'rb') as f:
+        with open(infilename, 'r') as f:
             infileContents = f.read()  # pylint: disable=invalid-name
             infileContents = re.sub(tryItOutAndCountRegex,  # pylint: disable=invalid-name
                                     ';\\\n"); count=\\1; tryItOut("\\\n',
                                     infileContents)
-        with open(infilename, 'wb') as f:
+        with open(infilename, 'w') as f:
             f.write(infileContents)
 
         print()
@@ -137,7 +137,7 @@ def strategicReduction(logPrefix, infilename, lithArgs, targetTime, lev):  # pyl
     # 1-line offset.
     if lithResult == LITH_FINISHED and origNumOfLines <= 50 and hasTryItOut and lev >= JS_VG_AMISS:
         intendedLines = []  # pylint: disable=invalid-name
-        with open(infilename, 'rb') as f:
+        with open(infilename, 'r') as f:
             for line in f:  # The testcase is likely to already be partially reduced.
                 if 'dumpln(cookie' not in line:  # jsfunfuzz-specific line ignore
                     # This should be simpler than re.compile.
@@ -172,14 +172,14 @@ def strategicReduction(logPrefix, infilename, lithArgs, targetTime, lev):  # pyl
     # Step 6: Run line reduction after activating SECOND DDBEGIN with a 1-line offset.
     if lithResult == LITH_FINISHED and origNumOfLines <= 50 and hasTryItOut and lev >= JS_VG_AMISS:
         infileContents = []  # pylint: disable=invalid-name
-        with open(infilename, 'rb') as f:
+        with open(infilename, 'r') as f:
             for line in f:
                 if 'NIGEBDD' in line:
                     infileContents.append(line.replace('NIGEBDD', 'DDBEGIN'))
                     infileContents.append('\n')  # The 1-line offset is added here.
                     continue
                 infileContents.append(line)
-        with open(infilename, 'wb') as f:
+        with open(infilename, 'w') as f:
             f.writelines(infileContents)
 
         print()

--- a/src/funfuzz/js/shell_flags.py
+++ b/src/funfuzz/js/shell_flags.py
@@ -7,7 +7,7 @@
 """Allows detection of support for various command-line flags.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import multiprocessing
 import random

--- a/src/funfuzz/js/shell_flags.py
+++ b/src/funfuzz/js/shell_flags.py
@@ -13,6 +13,8 @@ import multiprocessing
 import random
 import sys
 
+from past.builtins import range  # pylint: disable=redefined-builtin
+
 from . import inspect_shell
 from ..util import subprocesses as sps
 

--- a/src/funfuzz/loop_bot.py
+++ b/src/funfuzz/loop_bot.py
@@ -13,7 +13,7 @@ Config-ish bits should move to bot, OR move into a config file,
 OR this file should subprocess-call ITSELF rather than using a while loop.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import sys
 import subprocess

--- a/src/funfuzz/util/crashesat.py
+++ b/src/funfuzz/util/crashesat.py
@@ -9,7 +9,7 @@
 Not merged into Lithium, unsure if this still works for now. Still relies on grabCrashLog.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 from optparse import OptionParser  # pylint: disable=deprecated-module

--- a/src/funfuzz/util/create_collector.py
+++ b/src/funfuzz/util/create_collector.py
@@ -7,7 +7,7 @@
 """Functions here make use of a Collector created from FuzzManager.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 

--- a/src/funfuzz/util/detect_malloc_errors.py
+++ b/src/funfuzz/util/detect_malloc_errors.py
@@ -8,7 +8,7 @@
 which are signs of malloc being unhappy (double free, out-of-memory, etc).
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 PLINE = ""
 PPLINE = ""

--- a/src/funfuzz/util/download_build.py
+++ b/src/funfuzz/util/download_build.py
@@ -7,7 +7,7 @@
 """Allow downloading of builds.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import argparse
 import configparser

--- a/src/funfuzz/util/download_build.py
+++ b/src/funfuzz/util/download_build.py
@@ -466,7 +466,7 @@ def writeDownloadedShellFMConf(urlLink, bDir):  # pylint: disable=invalid-name,m
 
     downloadedShellFMConfPath = os.path.join(bDir, 'dist', 'js.fuzzmanagerconf')  # pylint: disable=invalid-name
     if not os.path.isfile(downloadedShellFMConfPath):
-        with open(downloadedShellFMConfPath, 'wb') as cfgfile:
+        with open(downloadedShellFMConfPath, 'w') as cfgfile:
             downloadedShellCfg.write(cfgfile)
 
     # Required pieces of the .fuzzmanagerconf file are platform, product and os

--- a/src/funfuzz/util/download_build.py
+++ b/src/funfuzz/util/download_build.py
@@ -21,6 +21,7 @@ import sys
 import urllib
 
 from future.moves.html.parser import HTMLParser
+from past.builtins import range  # pylint: disable=redefined-builtin
 
 from . import subprocesses as sps
 

--- a/src/funfuzz/util/file_manipulation.py
+++ b/src/funfuzz/util/file_manipulation.py
@@ -7,7 +7,7 @@
 """Functions dealing with files and their contents.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 
 def firstLine(s):  # pylint: disable=invalid-name,missing-param-doc,missing-return-doc,missing-return-type-doc

--- a/src/funfuzz/util/file_manipulation.py
+++ b/src/funfuzz/util/file_manipulation.py
@@ -21,7 +21,7 @@ def fuzzDice(filename):  # pylint: disable=invalid-name,missing-param-doc,missin
     """Return the lines of the file, except for the one line containing DICE."""
     before = []
     after = []
-    with open(filename, 'rb') as f:
+    with open(filename, 'r') as f:
         for line in f:
             if line.find("DICE") != -1:
                 break
@@ -36,7 +36,7 @@ def fuzzSplice(filename):  # pylint: disable=invalid-name,missing-param-doc,miss
     """Return the lines of a file, minus the ones between the two lines containing SPLICE."""
     before = []
     after = []
-    with open(filename, 'rb') as f:
+    with open(filename, 'r') as f:
         for line in f:
             before.append(line)
             if line.find("SPLICE") != -1:
@@ -80,5 +80,5 @@ def truncateMid(a, limit_each_side, insert_if_truncated):  # pylint: disable=inv
 
 def writeLinesToFile(lines, filename):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc
     """Write lines to a given filename."""
-    with open(filename, 'wb') as f:
+    with open(filename, 'w') as f:
         f.writelines(lines)

--- a/src/funfuzz/util/find_ignore_lists.py
+++ b/src/funfuzz/util/find_ignore_lists.py
@@ -7,7 +7,7 @@
 """Functions here attempt to find lists of bugs to ignore, e.g. via suppression files.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 

--- a/src/funfuzz/util/fork_join.py
+++ b/src/funfuzz/util/fork_join.py
@@ -7,7 +7,7 @@
 """Functions dealing with multiple processes.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import multiprocessing
 import os

--- a/src/funfuzz/util/fork_join.py
+++ b/src/funfuzz/util/fork_join.py
@@ -55,8 +55,8 @@ def logFileName(logDir, i, t):  # pylint: disable=invalid-name,missing-docstring
 
 
 def redirectOutputAndCallFun(logDir, i, fun, someArgs):  # pylint: disable=invalid-name,missing-docstring
-    sys.stdout = open(logFileName(logDir, i, "out"), 'wb', buffering=0)
-    sys.stderr = open(logFileName(logDir, i, "err"), 'wb', buffering=0)
+    sys.stdout = open(logFileName(logDir, i, "out"), 'w', buffering=0)
+    sys.stderr = open(logFileName(logDir, i, "err"), 'w', buffering=0)
     fun(*(someArgs + (i,)))
 
 

--- a/src/funfuzz/util/fork_join.py
+++ b/src/funfuzz/util/fork_join.py
@@ -13,6 +13,8 @@ import multiprocessing
 import os
 import sys
 
+from past.builtins import range  # pylint: disable=redefined-builtin
+
 
 # Call |fun| in a bunch of separate processes, then wait for them all to finish.
 # fun is called with someArgs, plus an additional argument with a numeric ID.

--- a/src/funfuzz/util/hg_helpers.py
+++ b/src/funfuzz/util/hg_helpers.py
@@ -7,7 +7,7 @@
 """Helper functions involving Mercurial (hg).
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import configparser
 import os

--- a/src/funfuzz/util/hg_helpers.py
+++ b/src/funfuzz/util/hg_helpers.py
@@ -15,13 +15,9 @@ import re
 import sys
 import subprocess
 
+from builtins import input  # pylint: disable=redefined-builtin
+
 from . import subprocesses as sps
-
-
-try:
-    input = raw_input  # pylint: disable=invalid-name,raw_input-builtin,redefined-builtin
-except NameError:
-    pass
 
 
 def destroyPyc(repoDir):  # pylint: disable=invalid-name,missing-docstring

--- a/src/funfuzz/util/hg_helpers.py
+++ b/src/funfuzz/util/hg_helpers.py
@@ -69,7 +69,7 @@ def existsAndIsAncestor(repoDir, a, b):  # pylint: disable=invalid-name,missing-
     # Takes advantage of "id(badhash)" being the empty set, in contrast to just "badhash", which is an error
     out = sps.captureStdout(['hg', '-R', repoDir, 'log', '-r', a + ' and ancestor(' + a + ',' + b + ')',
                              '--template={node|short}'], combineStderr=True, ignoreExitCode=True)[0]
-    return out != "" and out.find("abort: unknown revision") < 0
+    return out != "" and out.decode("utf-8", errors="replace").find("abort: unknown revision") < 0
 
 
 def getCsetHashFromBisectMsg(msg):  # pylint: disable=inconsistent-return-statements,invalid-name,missing-docstring
@@ -114,7 +114,7 @@ def getRepoHashAndId(repoDir, repoRev='parents() and default'):  # pylint: disab
             raise Exception('Invalid choice.')
         hg_id_full = sps.captureStdout(hg_log_template_cmds)[0]
     assert hg_id_full != ''
-    (hg_id_hash, hg_id_local_num) = hg_id_full.split(' ')
+    (hg_id_hash, hg_id_local_num) = hg_id_full.decode("utf-8", errors="replace").split(' ')
     sps.vdump('Finished getting the hash and local id number of the repository.')
     return hg_id_hash, hg_id_local_num, is_on_default
 

--- a/src/funfuzz/util/link_js.py
+++ b/src/funfuzz/util/link_js.py
@@ -15,7 +15,7 @@ import os
 def link_js(target_fn, file_list_fn, source_base, prologue="", module_dirs=None):
     # pylint: disable=missing-docstring
     module_dirs = module_dirs or []
-    with open(target_fn, "wb") as target:
+    with open(target_fn, "w") as target:
         target.write(prologue)
 
         # Add files listed in file_list_fn

--- a/src/funfuzz/util/link_js.py
+++ b/src/funfuzz/util/link_js.py
@@ -7,7 +7,7 @@
 """Functions to concatenate files, with one specially for js files.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 

--- a/src/funfuzz/util/lithium_helpers.py
+++ b/src/funfuzz/util/lithium_helpers.py
@@ -7,7 +7,7 @@
 """Helper functions to use the Lithium reducer.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import sys

--- a/src/funfuzz/util/lithium_helpers.py
+++ b/src/funfuzz/util/lithium_helpers.py
@@ -15,6 +15,8 @@ import shutil
 import subprocess
 import tempfile
 
+from past.builtins import range  # pylint: disable=redefined-builtin
+
 from . import subprocesses as sps
 
 runlithiumpy = [sys.executable, "-u", "-m", "lithium"]  # pylint: disable=invalid-name

--- a/src/funfuzz/util/repos_update.py
+++ b/src/funfuzz/util/repos_update.py
@@ -10,7 +10,7 @@ Only supports hg (Mercurial) for now.
 Assumes that the repositories are located in ../../trees/*.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 from copy import deepcopy
 import logging

--- a/src/funfuzz/util/s3cache.py
+++ b/src/funfuzz/util/s3cache.py
@@ -7,7 +7,7 @@
 """Functions here interact with Amazon EC2 using boto.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import shutil

--- a/src/funfuzz/util/subprocesses.py
+++ b/src/funfuzz/util/subprocesses.py
@@ -479,7 +479,7 @@ def test_rmTreeIncludingReadOnly():  # pylint: disable=invalid-name
     read_only_dir = os.path.join(test_dir, 'nestedReadOnlyDir')
     os.mkdir(read_only_dir)
     filename = os.path.join(read_only_dir, 'test.txt')
-    with open(filename, 'wb') as f:
+    with open(filename, 'w') as f:
         f.write('testing\n')
 
     os.chmod(filename, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)

--- a/src/funfuzz/util/subprocesses.py
+++ b/src/funfuzz/util/subprocesses.py
@@ -20,6 +20,8 @@ import subprocess
 import sys
 import time
 
+from past.builtins import range  # pylint: disable=redefined-builtin
+
 verbose = False  # pylint: disable=invalid-name
 
 isARMv7l = (platform.uname()[4] == 'armv7l')  # pylint: disable=invalid-name

--- a/src/funfuzz/util/subprocesses.py
+++ b/src/funfuzz/util/subprocesses.py
@@ -7,7 +7,7 @@
 """Miscellaneous helper functions.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import ctypes
 import errno


### PR DESCRIPTION
Here's a first wave of Python 3 fixes for funfuzz.

Some strings I've reverted from being set to bytes. This is the only way `configure` runs properly on both Python 2 and 3.

I switched to using the `builtins` and `past.builtins` libraries since we now import the Futurize module and it is also mentioned on the [official porting page](https://docs.python.org/3/howto/pyporting.html#the-short-explanation).