### PR TITLE
Split out PyPI pytest/linter-related dependencies.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,8 @@ install:
   - "%PYTHON%\\python.exe -m pip install --upgrade setuptools pip"
   - "%PYTHON%\\python.exe -m pip --version"
   - "git --version"
-  - "%PYTHON%\\python.exe -m pip install --upgrade -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip install --upgrade .[test]"  # Installs python testing-related packages
+  - "%PYTHON%\\python.exe -m pip install --upgrade -r requirements.txt"  # Gets FuzzManager, lithium-reducer from GitHub
   - "choco install codecov"
 build: off
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,8 @@ install:
   - python -m pip install --upgrade setuptools pip
   - python -m pip --version
   - python -m pip install --upgrade google-compute-engine  # For boto to work in Travis
-  - python -m pip install --upgrade -r requirements.txt
+  - python -m pip install --upgrade .[test]  # Installs python testing-related packages
+  - python -m pip install --upgrade -r requirements.txt  # Gets FuzzManager, lithium-reducer from GitHub
   - git --version
   - hg --version
   - python2 --version

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,32 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import itertools
+
 from setuptools import setup
+
+EXTRAS = {
+    ':python_version=="2.7"': [
+        "backports.tempfile>=1.0",
+        "functools32>=3.2.3.post2",
+        "mercurial>=4.5.3",
+        "subprocess32>=3.5.0rc1",
+    ]
+}
+EXTRAS[""] = list(set(itertools.chain.from_iterable(EXTRAS.values())))
+EXTRAS["test"] = [
+    "codecov==2.0.15",
+    "coverage==4.5.1",
+    "flake8==3.5.0",
+    "flake8-isort==2.5",
+    "isort==4.3.4",
+    "pylint==1.8.4",
+    "pytest==3.5.1",
+    "pytest-cov==2.5.1",
+    "pytest-flake8==1.0.1",
+    "pytest-pylint==0.9.0",
+]
+
 
 if __name__ == "__main__":
     setup(name="funfuzz",
@@ -30,32 +55,15 @@ if __name__ == "__main__":
           ]},
           package_dir={"": "src"},
           install_requires=[
-              "backports.print_function==1.1.1",
-              "boto==2.48.0",
-              "codecov==2.0.15",
-              "configparser==3.5.0",
-              "coverage==4.5.1",
-              "flake8==3.5.0",
-              "flake8-isort==2.5",
-              "future==0.16.0",
-              "isort==4.3.4",
+              "backports.print_function>=1.1.1",
+              "boto>=2.48.0",
+              "configparser>=3.5.0",
+              "future>=0.16.0",
               "pathlib2>=2.1.0",
-              "psutil==5.4.5",
-              "pylint==1.8.4",
-              "pytest==3.5.1",
-              "pytest-cov==2.5.1",
-              "pytest-flake8==1.0.1",
-              "pytest-pylint==0.9.0",
-              "requests==2.18.4",
-              "shellescape==3.4.1",
-              "whichcraft==0.4.1",
+              "psutil>=5.4.5",
+              "requests>=2.18.4",
+              "shellescape>=3.4.1",
+              "whichcraft>=0.4.1",
           ],
-          extras_require={
-              ':python_version=="2.7"': [
-                  "backports.tempfile==1.0",
-                  "functools32==3.2.3.post2",
-                  "mercurial>=4.5.3",
-                  "subprocess32==3.5.0rc1",
-              ]
-          },
+          extras_require=EXTRAS,
           zip_safe=False)


### PR DESCRIPTION
As per [discussed here](https://github.com/MozillaSecurity/funfuzz/pull/194#discussion_r187733155).