### PR TITLE
jsfunfuzz updates: remove generator expressions, support invisibleToDebugger/sameCompartmentAs, recomputeWrappers etc.

### DIFF
--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -990,6 +990,8 @@ function makeNewGlobalArg(d, b)
     propStrs.push("cloneSingletons: " + makeBoolean(d - 1, b));
   if (rnd(2))
     propStrs.push("disableLazyParsing: " + makeBoolean(d - 1, b));
+  if (rnd(2))
+    propStrs.push("invisibleToDebugger: " + makeBoolean(d - 1, b));
   return "{ " + propStrs.join(", ") + " }";
 }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -278,6 +278,7 @@ var statementMakers = Random.weighted([
 if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
   statementMakers = statementMakers.concat([
     function(d, b) { return "oomTest(" + makeFunction(d - 1, b) + ")"; },
+    function(d, b) { return "oomTest(" + makeFunction(d - 1, b) + ", { keepFailing: true })"; },
   ]);
 }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -712,8 +712,7 @@ var incDecOps = [
 
 
 var specialProperties = [
-  "__count__",
-  "__parent__", "__proto__", "constructor", "prototype",
+  "__proto__", "constructor", "prototype",
   "wrappedJSObject",
   "arguments", "caller", "callee",
   "toString", "valueOf",
@@ -786,7 +785,7 @@ var exprMakers =
   function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ", ", makeExpr(d, b), ")"]); },
   function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ")"]); },
 
-  // RegExp replace.  This is interesting for the same reason as array extras.  Also, in SpiderMonkey, the "this" argument is weird (obj.__parent__?)
+  // RegExp replace.  This is interesting for the same reason as array extras.
   function(d, b) { return cat(["'fafafa'", ".", "replace", "(", "/", "a", "/", "g", ", ", makeFunction(d, b), ")"]); },
 
   // Containment in an array or object (or, if this happens to end up on the LHS of an assignment, destructuring)

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -906,10 +906,6 @@ var exprMakers =
   // Spidermonkey: additional "strict" warnings, distinct from ES5 strict mode
   function(d, b) { return "(void options('strict'))"; },
 
-  // Spidermonkey: versions
-  // Commenting out because this version function has been removed as of m-c rev 392455 (Fx59) - 589914e65db7
-  //function(d, b) { return "(void version(" + Random.index([170, 180, 185]) + "))"; },
-
   // More special Spidermonkey shell functions
   // (Note: functions without returned objects or visible side effects go in testing-functions.js, in order to allow presence/absence differential testing.)
   //  function(d, b) { return "dumpObject(" + makeExpr(d, b) + ")" } }, // crashes easily, bug 836603

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -1281,9 +1281,6 @@ var functionMakers = [
   function(d, b) { return "async function* (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
   function(d, b) { return "async function* (y) { " + directivePrologue() + "yield y; await y; " + makeStatement(d, b.concat(["y"])) + "; yield y; await y; }"; },
 
-  // A generator expression -- kinda a function??
-  function(d, b) { return "(1 for (x in []))"; },
-
   // A simple wrapping pattern
   function(d, b) { return "/*wrap1*/(" + functionPrefix() + "(){ " + directivePrologue() + makeStatement(d, b) + "return " + makeFunction(d, b) + "})()"; },
 
@@ -1976,10 +1973,6 @@ var iterableExprMakers = Random.weighted([
 
   // Array comprehensions (JavaScript 1.7)
   { w: 1, v: function(d, b) { return cat(["[", makeExpr(d, b), makeComprehension(d, b), "]"]); } },
-
-  // Generator expressions (JavaScript 1.8)
-  { w: 1, v: function(d, b) { return cat([     makeExpr(d, b), makeComprehension(d, b)     ]); } },
-  { w: 1, v: function(d, b) { return cat(["(", makeExpr(d, b), makeComprehension(d, b), ")"]); } },
 
   // A generator that yields once
   { w: 1, v: function(d, b) { return "(function() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -985,6 +985,8 @@ function makeNewGlobalArg(d, b)
   // Make an options object to pass to the |newGlobal| shell builtin.
   var propStrs = [];
   if (rnd(2))
+    propStrs.push("sameCompartmentAs: " + makeExpr(d - 1, b));
+  if (rnd(2))
     propStrs.push("sameZoneAs: " + makeExpr(d - 1, b));
   if (rnd(2))
     propStrs.push("cloneSingletons: " + makeBoolean(d - 1, b));

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -170,6 +170,7 @@ var makeEvilCallback;
       ", lineNumber: 42" +
       ", isRunOnce: " + makeBoolean(d, b) +
       ", noScriptRval: " + makeBoolean(d, b) +
+      ", saveIncrementalBytecode: " + makeBoolean(d, b) +
       ", sourceIsLazy: " + makeBoolean(d, b) +
       ", catchTermination: " + makeBoolean(d, b) +
       ((rnd(5) == 0) ? (

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -58,7 +58,8 @@ function useSpidermonkeyShellSandbox(sandboxType)
   switch (sandboxType) {
     case 0:  primarySandbox = evalcx('');
     case 1:  primarySandbox = evalcx('lazy');
-    case 2:  primarySandbox = newGlobal({sameZoneAs: {}}); // same zone
+    case 2:  primarySandbox = newGlobal({sameCompartmentAs: {}});
+    case 3:  primarySandbox = newGlobal({sameZoneAs: {}}); // same zone
     default: primarySandbox = newGlobal(); // new zone
   }
 

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -163,6 +163,10 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     { w: 10, v: function(d, b) { return "void " + prefix + "relazifyFunctions" + "('compartment');"; } },
     { w: 5,  v: function(d, b) { return "void " + prefix + "relazifyFunctions" + "(" + fGlobal(d, b) + ");"; } },
 
+    // Test recomputeWrappers - see bug 1492406
+    { w: 10,  v: function(d, b) { return prefix + "recomputeWrappers" + "();"; } },
+    // Also test recomputeWrappers calling newGlobal, see the bug
+
     // [TestingFunctions.cpp, but debug-only and CRASHY]
     // After N js_malloc memory allocations, fail every following allocation
     { w: 1,  v: function(d, b) { return (typeof oomAfterAllocations == "function" && rnd(1000) === 0) ? prefix + "oomAfterAllocations" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },


### PR DESCRIPTION
These are improvements to jsfunfuzz.

Adds:

* `invisibleToDebugger` and `sameCompartmentAs` to `newGlobal` parameters to be tested
* `saveIncrementalBytecode` to `evaluate` parameters
* Initial support for `recomputeWrappers`
* the `keepFailing: true` option to `oomTest`

Removes:

* Support for generator expressions
* `Object.prototype` no longer has `__count__` and `__parent__`.

I am still poking at hooking up eslint to Travis to at least have a linter in place.