### PR TITLE
Rename sps to os_ops in loop.py

### DIFF
--- a/src/funfuzz/js/loop.py
+++ b/src/funfuzz/js/loop.py
@@ -23,7 +23,7 @@ from . import shell_flags
 from ..util import create_collector
 from ..util import file_manipulation
 from ..util import lithium_helpers
-from ..util import subprocesses as sps
+from ..util import os_ops
 
 if sys.version_info.major == 2:
     if os.name == "posix":
@@ -292,5 +292,5 @@ def jitCompareLines(jsfunfuzzOutputFilename, marker):  # pylint: disable=invalid
 
 if __name__ == "__main__":
     # pylint: disable=no-member
-    many_timed_runs(None, sps.make_wtmp_dir(Path(os.getcwdu() if sys.version_info.major == 2 else os.getcwd())),
+    many_timed_runs(None, os_ops.make_wtmp_dir(Path(os.getcwdu() if sys.version_info.major == 2 else os.getcwd())),
                     sys.argv[1:], create_collector.make_collector(), False)


### PR DESCRIPTION
4abb66c3f583d942e081532a561b444ecad32295 renamed this method and moved it to a new file. However, it never fixed the import, so running loop.py was broken.