### PR TITLE
Switch to the GCC 6 toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,19 @@ addons:
             - autoconf2.13
             - cargo
             - expect-dev  # unbuffer requires this
-            - g++-5
-            - g++-5-multilib
-            - gcc-5
-            - gcc-5-multilib
+            - g++-6
+            - g++-6-multilib
+            - gcc-6
+            - gcc-6-multilib
             - gdb
             - lib32z1  # needed by 32-bit builds
             - libc6-dbg  # needed by Valgrind
             - valgrind
 before_install:
-    # Use GCC 5
+    # Use GCC 6
     - mkdir -p latest-gcc-symlinks  # See https://git.io/vx1sH
-    - ln -s /usr/bin/g++-5 latest-gcc-symlinks/g++
-    - ln -s /usr/bin/gcc-5 latest-gcc-symlinks/gcc
+    - ln -s /usr/bin/g++-6 latest-gcc-symlinks/g++
+    - ln -s /usr/bin/gcc-6 latest-gcc-symlinks/gcc
     - export PATH=$PWD/latest-gcc-symlinks:$PATH
 install:
     - pip install --upgrade codecov pytest-cov pytest-flake8 pytest-pylint  # Already in venv, no need for --user

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
             - valgrind
 before_install:
     # Use GCC 5
-    - mkdir -p latest-gcc-symlinks  # See https://github.com/travis-ci/travis-ci/issues/3668#issuecomment-279276549
+    - mkdir -p latest-gcc-symlinks  # See https://git.io/vx1sH
     - ln -s /usr/bin/g++-5 latest-gcc-symlinks/g++
     - ln -s /usr/bin/gcc-5 latest-gcc-symlinks/gcc
     - export PATH=$PWD/latest-gcc-symlinks:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: trusty
 sudo: required  # has ~2x RAM: https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments
+group: travis_latest
 language: python
 matrix:
     fast_finish: true


### PR DESCRIPTION
Bug [1444274](https://bugzilla.mozilla.org/show_bug.cgi?id=1444274) switched mozilla-central to require GCC 6.1.0 and up, so this fairly-straightforward PR bumps the version in Travis.