### PR TITLE
Add eslint to jsfunfuzz on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,7 @@ before_install:
       rustup --version
       which rustc
       rustc --version
+      npm --version
     fi
 install:
   # Already in venv, no need for --user
@@ -183,6 +184,13 @@ script:
       # python -m pytest -s --flake8 -p no:pylint,cov -m "not slow"
     else
       python -m pytest -s --flake8 --pylint --pylint-jobs=2 -m "not slow" --cov --cov-report term-missing
+    fi
+  - |
+    if [ $TRAVIS_OS_NAME == "linux" ] ; then
+      pushd src/funfuzz/js/
+      npm install || travis_terminate 1
+      npm run lint || travis_terminate 1
+      popd
     fi
   - |
     if [ $TRAVIS_OS_NAME == "linux" ] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,11 @@ script:
     if [ $TRAVIS_OS_NAME == "linux" ] ; then
       pushd src/funfuzz/js/
       npm install || travis_terminate 1
+      npm install eslint-plugin-import --save-dev || travis_terminate 1
+      npm install eslint-plugin-jsdoc --save-dev || travis_terminate 1
+      npm install eslint-plugin-node --save-dev || travis_terminate 1
+      npm install eslint-plugin-promise --save-dev || travis_terminate 1
+      npm install eslint-plugin-standard --save-dev || travis_terminate 1
       npm run lint || travis_terminate 1
       popd
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -189,11 +189,6 @@ script:
     if [ $TRAVIS_OS_NAME == "linux" ] ; then
       pushd src/funfuzz/js/
       npm install || travis_terminate 1
-      npm install eslint-plugin-import --save-dev || travis_terminate 1
-      npm install eslint-plugin-jsdoc --save-dev || travis_terminate 1
-      npm install eslint-plugin-node --save-dev || travis_terminate 1
-      npm install eslint-plugin-promise --save-dev || travis_terminate 1
-      npm install eslint-plugin-standard --save-dev || travis_terminate 1
       npm run lint || travis_terminate 1
       popd
     fi

--- a/src/funfuzz/js/.eslintrc.js
+++ b/src/funfuzz/js/.eslintrc.js
@@ -1,0 +1,29 @@
+"use strict";
+
+module.exports = {
+  "parserOptions": {
+      "ecmaVersion": 2018,
+  },
+  "rules": {
+    // Adapted from m-c rev 440407:2d2dee08739f (Fx64) tools/lint/eslint/.eslintrc.js
+    "camelcase": "error",
+    "curly": ["error", "multi-line"],
+    "handle-callback-err": ["error", "er"],
+    "indent": ["error", 2, {"SwitchCase": 1}],
+    // Replaced by the "indent" rule
+    // "indent-legacy": ["error", 2, {"SwitchCase": 1}],
+    "linebreak-style": ["error", "unix"],
+    "max-len": ["error", 120, 2],
+    // Multiple empty lines can sometimes help readability
+    // "no-multiple-empty-lines": ["error", {"max": 1}],
+    "no-shadow": "error",
+    "no-undef": ["error", {"typeof": true}],
+    "no-undef-init": "error",
+    "one-var": ["error", "never"],
+    "operator-linebreak": ["error", "after"],
+    "quotes": ["error", "double"],
+    "semi": ["error", "always"],
+    // jsfunfuzz turns strict mode on and off
+    // "strict": ["error", "global"],
+  }
+};

--- a/src/funfuzz/js/.eslintrc.js
+++ b/src/funfuzz/js/.eslintrc.js
@@ -31,6 +31,8 @@ module.exports = {
     "operator-linebreak": "off",
     "quotes": ["error", "double"],
     "semi": ["error", "always"],
+    // jsfunfuzz has mostly been written in the current style for a long time
+    "space-before-function-paren": ["error", "never"],
     // jsfunfuzz turns strict mode on and off
     // "strict": ["error", "global"],
   }

--- a/src/funfuzz/js/.eslintrc.js
+++ b/src/funfuzz/js/.eslintrc.js
@@ -4,12 +4,12 @@ module.exports = {
     "ecmaFeatures": {
       "jsx": true
     },
-    "sourceType": "module"
+    // "sourceType": "module"
   },
 
   "env": {
     "es6": true,
-    "node": true,
+    // "node": true,
     "mocha": true
   },
 
@@ -44,7 +44,7 @@ module.exports = {
       "functions": "never"
     }],
     "comma-spacing": ["error", { "before": false, "after": true }],
-    "comma-style": ["error", "last"],
+    "comma-style": ["off"],
     "constructor-super": "error",
     "curly": ["error", "multi-line"],
     "dot-location": ["error", "property"],
@@ -136,6 +136,7 @@ module.exports = {
     "no-self-assign": "error",
     "no-self-compare": "error",
     "no-sequences": "error",
+    "no-shadow": "error",
     "no-shadow-restricted-names": "error",
     "no-sparse-arrays": "error",
     "no-tabs": "error",
@@ -165,12 +166,14 @@ module.exports = {
     "object-curly-spacing": ["error", "always"],
     "object-property-newline": ["error", { "allowMultiplePropertiesPerLine": true }],
     "one-var": ["error", { "initialized": "never" }],
-    "operator-linebreak": ["error", "after", { "overrides": { "?": "before", ":": "before" } }],
+    // jsfunfuzz has mostly been written in the current style for a long time, may help line-based reducer Lithium too
+    "operator-linebreak": "off",
     "padded-blocks": ["error", { "blocks": "never", "switches": "never", "classes": "never" }],
     "prefer-promise-reject-errors": "error",
-    "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
+    // jsfunfuzz has mostly been written in the current style for a long time
+    "quotes": ["error", "double", { "avoidEscape": true, "allowTemplateLiterals": true }],
     "rest-spread-spacing": ["error", "never"],
-    "semi": ["error", "never"],
+    "semi": ["error", "always"],
     "semi-spacing": ["error", { "before": false, "after": true }],
     "space-before-blocks": ["error", "always"],
     "space-before-function-paren": ["error", "always"],

--- a/src/funfuzz/js/.eslintrc.js
+++ b/src/funfuzz/js/.eslintrc.js
@@ -27,7 +27,8 @@ module.exports = {
     // object-shorthand requires to be fully on ES6+
     "object-shorthand": "off",
     "one-var": ["error", "never"],
-    "operator-linebreak": ["error", "after"],
+    // jsfunfuzz has mostly been written in the current style for a long time, may help line-based reducer Lithium too
+    "operator-linebreak": "off",
     "quotes": ["error", "double"],
     "semi": ["error", "always"],
     // jsfunfuzz turns strict mode on and off

--- a/src/funfuzz/js/.eslintrc.js
+++ b/src/funfuzz/js/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     "one-var": ["error", "never"],
     // jsfunfuzz has mostly been written in the current style for a long time, may help line-based reducer Lithium too
     "operator-linebreak": "off",
-    "quotes": ["error", "double"],
+    "quotes": ["error", "double", {"avoidEscape": true}],
     "semi": ["error", "always"],
     // jsfunfuzz has mostly been written in the current style for a long time
     "space-before-function-paren": ["error", "never"],

--- a/src/funfuzz/js/.eslintrc.js
+++ b/src/funfuzz/js/.eslintrc.js
@@ -21,6 +21,9 @@ module.exports = {
     "no-undef-init": "error",
     // We want to test object-curly-spacing in funfuzz
     "object-curly-spacing": "off",
+    // Turned off until we are ready to refactor jsfunfuzz
+    // There are multiple areas where we deliberately split up strings to avoid the harness searching jsfunfuzz itself
+    "no-useless-concat": "off",
     "one-var": ["error", "never"],
     "operator-linebreak": ["error", "after"],
     "quotes": ["error", "double"],

--- a/src/funfuzz/js/.eslintrc.js
+++ b/src/funfuzz/js/.eslintrc.js
@@ -24,6 +24,8 @@ module.exports = {
     // Turned off until we are ready to refactor jsfunfuzz
     // There are multiple areas where we deliberately split up strings to avoid the harness searching jsfunfuzz itself
     "no-useless-concat": "off",
+    // object-shorthand requires to be fully on ES6+
+    "object-shorthand": "off",
     "one-var": ["error", "never"],
     "operator-linebreak": ["error", "after"],
     "quotes": ["error", "double"],

--- a/src/funfuzz/js/.eslintrc.js
+++ b/src/funfuzz/js/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   "rules": {
     // Adapted from m-c rev 440407:2d2dee08739f (Fx64) tools/lint/eslint/.eslintrc.js
     "camelcase": "error",
-    "curly": ["error", "multi-line"],
+    "curly": ["error", "multi", "consistent"],
     "handle-callback-err": ["error", "er"],
     "indent": ["error", 2, {"SwitchCase": 1}],
     // Replaced by the "indent" rule

--- a/src/funfuzz/js/.eslintrc.js
+++ b/src/funfuzz/js/.eslintrc.js
@@ -19,6 +19,8 @@ module.exports = {
     "no-shadow": "error",
     "no-undef": ["error", {"typeof": true}],
     "no-undef-init": "error",
+    // We want to test object-curly-spacing in funfuzz
+    "object-curly-spacing": "off",
     "one-var": ["error", "never"],
     "operator-linebreak": ["error", "after"],
     "quotes": ["error", "double"],

--- a/src/funfuzz/js/.eslintrc.js
+++ b/src/funfuzz/js/.eslintrc.js
@@ -1,39 +1,242 @@
-"use strict";
-
 module.exports = {
   "parserOptions": {
-      "ecmaVersion": 2018,
+    "ecmaVersion": 2018,
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "sourceType": "module"
   },
+
+  "env": {
+    "es6": true,
+    "node": true,
+    "mocha": true
+  },
+
+  "plugins": [
+    "import",
+    "jsdoc",
+    "node",
+    "promise",
+    "standard"
+  ],
+
+  "globals": {
+    "o": true,
+    "document": false,
+    "navigator": false,
+    "window": false
+  },
+
   "rules": {
-    // Adapted from m-c rev 440407:2d2dee08739f (Fx64) tools/lint/eslint/.eslintrc.js
-    "camelcase": "error",
-    "curly": ["error", "multi", "consistent"],
-    "handle-callback-err": ["error", "er"],
-    "indent": ["error", 2, {"SwitchCase": 1}],
-    // Replaced by the "indent" rule
-    // "indent-legacy": ["error", 2, {"SwitchCase": 1}],
-    "linebreak-style": ["error", "unix"],
-    "max-len": ["error", 120, 2],
-    // Multiple empty lines can sometimes help readability
-    // "no-multiple-empty-lines": ["error", {"max": 1}],
-    "no-shadow": "error",
-    "no-undef": ["error", {"typeof": true}],
+    // Adapted from https://github.com/pyoor/DOMfuzz2/blob/612fc89851fd1179324179affbed6b3be3fe5bea/.eslintrc.json
+    // Standard style related rules
+    "accessor-pairs": "error",
+    "arrow-spacing": ["error", { "before": true, "after": true }],
+    "block-spacing": ["error", "always"],
+    "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
+    "camelcase": ["error", { "properties": "never" }],
+    "comma-dangle": ["error", {
+      "arrays": "never",
+      "objects": "never",
+      "imports": "never",
+      "exports": "never",
+      "functions": "never"
+    }],
+    "comma-spacing": ["error", { "before": false, "after": true }],
+    "comma-style": ["error", "last"],
+    "constructor-super": "error",
+    "curly": ["error", "multi-line"],
+    "dot-location": ["error", "property"],
+    "eol-last": "error",
+    "eqeqeq": ["error", "always", { "null": "ignore" }],
+    "func-call-spacing": ["error", "never"],
+    "generator-star-spacing": ["error", { "before": true, "after": true }],
+    "handle-callback-err": ["error", "^(err|error)$" ],
+    "indent": ["error", 2, {
+      "SwitchCase": 1,
+      "VariableDeclarator": 1,
+      "outerIIFEBody": 1,
+      "MemberExpression": 1,
+      "FunctionDeclaration": { "parameters": 1, "body": 1 },
+      "FunctionExpression": { "parameters": 1, "body": 1 },
+      "CallExpression": { "arguments": 1 },
+      "ArrayExpression": 1,
+      "ObjectExpression": 1,
+      "ImportDeclaration": 1,
+      "flatTernaryExpressions": false,
+      "ignoreComments": false
+    }],
+    "key-spacing": ["error", { "beforeColon": false, "afterColon": true }],
+    "keyword-spacing": ["error", { "before": true, "after": true }],
+    "new-cap": ["error", { "newIsCap": true, "capIsNew": false }],
+    "new-parens": "error",
+    "no-array-constructor": "error",
+    "no-caller": "error",
+    "no-class-assign": "error",
+    "no-compare-neg-zero": "error",
+    "no-cond-assign": "error",
+    "no-const-assign": "error",
+    "no-constant-condition": ["error", { "checkLoops": false }],
+    "no-control-regex": "error",
+    "no-debugger": "error",
+    "no-delete-var": "error",
+    "no-dupe-args": "error",
+    "no-dupe-class-members": "error",
+    "no-dupe-keys": "error",
+    "no-duplicate-case": "error",
+    "no-empty-character-class": "error",
+    "no-empty-pattern": "error",
+    "no-eval": "error",
+    "no-ex-assign": "error",
+    "no-extend-native": "error",
+    "no-extra-bind": "error",
+    "no-extra-boolean-cast": "error",
+    "no-extra-parens": ["error", "functions"],
+    "no-fallthrough": "error",
+    "no-floating-decimal": "error",
+    "no-func-assign": "error",
+    "no-global-assign": "error",
+    "no-implied-eval": "error",
+    "no-inner-declarations": ["error", "functions"],
+    "no-invalid-regexp": "error",
+    "no-irregular-whitespace": "error",
+    "no-iterator": "error",
+    "no-label-var": "error",
+    "no-labels": ["error", { "allowLoop": false, "allowSwitch": false }],
+    "no-lone-blocks": "error",
+    "no-mixed-operators": ["error", {
+      "groups": [
+        ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
+        ["&&", "||"],
+        ["in", "instanceof"]
+      ],
+      "allowSamePrecedence": true
+    }],
+    "no-mixed-spaces-and-tabs": "error",
+    "no-multi-spaces": "error",
+    "no-multi-str": "error",
+    "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 0 }],
+    "no-negated-in-lhs": "error",
+    "no-new": "error",
+    "no-new-func": "error",
+    "no-new-object": "error",
+    "no-new-require": "error",
+    "no-new-symbol": "error",
+    "no-new-wrappers": "error",
+    "no-obj-calls": "error",
+    "no-octal": "error",
+    "no-octal-escape": "error",
+    "no-path-concat": "error",
+    "no-proto": "error",
+    "no-redeclare": "error",
+    "no-regex-spaces": "error",
+    "no-return-assign": ["error", "except-parens"],
+    "no-return-await": "error",
+    "no-self-assign": "error",
+    "no-self-compare": "error",
+    "no-sequences": "error",
+    "no-shadow-restricted-names": "error",
+    "no-sparse-arrays": "error",
+    "no-tabs": "error",
+    "no-template-curly-in-string": "error",
+    "no-this-before-super": "error",
+    "no-throw-literal": "error",
+    "no-trailing-spaces": "error",
+    "no-undef": "error",
     "no-undef-init": "error",
-    // We want to test object-curly-spacing in funfuzz
-    "object-curly-spacing": "off",
-    // Turned off until we are ready to refactor jsfunfuzz
-    // There are multiple areas where we deliberately split up strings to avoid the harness searching jsfunfuzz itself
-    "no-useless-concat": "off",
-    // object-shorthand requires to be fully on ES6+
-    "object-shorthand": "off",
-    "one-var": ["error", "never"],
-    // jsfunfuzz has mostly been written in the current style for a long time, may help line-based reducer Lithium too
-    "operator-linebreak": "off",
-    "quotes": ["error", "double", {"avoidEscape": true}],
-    "semi": ["error", "always"],
-    // jsfunfuzz has mostly been written in the current style for a long time
-    "space-before-function-paren": ["error", "never"],
-    // jsfunfuzz turns strict mode on and off
-    // "strict": ["error", "global"],
+    "no-unexpected-multiline": "error",
+    "no-unmodified-loop-condition": "error",
+    "no-unneeded-ternary": ["error", { "defaultAssignment": false }],
+    "no-unreachable": "error",
+    "no-unsafe-finally": "error",
+    "no-unsafe-negation": "error",
+    "no-unused-expressions": ["error", { "allowShortCircuit": true, "allowTernary": true, "allowTaggedTemplates": true }],
+    "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": true }],
+    "no-use-before-define": ["error", { "functions": false, "classes": false, "variables": false }],
+    "no-useless-call": "error",
+    "no-useless-computed-key": "error",
+    "no-useless-constructor": "error",
+    "no-useless-escape": "error",
+    "no-useless-rename": "error",
+    "no-useless-return": "error",
+    "no-whitespace-before-property": "error",
+    "no-with": "error",
+    "object-curly-spacing": ["error", "always"],
+    "object-property-newline": ["error", { "allowMultiplePropertiesPerLine": true }],
+    "one-var": ["error", { "initialized": "never" }],
+    "operator-linebreak": ["error", "after", { "overrides": { "?": "before", ":": "before" } }],
+    "padded-blocks": ["error", { "blocks": "never", "switches": "never", "classes": "never" }],
+    "prefer-promise-reject-errors": "error",
+    "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
+    "rest-spread-spacing": ["error", "never"],
+    "semi": ["error", "never"],
+    "semi-spacing": ["error", { "before": false, "after": true }],
+    "space-before-blocks": ["error", "always"],
+    "space-before-function-paren": ["error", "always"],
+    "space-in-parens": ["error", "never"],
+    "space-infix-ops": "error",
+    "space-unary-ops": ["error", { "words": true, "nonwords": false }],
+    "spaced-comment": ["error", "always", {
+      "line": { "markers": ["*package", "!", "/", ",", "="] },
+      "block": { "balanced": true, "markers": ["*package", "!", ",", ":", "::", "flow-include"], "exceptions": ["*"] }
+    }],
+    "symbol-description": "error",
+    "template-curly-spacing": ["error", "never"],
+    "template-tag-spacing": ["error", "never"],
+    "unicode-bom": ["error", "never"],
+    "use-isnan": "error",
+    "valid-typeof": ["error", { "requireStringLiterals": true }],
+    "wrap-iife": ["error", "any", { "functionPrototypeMethods": true }],
+    "yield-star-spacing": ["error", "both"],
+    "yoda": ["error", "never"],
+
+    "import/export": "error",
+    "import/first": "error",
+    "import/no-duplicates": "error",
+    "import/no-named-default": "error",
+    "import/no-webpack-loader-syntax": "error",
+
+    "node/no-deprecated-api": "error",
+    "node/process-exit-as-throw": "error",
+
+    "promise/param-names": "error",
+
+    "standard/array-bracket-even-spacing": ["error", "either"],
+    "standard/computed-property-even-spacing": ["error", "even"],
+    "standard/no-callback-literal": "error",
+    "standard/object-curly-even-spacing": ["error", "either"],
+
+    // JSDoc related rules
+    "jsdoc/check-param-names": 1,
+    "jsdoc/check-tag-names": 1,
+    "jsdoc/check-types": 1,
+    "jsdoc/newline-after-description": 1,
+    "jsdoc/require-description-complete-sentence": 0,
+    "jsdoc/require-hyphen-before-param-description": 1,
+    "jsdoc/require-param": 1,
+    "jsdoc/require-param-description": 1,
+    "jsdoc/require-param-type": 1,
+    "jsdoc/require-returns-description": 0,
+    "jsdoc/require-returns-type": 1,
+    "require-jsdoc": [
+      1,
+      {
+        "require": {
+          "FunctionDeclaration": true,
+          "MethodDefinition": true,
+          "ClassDeclaration": true,
+          "ArrowFunctionExpression": false
+        }
+      }
+    ],
+    "valid-jsdoc": [
+      "error",
+      {
+        "requireParamDescription": false,
+        "requireReturnDescription": false,
+        "requireReturn": false
+      }
+    ]
   }
-};
+}

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global engine, ENGINE_JAVASCRIPTCORE, ENGINE_SPIDERMONKEY_TRUNK, gcIsQuiet, jsshell */
+
 /* eslint-disable complexity */
 function whatToTestSpidermonkeyTrunk(code)
 {

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -32,13 +32,13 @@ function whatToTestSpidermonkeyTrunk(code)
        && code.indexOf(".findScripts") == -1              // Debugger; see bug 1250863
        && code.indexOf("Date") == -1                      // time marches on
        && code.indexOf("backtrace") == -1                 // shows memory addresses
-       && code.indexOf("drainAllocationsLog") == -1       // this returns an object with a timestamp, see bug 1066313
+       && code.indexOf("drainAllocationsLog") == -1       // drainAllocationsLog returns an object with a timestamp, see bug 1066313
        && code.indexOf("dumpObject") == -1                // shows heap addresses
        && code.indexOf("dumpHeap") == -1                  // shows heap addresses
        && code.indexOf("dumpStringRepresentation") == -1  // shows memory addresses
        && code.indexOf("evalInCooperativeThread") == -1   // causes diffs especially in --no-threads
-       && code.indexOf("evalInWorker") == -1              // causes diffs in --no-threads/--ion-offthread-compile=off
-       && code.indexOf("getBacktrace") == -1              // this returns memory addresses that differ based on flags
+       && code.indexOf("evalInWorker") == -1              // causes diffs in --no-threads vs --ion-offthread-compile=off
+       && code.indexOf("getBacktrace") == -1              // getBacktrace returns memory addresses which differs depending on flags
        && code.indexOf("getLcovInfo") == -1
        && code.indexOf("load") == -1                      // load()ed regression test might output dates, etc
        && code.indexOf("offThreadCompileScript") == -1    // causes diffs in --no-threads vs --ion-offthread-compile=off
@@ -49,15 +49,15 @@ function whatToTestSpidermonkeyTrunk(code)
        && code.indexOf("promiseID") == -1                 // Promise IDs are for debugger-use only
        && code.indexOf("runOffThreadScript") == -1
        && code.indexOf("shortestPaths") == -1             // See bug 1308743
-       && code.indexOf("inIon") == -1                     // may turn true after some runs/return a str w/--no-ion
-       && code.indexOf("inJit") == -1                     // may turn true after some runs/return a str w/--no-baseline
+       && code.indexOf("inIon") == -1                     // may become true after several iterations, or return a string with --no-ion
+       && code.indexOf("inJit") == -1                     // may become true after several iterations, or return a string with --no-baseline
        && code.indexOf("random") == -1
        && code.indexOf("timeout") == -1                   // time runs and crawls
     ,
 
     expectConsistentOutputAcrossIter: true
     // within-process, e.g. ignore the following items for nestTest mismatch
-       && code.indexOf("options") == -1  // options() - per-cx. Shell doesn't create new cx for each sandbox/compartment
+       && code.indexOf("options") == -1             // options() is per-cx, and the js shell doesn't create a new cx for each sandbox/compartment
     ,
 
     expectConsistentOutputAcrossJITs: true
@@ -69,7 +69,7 @@ function whatToTestSpidermonkeyTrunk(code)
        && code.indexOf("getAllocationMetadata") == -1        // see bug 1296243
        && code.indexOf(".length") == -1                      // bug 1027846
        /* eslint-disable no-control-regex */
-       && !( codeL.match(/\/.*[\u0000\u0080-\uffff]/))  // doesn't seem to stay valid utf-8 aft. becoming Python
+       && !( codeL.match(/\/.*[\u0000\u0080-\uffff]/))       // doesn't stay valid utf-8 after going through python (?)
        /* eslint-enable no-control-regex */
     ,
 
@@ -118,7 +118,7 @@ function unlikelyToHang(code)
   return true
     && code.indexOf("infloop") == -1
     && !( codeL.match( /for.*in.*uneval/ )) // can be slow to loop through the huge string uneval(this), for example
-    && !( codeL.match( /for.*for.*for/ )) // nested for loops (incl. for..in, array comprehensions) can take a while
+    && !( codeL.match( /for.*for.*for/ )) // nested for loops (including for..in, array comprehensions, etc) can take a while
     && !( codeL.match( /for.*for.*gc/ ))
   ;
 }

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -16,58 +16,58 @@ function whatToTestSpidermonkeyTrunk (code) { // eslint-disable-line require-jsd
     allowParse: true,
 
     allowExec: unlikelyToHang(code)
-      && (jsshell || code.indexOf("nogeckoex") === -1)
+      && (jsshell || code.indexOf("nogeckoex") == -1)
     ,
 
     // Ideally we'd detect whether the shell was compiled with --enable-more-deterministic
     // Ignore both within-process & across-process, e.g. nestTest mismatch & compare_jit
     expectConsistentOutput: true
-       && (gcIsQuiet || code.indexOf("gc") === -1)
-       && code.indexOf("/*NODIFF*/") === -1                // Ignore diff testing on these labels
-       && code.indexOf(".script") === -1                   // Debugger; see bug 1237464
-       && code.indexOf(".parameterNames") === -1           // Debugger; see bug 1237464
-       && code.indexOf(".environment") === -1              // Debugger; see bug 1237464
-       && code.indexOf(".onNewGlobalObject") === -1        // Debugger; see bug 1238246
-       && code.indexOf(".takeCensus") === -1               // Debugger; see bug 1247863
-       && code.indexOf(".findScripts") === -1              // Debugger; see bug 1250863
-       && code.indexOf("Date") === -1                      // time marches on
-       && code.indexOf("backtrace") === -1                 // shows memory addresses
-       && code.indexOf("drainAllocationsLog") === -1       // drainAllocationsLog returns an object with a timestamp, see bug 1066313
-       && code.indexOf("dumpObject") === -1                // shows heap addresses
-       && code.indexOf("dumpHeap") === -1                  // shows heap addresses
-       && code.indexOf("dumpStringRepresentation") === -1  // shows memory addresses
-       && code.indexOf("evalInCooperativeThread") === -1   // causes diffs especially in --no-threads
-       && code.indexOf("evalInWorker") === -1              // causes diffs in --no-threads vs --ion-offthread-compile=off
-       && code.indexOf("getBacktrace") === -1              // getBacktrace returns memory addresses which differs depending on flags
-       && code.indexOf("getLcovInfo") === -1
-       && code.indexOf("load") === -1                      // load()ed regression test might output dates, etc
-       && code.indexOf("offThreadCompileScript") === -1    // causes diffs in --no-threads vs --ion-offthread-compile=off
-       && code.indexOf("oomAfterAllocations") === -1
-       && code.indexOf("oomAtAllocation") === -1
-       && code.indexOf("oomTest") === -1                   // causes diffs in --ion-eager vs --baseline-eager
-       && code.indexOf("printProfilerEvents") === -1       // causes diffs in --ion-eager vs --baseline-eager
-       && code.indexOf("promiseID") === -1                 // Promise IDs are for debugger-use only
-       && code.indexOf("runOffThreadScript") === -1
-       && code.indexOf("shortestPaths") === -1             // See bug 1308743
-       && code.indexOf("inIon") === -1                     // may become true after several iterations, or return a string with --no-ion
-       && code.indexOf("inJit") === -1                     // may become true after several iterations, or return a string with --no-baseline
-       && code.indexOf("random") === -1
-       && code.indexOf("timeout") === -1                   // time runs and crawls
+       && (gcIsQuiet || code.indexOf("gc") == -1)
+       && code.indexOf("/*NODIFF*/") == -1                // Ignore diff testing on these labels
+       && code.indexOf(".script") == -1                   // Debugger; see bug 1237464
+       && code.indexOf(".parameterNames") == -1           // Debugger; see bug 1237464
+       && code.indexOf(".environment") == -1              // Debugger; see bug 1237464
+       && code.indexOf(".onNewGlobalObject") == -1        // Debugger; see bug 1238246
+       && code.indexOf(".takeCensus") == -1               // Debugger; see bug 1247863
+       && code.indexOf(".findScripts") == -1              // Debugger; see bug 1250863
+       && code.indexOf("Date") == -1                      // time marches on
+       && code.indexOf("backtrace") == -1                 // shows memory addresses
+       && code.indexOf("drainAllocationsLog") == -1       // drainAllocationsLog returns an object with a timestamp, see bug 1066313
+       && code.indexOf("dumpObject") == -1                // shows heap addresses
+       && code.indexOf("dumpHeap") == -1                  // shows heap addresses
+       && code.indexOf("dumpStringRepresentation") == -1  // shows memory addresses
+       && code.indexOf("evalInCooperativeThread") == -1   // causes diffs especially in --no-threads
+       && code.indexOf("evalInWorker") == -1              // causes diffs in --no-threads vs --ion-offthread-compile=off
+       && code.indexOf("getBacktrace") == -1              // getBacktrace returns memory addresses which differs depending on flags
+       && code.indexOf("getLcovInfo") == -1
+       && code.indexOf("load") == -1                      // load()ed regression test might output dates, etc
+       && code.indexOf("offThreadCompileScript") == -1    // causes diffs in --no-threads vs --ion-offthread-compile=off
+       && code.indexOf("oomAfterAllocations") == -1
+       && code.indexOf("oomAtAllocation") == -1
+       && code.indexOf("oomTest") == -1                   // causes diffs in --ion-eager vs --baseline-eager
+       && code.indexOf("printProfilerEvents") == -1       // causes diffs in --ion-eager vs --baseline-eager
+       && code.indexOf("promiseID") == -1                 // Promise IDs are for debugger-use only
+       && code.indexOf("runOffThreadScript") == -1
+       && code.indexOf("shortestPaths") == -1             // See bug 1308743
+       && code.indexOf("inIon") == -1                     // may become true after several iterations, or return a string with --no-ion
+       && code.indexOf("inJit") == -1                     // may become true after several iterations, or return a string with --no-baseline
+       && code.indexOf("random") == -1
+       && code.indexOf("timeout") == -1                   // time runs and crawls
     ,
 
     expectConsistentOutputAcrossIter: true
     // within-process, e.g. ignore the following items for nestTest mismatch
-       && code.indexOf("options") === -1             // options() is per-cx, and the js shell doesn't create a new cx for each sandbox/compartment
+       && code.indexOf("options") == -1             // options() is per-cx, and the js shell doesn't create a new cx for each sandbox/compartment
     ,
 
     expectConsistentOutputAcrossJITs: true
     // across-process (e.g. running js shell with different run-time options) e.g. compare_jit
-       && code.indexOf("isAsmJSCompilationAvailable") === -1  // Causes false positives with --no-asmjs
-       && code.indexOf("'strict") === -1                      // see bug 743425
-       && code.indexOf("disassemble") === -1                  // see bug 1237403 (related to asm.js)
-       && code.indexOf("sourceIsLazy") === -1                 // see bug 1286407
-       && code.indexOf("getAllocationMetadata") === -1        // see bug 1296243
-       && code.indexOf(".length") === -1                      // bug 1027846
+       && code.indexOf("isAsmJSCompilationAvailable") == -1  // Causes false positives with --no-asmjs
+       && code.indexOf("'strict") == -1                      // see bug 743425
+       && code.indexOf("disassemble") == -1                  // see bug 1237403 (related to asm.js)
+       && code.indexOf("sourceIsLazy") == -1                 // see bug 1286407
+       && code.indexOf("getAllocationMetadata") == -1        // see bug 1296243
+       && code.indexOf(".length") == -1                      // bug 1027846
        /* eslint-disable no-control-regex */
        && !(codeL.match(/\/.*[\u0000\u0080-\uffff]/))       // doesn't stay valid utf-8 after going through python (?)
        /* eslint-enable no-control-regex */
@@ -99,14 +99,14 @@ function whatToTestGeneric (code) { // eslint-disable-line require-jsdoc
 }
 
 var whatToTest;
-if (engine === ENGINE_SPIDERMONKEY_TRUNK) { whatToTest = whatToTestSpidermonkeyTrunk; } else if (engine === ENGINE_JAVASCRIPTCORE) { whatToTest = whatToTestJavaScriptCore; } else { whatToTest = whatToTestGeneric; }
+if (engine == ENGINE_SPIDERMONKEY_TRUNK) { whatToTest = whatToTestSpidermonkeyTrunk; } else if (engine == ENGINE_JAVASCRIPTCORE) { whatToTest = whatToTestJavaScriptCore; } else { whatToTest = whatToTestGeneric; }
 
 function unlikelyToHang (code) { // eslint-disable-line require-jsdoc
   var codeL = code.replace(/\s/g, " ");
 
   // Things that are likely to hang in all JavaScript engines
   return true
-    && code.indexOf("infloop") === -1
+    && code.indexOf("infloop") == -1
     && !(codeL.match(/for.*in.*uneval/)) // can be slow to loop through the huge string uneval(this), for example
     && !(codeL.match(/for.*for.*for/)) // nested for loops (including for..in, array comprehensions, etc) can take a while
     && !(codeL.match(/for.*for.*gc/))

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -5,7 +5,6 @@
 
 function whatToTestSpidermonkeyTrunk(code)
 {
-  /* jshint laxcomma: true */
   // regexps can't match across lines, so replace whitespace with spaces.
   var codeL = code.replace(/\s/g, " ");
 

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported whatToTest */
 /* global engine, ENGINE_JAVASCRIPTCORE, ENGINE_SPIDERMONKEY_TRUNK, gcIsQuiet, jsshell */
 
 /* eslint-disable complexity, no-multi-spaces */

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* eslint-disable complexity */
 function whatToTestSpidermonkeyTrunk(code)
 {
   // regexps can't match across lines, so replace whitespace with spaces.
@@ -69,6 +70,7 @@ function whatToTestSpidermonkeyTrunk(code)
 
   };
 }
+/* eslint-enable complexity */
 
 function whatToTestJavaScriptCore(code)
 {

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -32,13 +32,13 @@ function whatToTestSpidermonkeyTrunk(code)
        && code.indexOf(".findScripts") == -1              // Debugger; see bug 1250863
        && code.indexOf("Date") == -1                      // time marches on
        && code.indexOf("backtrace") == -1                 // shows memory addresses
-       && code.indexOf("drainAllocationsLog") == -1       // drainAllocationsLog returns an object with a timestamp, see bug 1066313
+       && code.indexOf("drainAllocationsLog") == -1       // this returns an object with a timestamp, see bug 1066313
        && code.indexOf("dumpObject") == -1                // shows heap addresses
        && code.indexOf("dumpHeap") == -1                  // shows heap addresses
        && code.indexOf("dumpStringRepresentation") == -1  // shows memory addresses
        && code.indexOf("evalInCooperativeThread") == -1   // causes diffs especially in --no-threads
-       && code.indexOf("evalInWorker") == -1              // causes diffs in --no-threads vs --ion-offthread-compile=off
-       && code.indexOf("getBacktrace") == -1              // getBacktrace returns memory addresses which differs depending on flags
+       && code.indexOf("evalInWorker") == -1              // causes diffs in --no-threads/--ion-offthread-compile=off
+       && code.indexOf("getBacktrace") == -1              // this returns memory addresses that differ based on flags
        && code.indexOf("getLcovInfo") == -1
        && code.indexOf("load") == -1                      // load()ed regression test might output dates, etc
        && code.indexOf("offThreadCompileScript") == -1    // causes diffs in --no-threads vs --ion-offthread-compile=off
@@ -49,15 +49,15 @@ function whatToTestSpidermonkeyTrunk(code)
        && code.indexOf("promiseID") == -1                 // Promise IDs are for debugger-use only
        && code.indexOf("runOffThreadScript") == -1
        && code.indexOf("shortestPaths") == -1             // See bug 1308743
-       && code.indexOf("inIon") == -1                     // may become true after several iterations, or return a string with --no-ion
-       && code.indexOf("inJit") == -1                     // may become true after several iterations, or return a string with --no-baseline
+       && code.indexOf("inIon") == -1                     // may turn true after some runs/return a str w/--no-ion
+       && code.indexOf("inJit") == -1                     // may turn true after some runs/return a str w/--no-baseline
        && code.indexOf("random") == -1
        && code.indexOf("timeout") == -1                   // time runs and crawls
     ,
 
     expectConsistentOutputAcrossIter: true
     // within-process, e.g. ignore the following items for nestTest mismatch
-       && code.indexOf("options") == -1             // options() is per-cx, and the js shell doesn't create a new cx for each sandbox/compartment
+       && code.indexOf("options") == -1  // options() - per-cx. Shell doesn't create new cx for each sandbox/compartment
     ,
 
     expectConsistentOutputAcrossJITs: true
@@ -69,7 +69,7 @@ function whatToTestSpidermonkeyTrunk(code)
        && code.indexOf("getAllocationMetadata") == -1        // see bug 1296243
        && code.indexOf(".length") == -1                      // bug 1027846
        /* eslint-disable no-control-regex */
-       && !( codeL.match(/\/.*[\u0000\u0080-\uffff]/))       // doesn't stay valid utf-8 after going through python (?)
+       && !( codeL.match(/\/.*[\u0000\u0080-\uffff]/))  // doesn't seem to stay valid utf-8 aft. becoming Python
        /* eslint-enable no-control-regex */
     ,
 
@@ -118,7 +118,7 @@ function unlikelyToHang(code)
   return true
     && code.indexOf("infloop") == -1
     && !( codeL.match( /for.*in.*uneval/ )) // can be slow to loop through the huge string uneval(this), for example
-    && !( codeL.match( /for.*for.*for/ )) // nested for loops (including for..in, array comprehensions, etc) can take a while
+    && !( codeL.match( /for.*for.*for/ )) // nested for loops (incl. for..in, array comprehensions) can take a while
     && !( codeL.match( /for.*for.*gc/ ))
   ;
 }

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -120,5 +120,5 @@ function unlikelyToHang(code)
     && !( codeL.match( /for.*in.*uneval/ )) // can be slow to loop through the huge string uneval(this), for example
     && !( codeL.match( /for.*for.*for/ )) // nested for loops (including for..in, array comprehensions, etc) can take a while
     && !( codeL.match( /for.*for.*gc/ ))
-    ;
+  ;
 }

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -16,58 +16,58 @@ function whatToTestSpidermonkeyTrunk (code) { // eslint-disable-line require-jsd
     allowParse: true,
 
     allowExec: unlikelyToHang(code)
-      && (jsshell || code.indexOf("nogeckoex") == -1)
+      && (jsshell || code.indexOf("nogeckoex") === -1)
     ,
 
     // Ideally we'd detect whether the shell was compiled with --enable-more-deterministic
     // Ignore both within-process & across-process, e.g. nestTest mismatch & compare_jit
     expectConsistentOutput: true
-       && (gcIsQuiet || code.indexOf("gc") == -1)
-       && code.indexOf("/*NODIFF*/") == -1                // Ignore diff testing on these labels
-       && code.indexOf(".script") == -1                   // Debugger; see bug 1237464
-       && code.indexOf(".parameterNames") == -1           // Debugger; see bug 1237464
-       && code.indexOf(".environment") == -1              // Debugger; see bug 1237464
-       && code.indexOf(".onNewGlobalObject") == -1        // Debugger; see bug 1238246
-       && code.indexOf(".takeCensus") == -1               // Debugger; see bug 1247863
-       && code.indexOf(".findScripts") == -1              // Debugger; see bug 1250863
-       && code.indexOf("Date") == -1                      // time marches on
-       && code.indexOf("backtrace") == -1                 // shows memory addresses
-       && code.indexOf("drainAllocationsLog") == -1       // drainAllocationsLog returns an object with a timestamp, see bug 1066313
-       && code.indexOf("dumpObject") == -1                // shows heap addresses
-       && code.indexOf("dumpHeap") == -1                  // shows heap addresses
-       && code.indexOf("dumpStringRepresentation") == -1  // shows memory addresses
-       && code.indexOf("evalInCooperativeThread") == -1   // causes diffs especially in --no-threads
-       && code.indexOf("evalInWorker") == -1              // causes diffs in --no-threads vs --ion-offthread-compile=off
-       && code.indexOf("getBacktrace") == -1              // getBacktrace returns memory addresses which differs depending on flags
-       && code.indexOf("getLcovInfo") == -1
-       && code.indexOf("load") == -1                      // load()ed regression test might output dates, etc
-       && code.indexOf("offThreadCompileScript") == -1    // causes diffs in --no-threads vs --ion-offthread-compile=off
-       && code.indexOf("oomAfterAllocations") == -1
-       && code.indexOf("oomAtAllocation") == -1
-       && code.indexOf("oomTest") == -1                   // causes diffs in --ion-eager vs --baseline-eager
-       && code.indexOf("printProfilerEvents") == -1       // causes diffs in --ion-eager vs --baseline-eager
-       && code.indexOf("promiseID") == -1                 // Promise IDs are for debugger-use only
-       && code.indexOf("runOffThreadScript") == -1
-       && code.indexOf("shortestPaths") == -1             // See bug 1308743
-       && code.indexOf("inIon") == -1                     // may become true after several iterations, or return a string with --no-ion
-       && code.indexOf("inJit") == -1                     // may become true after several iterations, or return a string with --no-baseline
-       && code.indexOf("random") == -1
-       && code.indexOf("timeout") == -1                   // time runs and crawls
+       && (gcIsQuiet || code.indexOf("gc") === -1)
+       && code.indexOf("/*NODIFF*/") === -1                // Ignore diff testing on these labels
+       && code.indexOf(".script") === -1                   // Debugger; see bug 1237464
+       && code.indexOf(".parameterNames") === -1           // Debugger; see bug 1237464
+       && code.indexOf(".environment") === -1              // Debugger; see bug 1237464
+       && code.indexOf(".onNewGlobalObject") === -1        // Debugger; see bug 1238246
+       && code.indexOf(".takeCensus") === -1               // Debugger; see bug 1247863
+       && code.indexOf(".findScripts") === -1              // Debugger; see bug 1250863
+       && code.indexOf("Date") === -1                      // time marches on
+       && code.indexOf("backtrace") === -1                 // shows memory addresses
+       && code.indexOf("drainAllocationsLog") === -1       // drainAllocationsLog returns an object with a timestamp, see bug 1066313
+       && code.indexOf("dumpObject") === -1                // shows heap addresses
+       && code.indexOf("dumpHeap") === -1                  // shows heap addresses
+       && code.indexOf("dumpStringRepresentation") === -1  // shows memory addresses
+       && code.indexOf("evalInCooperativeThread") === -1   // causes diffs especially in --no-threads
+       && code.indexOf("evalInWorker") === -1              // causes diffs in --no-threads vs --ion-offthread-compile=off
+       && code.indexOf("getBacktrace") === -1              // getBacktrace returns memory addresses which differs depending on flags
+       && code.indexOf("getLcovInfo") === -1
+       && code.indexOf("load") === -1                      // load()ed regression test might output dates, etc
+       && code.indexOf("offThreadCompileScript") === -1    // causes diffs in --no-threads vs --ion-offthread-compile=off
+       && code.indexOf("oomAfterAllocations") === -1
+       && code.indexOf("oomAtAllocation") === -1
+       && code.indexOf("oomTest") === -1                   // causes diffs in --ion-eager vs --baseline-eager
+       && code.indexOf("printProfilerEvents") === -1       // causes diffs in --ion-eager vs --baseline-eager
+       && code.indexOf("promiseID") === -1                 // Promise IDs are for debugger-use only
+       && code.indexOf("runOffThreadScript") === -1
+       && code.indexOf("shortestPaths") === -1             // See bug 1308743
+       && code.indexOf("inIon") === -1                     // may become true after several iterations, or return a string with --no-ion
+       && code.indexOf("inJit") === -1                     // may become true after several iterations, or return a string with --no-baseline
+       && code.indexOf("random") === -1
+       && code.indexOf("timeout") === -1                   // time runs and crawls
     ,
 
     expectConsistentOutputAcrossIter: true
     // within-process, e.g. ignore the following items for nestTest mismatch
-       && code.indexOf("options") == -1             // options() is per-cx, and the js shell doesn't create a new cx for each sandbox/compartment
+       && code.indexOf("options") === -1             // options() is per-cx, and the js shell doesn't create a new cx for each sandbox/compartment
     ,
 
     expectConsistentOutputAcrossJITs: true
     // across-process (e.g. running js shell with different run-time options) e.g. compare_jit
-       && code.indexOf("isAsmJSCompilationAvailable") == -1  // Causes false positives with --no-asmjs
-       && code.indexOf("'strict") == -1                      // see bug 743425
-       && code.indexOf("disassemble") == -1                  // see bug 1237403 (related to asm.js)
-       && code.indexOf("sourceIsLazy") == -1                 // see bug 1286407
-       && code.indexOf("getAllocationMetadata") == -1        // see bug 1296243
-       && code.indexOf(".length") == -1                      // bug 1027846
+       && code.indexOf("isAsmJSCompilationAvailable") === -1  // Causes false positives with --no-asmjs
+       && code.indexOf("'strict") === -1                      // see bug 743425
+       && code.indexOf("disassemble") === -1                  // see bug 1237403 (related to asm.js)
+       && code.indexOf("sourceIsLazy") === -1                 // see bug 1286407
+       && code.indexOf("getAllocationMetadata") === -1        // see bug 1296243
+       && code.indexOf(".length") === -1                      // bug 1027846
        /* eslint-disable no-control-regex */
        && !(codeL.match(/\/.*[\u0000\u0080-\uffff]/))       // doesn't stay valid utf-8 after going through python (?)
        /* eslint-enable no-control-regex */
@@ -99,14 +99,14 @@ function whatToTestGeneric (code) { // eslint-disable-line require-jsdoc
 }
 
 var whatToTest;
-if (engine == ENGINE_SPIDERMONKEY_TRUNK) { whatToTest = whatToTestSpidermonkeyTrunk; } else if (engine == ENGINE_JAVASCRIPTCORE) { whatToTest = whatToTestJavaScriptCore; } else { whatToTest = whatToTestGeneric; }
+if (engine === ENGINE_SPIDERMONKEY_TRUNK) { whatToTest = whatToTestSpidermonkeyTrunk; } else if (engine === ENGINE_JAVASCRIPTCORE) { whatToTest = whatToTestJavaScriptCore; } else { whatToTest = whatToTestGeneric; }
 
 function unlikelyToHang (code) { // eslint-disable-line require-jsdoc
   var codeL = code.replace(/\s/g, " ");
 
   // Things that are likely to hang in all JavaScript engines
   return true
-    && code.indexOf("infloop") == -1
+    && code.indexOf("infloop") === -1
     && !(codeL.match(/for.*in.*uneval/)) // can be slow to loop through the huge string uneval(this), for example
     && !(codeL.match(/for.*for.*for/)) // nested for loops (including for..in, array comprehensions, etc) can take a while
     && !(codeL.match(/for.*for.*gc/))

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -5,7 +5,7 @@
 
 /* global engine, ENGINE_JAVASCRIPTCORE, ENGINE_SPIDERMONKEY_TRUNK, gcIsQuiet, jsshell */
 
-/* eslint-disable complexity */
+/* eslint-disable complexity, no-multi-spaces */
 function whatToTestSpidermonkeyTrunk(code)
 {
   // regexps can't match across lines, so replace whitespace with spaces.
@@ -75,7 +75,7 @@ function whatToTestSpidermonkeyTrunk(code)
 
   };
 }
-/* eslint-enable complexity */
+/* eslint-enable complexity, no-multi-spaces */
 
 function whatToTestJavaScriptCore(code)
 {

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -7,8 +7,7 @@
 /* global engine, ENGINE_JAVASCRIPTCORE, ENGINE_SPIDERMONKEY_TRUNK, gcIsQuiet, jsshell */
 
 /* eslint-disable complexity, no-multi-spaces */
-function whatToTestSpidermonkeyTrunk(code)
-{
+function whatToTestSpidermonkeyTrunk (code) {
   // regexps can't match across lines, so replace whitespace with spaces.
   var codeL = code.replace(/\s/g, " ");
 
@@ -70,56 +69,46 @@ function whatToTestSpidermonkeyTrunk(code)
        && code.indexOf("getAllocationMetadata") == -1        // see bug 1296243
        && code.indexOf(".length") == -1                      // bug 1027846
        /* eslint-disable no-control-regex */
-       && !( codeL.match(/\/.*[\u0000\u0080-\uffff]/))       // doesn't stay valid utf-8 after going through python (?)
+       && !(codeL.match(/\/.*[\u0000\u0080-\uffff]/))       // doesn't stay valid utf-8 after going through python (?)
        /* eslint-enable no-control-regex */
-    ,
 
   };
 }
 /* eslint-enable complexity, no-multi-spaces */
 
-function whatToTestJavaScriptCore(code)
-{
+function whatToTestJavaScriptCore (code) {
   return {
 
     allowParse: true,
     allowExec: unlikelyToHang(code),
     expectConsistentOutput: false,
     expectConsistentOutputAcrossIter: false,
-    expectConsistentOutputAcrossJITs: false,
+    expectConsistentOutputAcrossJITs: false
 
   };
 }
 
-function whatToTestGeneric(code)
-{
+function whatToTestGeneric (code) {
   return {
     allowParse: true,
     allowExec: unlikelyToHang(code),
     expectConsistentOutput: false,
     expectConsistentOutputAcrossIter: false,
-    expectConsistentOutputAcrossJITs: false,
+    expectConsistentOutputAcrossJITs: false
   };
 }
 
 var whatToTest;
-if (engine == ENGINE_SPIDERMONKEY_TRUNK)
-  whatToTest = whatToTestSpidermonkeyTrunk;
-else if (engine == ENGINE_JAVASCRIPTCORE)
-  whatToTest = whatToTestJavaScriptCore;
-else
-  whatToTest = whatToTestGeneric;
+if (engine == ENGINE_SPIDERMONKEY_TRUNK) { whatToTest = whatToTestSpidermonkeyTrunk; } else if (engine == ENGINE_JAVASCRIPTCORE) { whatToTest = whatToTestJavaScriptCore; } else { whatToTest = whatToTestGeneric; }
 
-
-function unlikelyToHang(code)
-{
+function unlikelyToHang (code) {
   var codeL = code.replace(/\s/g, " ");
 
   // Things that are likely to hang in all JavaScript engines
   return true
     && code.indexOf("infloop") == -1
-    && !( codeL.match( /for.*in.*uneval/ )) // can be slow to loop through the huge string uneval(this), for example
-    && !( codeL.match( /for.*for.*for/ )) // nested for loops (including for..in, array comprehensions, etc) can take a while
-    && !( codeL.match( /for.*for.*gc/ ))
+    && !(codeL.match(/for.*in.*uneval/)) // can be slow to loop through the huge string uneval(this), for example
+    && !(codeL.match(/for.*for.*for/)) // nested for loops (including for..in, array comprehensions, etc) can take a while
+    && !(codeL.match(/for.*for.*gc/))
   ;
 }

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -71,6 +71,7 @@ function whatToTestSpidermonkeyTrunk(code)
        /* eslint-disable no-control-regex */
        && !( codeL.match(/\/.*[\u0000\u0080-\uffff]/))       // doesn't stay valid utf-8 after going through python (?)
        /* eslint-enable no-control-regex */
+    ,
 
   };
 }
@@ -84,7 +85,7 @@ function whatToTestJavaScriptCore(code)
     allowExec: unlikelyToHang(code),
     expectConsistentOutput: false,
     expectConsistentOutputAcrossIter: false,
-    expectConsistentOutputAcrossJITs: false
+    expectConsistentOutputAcrossJITs: false,
 
   };
 }
@@ -96,7 +97,7 @@ function whatToTestGeneric(code)
     allowExec: unlikelyToHang(code),
     expectConsistentOutput: false,
     expectConsistentOutputAcrossIter: false,
-    expectConsistentOutputAcrossJITs: false
+    expectConsistentOutputAcrossJITs: false,
   };
 }
 

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -7,7 +7,7 @@
 /* global engine, ENGINE_JAVASCRIPTCORE, ENGINE_SPIDERMONKEY_TRUNK, gcIsQuiet, jsshell */
 
 /* eslint-disable complexity, no-multi-spaces */
-function whatToTestSpidermonkeyTrunk (code) {
+function whatToTestSpidermonkeyTrunk (code) { // eslint-disable-line require-jsdoc
   // regexps can't match across lines, so replace whitespace with spaces.
   var codeL = code.replace(/\s/g, " ");
 
@@ -76,7 +76,7 @@ function whatToTestSpidermonkeyTrunk (code) {
 }
 /* eslint-enable complexity, no-multi-spaces */
 
-function whatToTestJavaScriptCore (code) {
+function whatToTestJavaScriptCore (code) { // eslint-disable-line require-jsdoc
   return {
 
     allowParse: true,
@@ -88,7 +88,7 @@ function whatToTestJavaScriptCore (code) {
   };
 }
 
-function whatToTestGeneric (code) {
+function whatToTestGeneric (code) { // eslint-disable-line require-jsdoc
   return {
     allowParse: true,
     allowExec: unlikelyToHang(code),
@@ -101,7 +101,7 @@ function whatToTestGeneric (code) {
 var whatToTest;
 if (engine == ENGINE_SPIDERMONKEY_TRUNK) { whatToTest = whatToTestSpidermonkeyTrunk; } else if (engine == ENGINE_JAVASCRIPTCORE) { whatToTest = whatToTestJavaScriptCore; } else { whatToTest = whatToTestGeneric; }
 
-function unlikelyToHang (code) {
+function unlikelyToHang (code) { // eslint-disable-line require-jsdoc
   var codeL = code.replace(/\s/g, " ");
 
   // Things that are likely to hang in all JavaScript engines

--- a/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
+++ b/src/funfuzz/js/jsfunfuzz/avoid-known-bugs.js
@@ -66,7 +66,9 @@ function whatToTestSpidermonkeyTrunk(code)
        && code.indexOf("sourceIsLazy") == -1                 // see bug 1286407
        && code.indexOf("getAllocationMetadata") == -1        // see bug 1296243
        && code.indexOf(".length") == -1                      // bug 1027846
+       /* eslint-disable no-control-regex */
        && !( codeL.match(/\/.*[\u0000\u0080-\uffff]/))       // doesn't stay valid utf-8 after going through python (?)
+       /* eslint-enable no-control-regex */
 
   };
 }

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -45,7 +45,7 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
       var h;
       try {
         h = a[hn];
-      } catch(e) {
+      } catch (e) {
         if (debugMode) {
           dumpln("Threw: " + fullName);
         }

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -49,7 +49,7 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
         h = null;
       }
 
-      if (typeof h === "function" && hn !== "constructor") {
+      if (typeof h === "function" && hn != "constructor") {
         allMethodNames.push(hn);
         builtinFunctions.push(fullName);
       }
@@ -64,9 +64,9 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
       var gn = gns[i];
       // Assume that most uppercase names are constructors.
       // Skip Worker in shell (removed in bug 771281).
-      if (gn.charCodeAt(0) > 0x40 && gn.charCodeAt(0) < 0x60 && gn !== "PerfMeasurement" && !(jsshell && gn === "Worker")) {
+      if (gn.charCodeAt(0) > 0x40 && gn.charCodeAt(0) < 0x60 && gn != "PerfMeasurement" && !(jsshell && gn == "Worker")) {
         var g = glob[gn];
-        if (typeof g === "function" && g.toString().indexOf("[native code]") !== -1) {
+        if (typeof g === "function" && g.toString().indexOf("[native code]") != -1) {
           constructors.push(gn);
           builtinProperties.push(gn);
           builtinFunctions.push(gn);

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -12,9 +12,11 @@
         <Jesse> why is Array.prototype.length not a getter? http://pastebin.mozilla.org/1990723
         <jorendorff> backward compatibility
         <jorendorff> ES3 already allowed programs to create objects with arbitrary __proto__
-        <jorendorff> .length was specified to work as a data property; accessor properties inherit differently, especially when setting
+        <jorendorff> .length was specified to work as a data property;
+            accessor properties inherit differently, especially when setting
         <jorendorff> maybe only when setting, come to think of it
-        <jorendorff> I guess it could've been made an accessor property without breaking anything important. I didn't realize it at the time.
+        <jorendorff> I guess it could've been made an accessor property without breaking anything important.
+            I didn't realize it at the time.
 */
 
 var constructors = []; // "Array"
@@ -68,7 +70,8 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
       var gn = gns[i];
       // Assume that most uppercase names are constructors.
       // Skip Worker in shell (removed in bug 771281).
-      if (0x40 < gn.charCodeAt(0) && gn.charCodeAt(0) < 0x60 && gn != "PerfMeasurement" && !(jsshell && gn == "Worker")) {
+      if (0x40 < gn.charCodeAt(0) && gn.charCodeAt(0) < 0x60 &&
+          gn != "PerfMeasurement" && !(jsshell && gn == "Worker")) {
         var g = glob[gn];
         if (typeof g == "function" && g.toString().indexOf("[native code]") != -1) {
           constructors.push(gn);

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -49,7 +49,7 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
         h = null;
       }
 
-      if (typeof h === "function" && hn != "constructor") {
+      if (typeof h === "function" && hn !== "constructor") {
         allMethodNames.push(hn);
         builtinFunctions.push(fullName);
       }
@@ -64,9 +64,9 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
       var gn = gns[i];
       // Assume that most uppercase names are constructors.
       // Skip Worker in shell (removed in bug 771281).
-      if (gn.charCodeAt(0) > 0x40 && gn.charCodeAt(0) < 0x60 && gn != "PerfMeasurement" && !(jsshell && gn == "Worker")) {
+      if (gn.charCodeAt(0) > 0x40 && gn.charCodeAt(0) < 0x60 && gn !== "PerfMeasurement" && !(jsshell && gn === "Worker")) {
         var g = glob[gn];
-        if (typeof g === "function" && g.toString().indexOf("[native code]") != -1) {
+        if (typeof g === "function" && g.toString().indexOf("[native code]") !== -1) {
           constructors.push(gn);
           builtinProperties.push(gn);
           builtinFunctions.push(gn);

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -12,11 +12,9 @@
         <Jesse> why is Array.prototype.length not a getter? http://pastebin.mozilla.org/1990723
         <jorendorff> backward compatibility
         <jorendorff> ES3 already allowed programs to create objects with arbitrary __proto__
-        <jorendorff> .length was specified to work as a data property;
-            accessor properties inherit differently, especially when setting
+        <jorendorff> .length was specified to work as a data property; accessor properties inherit differently, especially when setting
         <jorendorff> maybe only when setting, come to think of it
-        <jorendorff> I guess it could've been made an accessor property without breaking anything important.
-            I didn't realize it at the time.
+        <jorendorff> I guess it could've been made an accessor property without breaking anything important. I didn't realize it at the time.
 */
 
 var constructors = []; // "Array"
@@ -70,8 +68,7 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
       var gn = gns[i];
       // Assume that most uppercase names are constructors.
       // Skip Worker in shell (removed in bug 771281).
-      if (0x40 < gn.charCodeAt(0) && gn.charCodeAt(0) < 0x60 &&
-          gn != "PerfMeasurement" && !(jsshell && gn == "Worker")) {
+      if (0x40 < gn.charCodeAt(0) && gn.charCodeAt(0) < 0x60 && gn != "PerfMeasurement" && !(jsshell && gn == "Worker")) {
         var g = glob[gn];
         if (typeof g == "function" && g.toString().indexOf("[native code]") != -1) {
           constructors.push(gn);

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global dumpln, jsshell, print, Proxy, quit, uneval */
+
 /*
         It might be more interesting to use Object.getOwnPropertyDescriptor to find out if
         a thing is exposed as a getter (like Debugger.prototype.enabled).  But there are exceptions:

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -27,7 +27,7 @@ var builtinObjectNames = []; // "Array", "Array.prototype", ... (indexes into th
 var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
 
 (function exploreBuiltins (glob, debugMode) {
-  function exploreDeeper (a, an) {
+  function exploreDeeper (a, an) { // eslint-disable-line require-jsdoc
     if (!a) { return; }
     var hns = Object.getOwnPropertyNames(a);
     var propertyNames = [];
@@ -58,7 +58,7 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
     builtinObjectNames.push(an);
   }
 
-  function exploreConstructors () {
+  function exploreConstructors () { // eslint-disable-line require-jsdoc
     var gns = Object.getOwnPropertyNames(glob);
     for (var i = 0; i < gns.length; ++i) {
       var gn = gns[i];

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -48,9 +48,9 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
       try {
         h = a[hn];
       } catch (e) {
-        if (debugMode) {
+        if (debugMode) 
           dumpln("Threw: " + fullName);
-        }
+        
         h = null;
       }
 

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -26,12 +26,9 @@ var allPropertyNames = []; // "length"
 var builtinObjectNames = []; // "Array", "Array.prototype", ... (indexes into the builtinObjects)
 var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
 
-(function exploreBuiltins(glob, debugMode) {
-
-  function exploreDeeper(a, an)
-  {
-    if (!a)
-      return;
+(function exploreBuiltins (glob, debugMode) {
+  function exploreDeeper (a, an) {
+    if (!a) { return; }
     var hns = Object.getOwnPropertyNames(a);
     var propertyNames = [];
     for (var j = 0; j < hns.length; ++j) {
@@ -52,7 +49,7 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
         h = null;
       }
 
-      if (typeof h == "function" && hn != "constructor") {
+      if (typeof h === "function" && hn != "constructor") {
         allMethodNames.push(hn);
         builtinFunctions.push(fullName);
       }
@@ -61,16 +58,15 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
     builtinObjectNames.push(an);
   }
 
-  function exploreConstructors()
-  {
+  function exploreConstructors () {
     var gns = Object.getOwnPropertyNames(glob);
     for (var i = 0; i < gns.length; ++i) {
       var gn = gns[i];
       // Assume that most uppercase names are constructors.
       // Skip Worker in shell (removed in bug 771281).
-      if (0x40 < gn.charCodeAt(0) && gn.charCodeAt(0) < 0x60 && gn != "PerfMeasurement" && !(jsshell && gn == "Worker")) {
+      if (gn.charCodeAt(0) > 0x40 && gn.charCodeAt(0) < 0x60 && gn != "PerfMeasurement" && !(jsshell && gn == "Worker")) {
         var g = glob[gn];
-        if (typeof g == "function" && g.toString().indexOf("[native code]") != -1) {
+        if (typeof g === "function" && g.toString().indexOf("[native code]") != -1) {
           constructors.push(gn);
           builtinProperties.push(gn);
           builtinFunctions.push(gn);
@@ -96,5 +92,4 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
     print(uneval(builtinObjects));
     quit();
   }
-
 })(this, false);

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -48,9 +48,9 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
       try {
         h = a[hn];
       } catch (e) {
-        if (debugMode) 
+        if (debugMode) {
           dumpln("Threw: " + fullName);
-        
+        }
         h = null;
       }
 

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -15,28 +15,28 @@ var ENGINE_SPIDERMONKEY_TRUNK = 1;
 var ENGINE_JAVASCRIPTCORE = 4;
 
 var engine = ENGINE_UNKNOWN;
-var jsshell = (typeof window == "undefined"); // eslint-disable-line no-undef
-var xpcshell = jsshell && (typeof Components == "object"); // eslint-disable-line no-undef
+var jsshell = (typeof window === "undefined"); // eslint-disable-line no-undef
+var xpcshell = jsshell && (typeof Components === "object"); // eslint-disable-line no-undef
 var dump;
 var dumpln;
 var printImportant;
 if (jsshell) {
   dumpln = print;
-  printImportant = function(s) { dumpln("***"); dumpln(s); };
-  if (typeof verifyprebarriers == "function") {
+  printImportant = function (s) { dumpln("***"); dumpln(s); };
+  if (typeof verifyprebarriers === "function") {
     // Run a diff between the help() outputs of different js shells.
     // Make sure the function to look out for is not located only in some
     // particular #ifdef, e.g. JS_GC_ZEAL, or controlled by --fuzzing-safe.
-    if (typeof wasmIsSupported == "function") {
+    if (typeof wasmIsSupported === "function") {
       engine = ENGINE_SPIDERMONKEY_TRUNK;
     }
 
     // Avoid accidentally waiting for user input that will never come.
-    readline = function() {};
-  } else if (typeof XPCNativeWrapper == "function") { // eslint-disable-line no-undef
+    readline = function () {};
+  } else if (typeof XPCNativeWrapper === "function") { // eslint-disable-line no-undef
     // e.g. xpcshell or firefox
     engine = ENGINE_SPIDERMONKEY_TRUNK;
-  } else if (typeof debug == "function") {
+  } else if (typeof debug === "function") {
     engine = ENGINE_JAVASCRIPTCORE;
   }
 } else {
@@ -44,16 +44,16 @@ if (jsshell) {
     // XXX detect Google Chrome for V8
     engine = ENGINE_JAVASCRIPTCORE;
     // This worked in Safari 3.0, but it might not work in Safari 3.1.
-    dump = function(s) { console.log(s); };
+    dump = function (s) { console.log(s); };
   } else if (navigator.userAgent.indexOf("Gecko") != -1) { // eslint-disable-line no-undef
     engine = ENGINE_SPIDERMONKEY_TRUNK;
-  } else if (typeof dump != "function") {
+  } else if (typeof dump !== "function") {
     // In other browsers, jsfunfuzz does not know how to log anything.
-    dump = function() { };
+    dump = function () { };
   }
-  dumpln = function(s) { dump(s + "\n"); };
+  dumpln = function (s) { dump(s + "\n"); };
 
-  printImportant = function(s) {
+  printImportant = function (s) {
     dumpln(s);
     var p = document.createElement("pre"); // eslint-disable-line no-undef
     p.appendChild(document.createTextNode(s)); // eslint-disable-line no-undef
@@ -61,29 +61,25 @@ if (jsshell) {
   };
 }
 
-if (typeof gc == "undefined")
-  this.gc = function() {};
+if (typeof gc === "undefined") { this.gc = function () {}; }
 var gcIsQuiet = !(gc()); // see bug 706433
 
 // If the JavaScript engine being tested has heuristics like
 //   "recompile any loop that is run more than X times"
 // this should be set to the highest such X.
 var HOTLOOP = 60;
-function loopCount() { return rnd(rnd(HOTLOOP * 3)); }
-function loopModulo() { return (rnd(2) ? rnd(rnd(HOTLOOP * 2)) : rnd(5)) + 2; }
+function loopCount () { return rnd(rnd(HOTLOOP * 3)); }
+function loopModulo () { return (rnd(2) ? rnd(rnd(HOTLOOP * 2)) : rnd(5)) + 2; }
 
-function simpleSource(st)
-{
-  function hexify(c)
-  {
+function simpleSource (st) {
+  function hexify (c) {
     var code = c.charCodeAt(0);
     var hex = code.toString(16);
-    while (hex.length < 4)
-      hex = "0" + hex;
+    while (hex.length < 4) { hex = "0" + hex; }
     return "\\u" + hex;
   }
 
-  if (typeof st == "string")
+  if (typeof st === "string") {
     return ("\"" +
       st.replace(/\\/g, "\\\\")
         .replace(/\"/g, "\\\"")
@@ -91,17 +87,10 @@ function simpleSource(st)
         .replace(/\n/g, "\\n")
         .replace(/[^ -~]/g, hexify) + // not space (32) through tilde (126)
       "\"");
-  else
-    return "" + st; // hope this is right ;)  should work for numbers.
+  } else { return "" + st; } // hope this is right ;)  should work for numbers.
 }
 
-var haveRealUneval = (typeof uneval == "function");
-if (!haveRealUneval)
-  uneval = simpleSource;
+var haveRealUneval = (typeof uneval === "function");
+if (!haveRealUneval) { uneval = simpleSource; }
 
-if (engine == ENGINE_UNKNOWN)
-  printImportant("Targeting an unknown JavaScript engine!");
-else if (engine == ENGINE_SPIDERMONKEY_TRUNK)
-  printImportant("Targeting SpiderMonkey / Gecko (trunk).");
-else if (engine == ENGINE_JAVASCRIPTCORE)
-  printImportant("Targeting JavaScriptCore / WebKit.");
+if (engine == ENGINE_UNKNOWN) { printImportant("Targeting an unknown JavaScript engine!"); } else if (engine == ENGINE_SPIDERMONKEY_TRUNK) { printImportant("Targeting SpiderMonkey / Gecko (trunk)."); } else if (engine == ENGINE_JAVASCRIPTCORE) { printImportant("Targeting JavaScriptCore / WebKit."); }

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -3,6 +3,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global console, debug, gc, print, readline:writable, rnd, uneval:writable, verifyprebarriers, wasmIsSupported */
+/* XPCNativeWrapper */
+
 // jsfunfuzz is best run in a command-line shell.  It can also run in
 // a web browser, but you might have trouble reproducing bugs that way.
 
@@ -11,8 +14,8 @@ var ENGINE_SPIDERMONKEY_TRUNK = 1;
 var ENGINE_JAVASCRIPTCORE = 4;
 
 var engine = ENGINE_UNKNOWN;
-var jsshell = (typeof window == "undefined");
-var xpcshell = jsshell && (typeof Components == "object");
+var jsshell = (typeof window == "undefined"); // eslint-disable-line no-undef
+var xpcshell = jsshell && (typeof Components == "object"); // eslint-disable-line no-undef
 var dump;
 var dumpln;
 var printImportant;
@@ -29,19 +32,19 @@ if (jsshell) {
 
     // Avoid accidentally waiting for user input that will never come.
     readline = function(){};
-  } else if (typeof XPCNativeWrapper == "function") {
+  } else if (typeof XPCNativeWrapper == "function") { // eslint-disable-line no-undef
     // e.g. xpcshell or firefox
     engine = ENGINE_SPIDERMONKEY_TRUNK;
   } else if (typeof debug == "function") {
     engine = ENGINE_JAVASCRIPTCORE;
   }
 } else {
-  if (navigator.userAgent.indexOf("WebKit") != -1) {
+  if (navigator.userAgent.indexOf("WebKit") != -1) { // eslint-disable-line no-undef
     // XXX detect Google Chrome for V8
     engine = ENGINE_JAVASCRIPTCORE;
     // This worked in Safari 3.0, but it might not work in Safari 3.1.
     dump = function(s) { console.log(s); };
-  } else if (navigator.userAgent.indexOf("Gecko") != -1) {
+  } else if (navigator.userAgent.indexOf("Gecko") != -1) { // eslint-disable-line no-undef
     engine = ENGINE_SPIDERMONKEY_TRUNK;
   } else if (typeof dump != "function") {
     // In other browsers, jsfunfuzz does not know how to log anything.
@@ -51,9 +54,9 @@ if (jsshell) {
 
   printImportant = function(s) {
     dumpln(s);
-    var p = document.createElement("pre");
-    p.appendChild(document.createTextNode(s));
-    document.body.appendChild(p);
+    var p = document.createElement("pre"); // eslint-disable-line no-undef
+    p.appendChild(document.createTextNode(s)); // eslint-disable-line no-undef
+    document.body.appendChild(p); // eslint-disable-line no-undef
   };
 }
 

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -26,9 +26,9 @@ if (jsshell) {
     // Run a diff between the help() outputs of different js shells.
     // Make sure the function to look out for is not located only in some
     // particular #ifdef, e.g. JS_GC_ZEAL, or controlled by --fuzzing-safe.
-    if (typeof wasmIsSupported == "function") {
+    if (typeof wasmIsSupported == "function") 
       engine = ENGINE_SPIDERMONKEY_TRUNK;
-    }
+    
 
     // Avoid accidentally waiting for user input that will never come.
     readline = function() {};

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -31,7 +31,7 @@ if (jsshell) {
     }
 
     // Avoid accidentally waiting for user input that will never come.
-    readline = function(){};
+    readline = function() {};
   } else if (typeof XPCNativeWrapper == "function") { // eslint-disable-line no-undef
     // e.g. xpcshell or firefox
     engine = ENGINE_SPIDERMONKEY_TRUNK;
@@ -61,7 +61,7 @@ if (jsshell) {
 }
 
 if (typeof gc == "undefined")
-  this.gc = function(){};
+  this.gc = function() {};
 var gcIsQuiet = !(gc()); // see bug 706433
 
 // If the JavaScript engine being tested has heuristics like

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -40,12 +40,12 @@ if (jsshell) {
     engine = ENGINE_JAVASCRIPTCORE;
   }
 } else {
-  if (navigator.userAgent.indexOf("WebKit") != -1) { // eslint-disable-line no-undef
+  if (navigator.userAgent.indexOf("WebKit") !== -1) { // eslint-disable-line no-undef
     // XXX detect Google Chrome for V8
     engine = ENGINE_JAVASCRIPTCORE;
     // This worked in Safari 3.0, but it might not work in Safari 3.1.
     dump = function (s) { console.log(s); };
-  } else if (navigator.userAgent.indexOf("Gecko") != -1) { // eslint-disable-line no-undef
+  } else if (navigator.userAgent.indexOf("Gecko") !== -1) { // eslint-disable-line no-undef
     engine = ENGINE_SPIDERMONKEY_TRUNK;
   } else if (typeof dump !== "function") {
     // In other browsers, jsfunfuzz does not know how to log anything.
@@ -93,4 +93,4 @@ function simpleSource (st) { // eslint-disable-line require-jsdoc
 var haveRealUneval = (typeof uneval === "function");
 if (!haveRealUneval) { uneval = simpleSource; }
 
-if (engine == ENGINE_UNKNOWN) { printImportant("Targeting an unknown JavaScript engine!"); } else if (engine == ENGINE_SPIDERMONKEY_TRUNK) { printImportant("Targeting SpiderMonkey / Gecko (trunk)."); } else if (engine == ENGINE_JAVASCRIPTCORE) { printImportant("Targeting JavaScriptCore / WebKit."); }
+if (engine === ENGINE_UNKNOWN) { printImportant("Targeting an unknown JavaScript engine!"); } else if (engine === ENGINE_SPIDERMONKEY_TRUNK) { printImportant("Targeting SpiderMonkey / Gecko (trunk)."); } else if (engine === ENGINE_JAVASCRIPTCORE) { printImportant("Targeting JavaScriptCore / WebKit."); }

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -68,7 +68,7 @@ var HOTLOOP = 60;
 function loopCount() { return rnd(rnd(HOTLOOP * 3)); }
 function loopModulo() { return (rnd(2) ? rnd(rnd(HOTLOOP * 2)) : rnd(5)) + 2; }
 
-function simpleSource(s)
+function simpleSource(st)
 {
   function hexify(c)
   {
@@ -79,16 +79,16 @@ function simpleSource(s)
     return "\\u" + hex;
   }
 
-  if (typeof s == "string")
+  if (typeof st == "string")
     return ("\"" +
-      s.replace(/\\/g, "\\\\")
-       .replace(/\"/g, "\\\"")
-       .replace(/\0/g, "\\0")
-       .replace(/\n/g, "\\n")
-       .replace(/[^ -~]/g, hexify) + // not space (32) through tilde (126)
+      st.replace(/\\/g, "\\\\")
+        .replace(/\"/g, "\\\"")
+        .replace(/\0/g, "\\0")
+        .replace(/\n/g, "\\n")
+        .replace(/[^ -~]/g, hexify) + // not space (32) through tilde (126)
       "\"");
   else
-    return "" + s; // hope this is right ;)  should work for numbers.
+    return "" + st; // hope this is right ;)  should work for numbers.
 }
 
 var haveRealUneval = (typeof uneval == "function");

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -26,9 +26,9 @@ if (jsshell) {
     // Run a diff between the help() outputs of different js shells.
     // Make sure the function to look out for is not located only in some
     // particular #ifdef, e.g. JS_GC_ZEAL, or controlled by --fuzzing-safe.
-    if (typeof wasmIsSupported == "function") 
+    if (typeof wasmIsSupported == "function") {
       engine = ENGINE_SPIDERMONKEY_TRUNK;
-    
+    }
 
     // Avoid accidentally waiting for user input that will never come.
     readline = function() {};

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -68,11 +68,11 @@ var gcIsQuiet = !(gc()); // see bug 706433
 //   "recompile any loop that is run more than X times"
 // this should be set to the highest such X.
 var HOTLOOP = 60;
-function loopCount () { return rnd(rnd(HOTLOOP * 3)); }
-function loopModulo () { return (rnd(2) ? rnd(rnd(HOTLOOP * 2)) : rnd(5)) + 2; }
+function loopCount () { return rnd(rnd(HOTLOOP * 3)); } // eslint-disable-line require-jsdoc
+function loopModulo () { return (rnd(2) ? rnd(rnd(HOTLOOP * 2)) : rnd(5)) + 2; } // eslint-disable-line require-jsdoc
 
-function simpleSource (st) {
-  function hexify (c) {
+function simpleSource (st) { // eslint-disable-line require-jsdoc
+  function hexify (c) { // eslint-disable-line require-jsdoc
     var code = c.charCodeAt(0);
     var hex = code.toString(16);
     while (hex.length < 4) { hex = "0" + hex; }

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -82,7 +82,7 @@ function simpleSource (st) { // eslint-disable-line require-jsdoc
   if (typeof st === "string") {
     return ("\"" +
       st.replace(/\\/g, "\\\\")
-        .replace(/\"/g, "\\\"")
+        .replace(/"/g, "\\\"")
         .replace(/\0/g, "\\0")
         .replace(/\n/g, "\\n")
         .replace(/[^ -~]/g, hexify) + // not space (32) through tilde (126)

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -40,12 +40,12 @@ if (jsshell) {
     engine = ENGINE_JAVASCRIPTCORE;
   }
 } else {
-  if (navigator.userAgent.indexOf("WebKit") !== -1) { // eslint-disable-line no-undef
+  if (navigator.userAgent.indexOf("WebKit") != -1) { // eslint-disable-line no-undef
     // XXX detect Google Chrome for V8
     engine = ENGINE_JAVASCRIPTCORE;
     // This worked in Safari 3.0, but it might not work in Safari 3.1.
     dump = function (s) { console.log(s); };
-  } else if (navigator.userAgent.indexOf("Gecko") !== -1) { // eslint-disable-line no-undef
+  } else if (navigator.userAgent.indexOf("Gecko") != -1) { // eslint-disable-line no-undef
     engine = ENGINE_SPIDERMONKEY_TRUNK;
   } else if (typeof dump !== "function") {
     // In other browsers, jsfunfuzz does not know how to log anything.
@@ -93,4 +93,4 @@ function simpleSource (st) { // eslint-disable-line require-jsdoc
 var haveRealUneval = (typeof uneval === "function");
 if (!haveRealUneval) { uneval = simpleSource; }
 
-if (engine === ENGINE_UNKNOWN) { printImportant("Targeting an unknown JavaScript engine!"); } else if (engine === ENGINE_SPIDERMONKEY_TRUNK) { printImportant("Targeting SpiderMonkey / Gecko (trunk)."); } else if (engine === ENGINE_JAVASCRIPTCORE) { printImportant("Targeting JavaScriptCore / WebKit."); }
+if (engine == ENGINE_UNKNOWN) { printImportant("Targeting an unknown JavaScript engine!"); } else if (engine == ENGINE_SPIDERMONKEY_TRUNK) { printImportant("Targeting SpiderMonkey / Gecko (trunk)."); } else if (engine == ENGINE_JAVASCRIPTCORE) { printImportant("Targeting JavaScriptCore / WebKit."); }

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported gcIsQuiet, loopCount, loopModulo, readline, xpcshell */
 /* global console, debug, gc, print, readline:writable, rnd, uneval:writable, verifyprebarriers, wasmIsSupported */
 /* XPCNativeWrapper */
 

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -3,6 +3,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global count:writable, dumpln, engine, ENGINE_SPIDERMONKEY_TRUNK, jsshell */
+/* global makeScript, mathInitFCM, print, printImportant, Random, rnd, tryItOut, uneval */
+
 function start(glob)
 {
   var fuzzSeed = Math.floor(Math.random() * Math.pow(2,28));
@@ -41,7 +44,7 @@ function start(glob)
       lastTime = new Date();
     } while(lastTime - startTime < MAX_TOTAL_TIME);
   } else {
-    setTimeout(testStuffForAWhile, 200);
+    setTimeout(testStuffForAWhile, 200); // eslint-disable-line no-undef
   }
 
   function testStuffForAWhile()
@@ -52,7 +55,7 @@ function start(glob)
     if (count % 10000 < 100)
       printImportant("Iterations: " + count);
 
-    setTimeout(testStuffForAWhile, 30);
+    setTimeout(testStuffForAWhile, 30); // eslint-disable-line no-undef
   }
 
   function testOne()

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -7,8 +7,7 @@
 /* global count:writable, dumpln, engine, ENGINE_SPIDERMONKEY_TRUNK, jsshell */
 /* global makeScript, mathInitFCM, print, printImportant, Random, rnd, tryItOut, uneval */
 
-function start(glob)
-{
+function start (glob) {
   var fuzzSeed = Math.floor(Math.random() * Math.pow(2, 28));
   dumpln("fuzzSeed: " + fuzzSeed);
   Random.init(fuzzSeed);
@@ -48,19 +47,15 @@ function start(glob)
     setTimeout(testStuffForAWhile, 200); // eslint-disable-line no-undef
   }
 
-  function testStuffForAWhile()
-  {
-    for (var j = 0; j < 100; ++j)
-      testOne();
+  function testStuffForAWhile () {
+    for (var j = 0; j < 100; ++j) { testOne(); }
 
-    if (count % 10000 < 100)
-      printImportant("Iterations: " + count);
+    if (count % 10000 < 100) { printImportant("Iterations: " + count); }
 
     setTimeout(testStuffForAWhile, 30); // eslint-disable-line no-undef
   }
 
-  function testOne()
-  {
+  function testOne () {
     ++count;
 
     // Sometimes it makes sense to start with simpler functions:
@@ -96,8 +91,7 @@ function start(glob)
   }
 }
 
-
-function failsToCompileInTry(code) {
+function failsToCompileInTry (code) {
   // Why would this happen? One way is "let x, x"
   try {
     var codeInTry = "try { " + code + " } catch(e) { }";
@@ -107,4 +101,3 @@ function failsToCompileInTry(code) {
     return true;
   }
 }
-

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -66,7 +66,7 @@ function start (glob) { // eslint-disable-line require-jsdoc
       // More complicated, but results in a much shorter script, making SpiderMonkey happier.
       var MTA = uneval(Random.twister.export_mta());
       var MTI = Random.twister.export_mti();
-      if (MTA !== Random.lastDumpedMTA) {
+      if (MTA != Random.lastDumpedMTA) {
         dumpln(cookie + "Random.twister.import_mta(" + MTA + ");");
         Random.lastDumpedMTA = MTA;
       }
@@ -75,7 +75,7 @@ function start (glob) { // eslint-disable-line require-jsdoc
 
     var code = makeScript(depth);
 
-    if (count === 1 && engine === ENGINE_SPIDERMONKEY_TRUNK && rnd(5)) {
+    if (count == 1 && engine == ENGINE_SPIDERMONKEY_TRUNK && rnd(5)) {
       code = "tryRunning = useSpidermonkeyShellSandbox(" + rnd(4) + ");";
       // print("Sane mode!")
     }

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported failsToCompileInTry, start */
 /* global count:writable, dumpln, engine, ENGINE_SPIDERMONKEY_TRUNK, jsshell */
 /* global makeScript, mathInitFCM, print, printImportant, Random, rnd, tryItOut, uneval */
 

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -84,11 +84,11 @@ function start(glob)
       // print("Sane mode!")
     }
 
-  //  if (rnd(10) === 1) {
-  //    var dp = "/*infloop-deParen*/" + Random.index(deParen(code));
-  //    if (dp)
-  //      code = dp;
-  //  }
+    //  if (rnd(10) === 1) {
+    //    var dp = "/*infloop-deParen*/" + Random.index(deParen(code));
+    //    if (dp)
+    //      code = dp;
+    //  }
     dumpln(cookie + "count=" + count + "; tryItOut(" + uneval(code) + ");");
 
     tryItOut(code);

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -66,7 +66,7 @@ function start (glob) { // eslint-disable-line require-jsdoc
       // More complicated, but results in a much shorter script, making SpiderMonkey happier.
       var MTA = uneval(Random.twister.export_mta());
       var MTI = Random.twister.export_mti();
-      if (MTA != Random.lastDumpedMTA) {
+      if (MTA !== Random.lastDumpedMTA) {
         dumpln(cookie + "Random.twister.import_mta(" + MTA + ");");
         Random.lastDumpedMTA = MTA;
       }
@@ -75,7 +75,7 @@ function start (glob) { // eslint-disable-line require-jsdoc
 
     var code = makeScript(depth);
 
-    if (count == 1 && engine == ENGINE_SPIDERMONKEY_TRUNK && rnd(5)) {
+    if (count === 1 && engine === ENGINE_SPIDERMONKEY_TRUNK && rnd(5)) {
       code = "tryRunning = useSpidermonkeyShellSandbox(" + rnd(4) + ");";
       // print("Sane mode!")
     }

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -42,7 +42,7 @@ function start(glob)
         print("That took " + elapsed1 + "ms!");
       }
       lastTime = new Date();
-    } while(lastTime - startTime < MAX_TOTAL_TIME);
+    } while (lastTime - startTime < MAX_TOTAL_TIME);
   } else {
     setTimeout(testStuffForAWhile, 200); // eslint-disable-line no-undef
   }
@@ -102,7 +102,7 @@ function failsToCompileInTry(code) {
     var codeInTry = "try { " + code + " } catch(e) { }";
     void new Function(codeInTry);
     return false;
-  } catch(e) {
+  } catch (e) {
     return true;
   }
 }

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -63,7 +63,7 @@ function start(glob)
     ++count;
 
     // Sometimes it makes sense to start with simpler functions:
-    //var depth = ((count / 1000) | 0) & 16;
+    // var depth = ((count / 1000) | 0) & 16;
     var depth = 14;
 
     if (dumpEachSeed) {
@@ -81,7 +81,7 @@ function start(glob)
 
     if (count == 1 && engine == ENGINE_SPIDERMONKEY_TRUNK && rnd(5)) {
       code = "tryRunning = useSpidermonkeyShellSandbox(" + rnd(4) + ");";
-      //print("Sane mode!")
+      // print("Sane mode!")
     }
 
   //  if (rnd(10) === 1) {

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -21,9 +21,9 @@ function start(glob)
   // Can be set to true if makeStatement has side effects, such as crashing, so you have to reduce "the hard way".
   var dumpEachSeed = false;
 
-  if (dumpEachSeed) 
+  if (dumpEachSeed) {
     dumpln(cookie + "Random.init(0);");
-  
+  }
 
   mathInitFCM();
 
@@ -38,9 +38,9 @@ function start(glob)
     do {
       testOne();
       var elapsed1 = new Date() - lastTime;
-      if (elapsed1 > 1000) 
+      if (elapsed1 > 1000) {
         print("That took " + elapsed1 + "ms!");
-      
+      }
       lastTime = new Date();
     } while (lastTime - startTime < MAX_TOTAL_TIME);
   } else {
@@ -79,10 +79,10 @@ function start(glob)
 
     var code = makeScript(depth);
 
-    if (count == 1 && engine == ENGINE_SPIDERMONKEY_TRUNK && rnd(5)) 
+    if (count == 1 && engine == ENGINE_SPIDERMONKEY_TRUNK && rnd(5)) {
       code = "tryRunning = useSpidermonkeyShellSandbox(" + rnd(4) + ");";
       // print("Sane mode!")
-    
+    }
 
     //  if (rnd(10) === 1) {
     //    var dp = "/*infloop-deParen*/" + Random.index(deParen(code));

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -7,7 +7,7 @@
 /* global count:writable, dumpln, engine, ENGINE_SPIDERMONKEY_TRUNK, jsshell */
 /* global makeScript, mathInitFCM, print, printImportant, Random, rnd, tryItOut, uneval */
 
-function start (glob) {
+function start (glob) { // eslint-disable-line require-jsdoc
   var fuzzSeed = Math.floor(Math.random() * Math.pow(2, 28));
   dumpln("fuzzSeed: " + fuzzSeed);
   Random.init(fuzzSeed);
@@ -47,7 +47,7 @@ function start (glob) {
     setTimeout(testStuffForAWhile, 200); // eslint-disable-line no-undef
   }
 
-  function testStuffForAWhile () {
+  function testStuffForAWhile () { // eslint-disable-line require-jsdoc
     for (var j = 0; j < 100; ++j) { testOne(); }
 
     if (count % 10000 < 100) { printImportant("Iterations: " + count); }
@@ -55,7 +55,7 @@ function start (glob) {
     setTimeout(testStuffForAWhile, 30); // eslint-disable-line no-undef
   }
 
-  function testOne () {
+  function testOne () { // eslint-disable-line require-jsdoc
     ++count;
 
     // Sometimes it makes sense to start with simpler functions:
@@ -91,7 +91,7 @@ function start (glob) {
   }
 }
 
-function failsToCompileInTry (code) {
+function failsToCompileInTry (code) { // eslint-disable-line require-jsdoc
   // Why would this happen? One way is "let x, x"
   try {
     var codeInTry = "try { " + code + " } catch(e) { }";

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -95,7 +95,7 @@ function failsToCompileInTry (code) { // eslint-disable-line require-jsdoc
   // Why would this happen? One way is "let x, x"
   try {
     var codeInTry = "try { " + code + " } catch(e) { }";
-    void new Function(codeInTry);
+    void new Function(codeInTry); // eslint-disable-line no-new-func
     return false;
   } catch (e) {
     return true;

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -21,9 +21,9 @@ function start(glob)
   // Can be set to true if makeStatement has side effects, such as crashing, so you have to reduce "the hard way".
   var dumpEachSeed = false;
 
-  if (dumpEachSeed) {
+  if (dumpEachSeed) 
     dumpln(cookie + "Random.init(0);");
-  }
+  
 
   mathInitFCM();
 
@@ -38,9 +38,9 @@ function start(glob)
     do {
       testOne();
       var elapsed1 = new Date() - lastTime;
-      if (elapsed1 > 1000) {
+      if (elapsed1 > 1000) 
         print("That took " + elapsed1 + "ms!");
-      }
+      
       lastTime = new Date();
     } while (lastTime - startTime < MAX_TOTAL_TIME);
   } else {
@@ -79,10 +79,10 @@ function start(glob)
 
     var code = makeScript(depth);
 
-    if (count == 1 && engine == ENGINE_SPIDERMONKEY_TRUNK && rnd(5)) {
+    if (count == 1 && engine == ENGINE_SPIDERMONKEY_TRUNK && rnd(5)) 
       code = "tryRunning = useSpidermonkeyShellSandbox(" + rnd(4) + ");";
       // print("Sane mode!")
-    }
+    
 
     //  if (rnd(10) === 1) {
     //    var dp = "/*infloop-deParen*/" + Random.index(deParen(code));

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -8,7 +8,7 @@
 
 function start(glob)
 {
-  var fuzzSeed = Math.floor(Math.random() * Math.pow(2,28));
+  var fuzzSeed = Math.floor(Math.random() * Math.pow(2, 28));
   dumpln("fuzzSeed: " + fuzzSeed);
   Random.init(fuzzSeed);
 

--- a/src/funfuzz/js/jsfunfuzz/error-reporting.js
+++ b/src/funfuzz/js/jsfunfuzz/error-reporting.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported confused, errorstack, errorToString, foundABug */
 /* global dumpln, jsshell, print, printImportant, quit */
 
 function confused(s)

--- a/src/funfuzz/js/jsfunfuzz/error-reporting.js
+++ b/src/funfuzz/js/jsfunfuzz/error-reporting.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global dumpln, jsshell, print, printImportant, quit */
+
 function confused(s)
 {
   if (jsshell) {

--- a/src/funfuzz/js/jsfunfuzz/error-reporting.js
+++ b/src/funfuzz/js/jsfunfuzz/error-reporting.js
@@ -6,7 +6,7 @@
 /* exported confused, errorstack, errorToString, foundABug */
 /* global dumpln, jsshell, print, printImportant, quit */
 
-function confused (s) {
+function confused (s) { // eslint-disable-line require-jsdoc
   if (jsshell) {
     // Magic string that js_interesting looks for
     // Currently disabled until its use can be figured out
@@ -17,7 +17,7 @@ function confused (s) {
   }
 }
 
-function foundABug (summary, details) {
+function foundABug (summary, details) { // eslint-disable-line require-jsdoc
   // Magic pair of strings that js_interesting looks for
   // Break up the following string so internal js functions do not print it deliberately
   printImportant("Found" + " a bug: " + summary);
@@ -30,7 +30,7 @@ function foundABug (summary, details) {
   }
 }
 
-function errorToString (e) {
+function errorToString (e) { // eslint-disable-line require-jsdoc
   try {
     return ("" + e);
   } catch (e2) {
@@ -38,7 +38,7 @@ function errorToString (e) {
   }
 }
 
-function errorstack () {
+function errorstack () { // eslint-disable-line require-jsdoc
   print("EEE");
   try {
     void ([].qwerty.qwerty);

--- a/src/funfuzz/js/jsfunfuzz/error-reporting.js
+++ b/src/funfuzz/js/jsfunfuzz/error-reporting.js
@@ -45,5 +45,5 @@ function errorstack()
   print("EEE");
   try {
     void ([].qwerty.qwerty);
-  } catch(e) { print(e.stack); }
+  } catch (e) { print(e.stack); }
 }

--- a/src/funfuzz/js/jsfunfuzz/error-reporting.js
+++ b/src/funfuzz/js/jsfunfuzz/error-reporting.js
@@ -22,9 +22,9 @@ function foundABug(summary, details)
   // Magic pair of strings that js_interesting looks for
   // Break up the following string so internal js functions do not print it deliberately
   printImportant("Found" + " a bug: " + summary);
-  if (details) {
+  if (details) 
     printImportant(details);
-  }
+  
   if (jsshell) {
     dumpln("jsfunfuzz stopping due to finding a bug.");
     quit();

--- a/src/funfuzz/js/jsfunfuzz/error-reporting.js
+++ b/src/funfuzz/js/jsfunfuzz/error-reporting.js
@@ -22,9 +22,9 @@ function foundABug(summary, details)
   // Magic pair of strings that js_interesting looks for
   // Break up the following string so internal js functions do not print it deliberately
   printImportant("Found" + " a bug: " + summary);
-  if (details) 
+  if (details) {
     printImportant(details);
-  
+  }
   if (jsshell) {
     dumpln("jsfunfuzz stopping due to finding a bug.");
     quit();

--- a/src/funfuzz/js/jsfunfuzz/error-reporting.js
+++ b/src/funfuzz/js/jsfunfuzz/error-reporting.js
@@ -6,8 +6,7 @@
 /* exported confused, errorstack, errorToString, foundABug */
 /* global dumpln, jsshell, print, printImportant, quit */
 
-function confused(s)
-{
+function confused (s) {
   if (jsshell) {
     // Magic string that js_interesting looks for
     // Currently disabled until its use can be figured out
@@ -18,8 +17,7 @@ function confused(s)
   }
 }
 
-function foundABug(summary, details)
-{
+function foundABug (summary, details) {
   // Magic pair of strings that js_interesting looks for
   // Break up the following string so internal js functions do not print it deliberately
   printImportant("Found" + " a bug: " + summary);
@@ -32,8 +30,7 @@ function foundABug(summary, details)
   }
 }
 
-function errorToString(e)
-{
+function errorToString (e) {
   try {
     return ("" + e);
   } catch (e2) {
@@ -41,8 +38,7 @@ function errorToString(e)
   }
 }
 
-function errorstack()
-{
+function errorstack () {
   print("EEE");
   try {
     void ([].qwerty.qwerty);

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global makeExpr, makeStatement, Random, rnd, totallyRandom */
+
 /***************************
  * GENERATE ASM.JS MODULES *
  ***************************/

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -75,7 +75,7 @@ function asmJsFunction(globalEnv, name, ret, args)
 
   // Add the required return statement at the end of the function
   if (ret != "void" || rnd(2))
-  s += asmReturnStatement("    ", env);
+    s += asmReturnStatement("    ", env);
 
   s += "  }\n";
 
@@ -120,7 +120,7 @@ function asmAssignmentStatement(indent, env)
   }
 
   var local = Random.index(env.locals);
-    if (local.charAt(0) == "d") {
+  if (local.charAt(0) == "d") {
     return indent + local + " = " + doubleExpr(10, env) + ";\n";
   } else {
     return indent + local + " = " + intExpr(10, env) + ";\n";
@@ -177,96 +177,96 @@ var additive = ["+", "-"];
 // * We're allowed to write to some fields of |e|
 
 var intExpr = autoExpr(Random.weighted([
-    {w: 1,  v: function(d, e) { return intLiteralRange(-0x8000000, 0xffffffff); }},
-    {w: 1,  v: function(d, e) { return intExpr(d - 3, e) + " ? " + intExpr(d - 3, e) + " : " + intExpr(d - 3, e); }},
-    {w: 1,  v: function(d, e) { return "!" + intExpr(d - 1, e); }},
-    {w: 1,  v: function(d, e) { return signedExpr(d - 1, e); }},
-    {w: 1,  v: function(d, e) { return unsignedExpr(d - 1, e); }},
-    {w: 10, v: function(d, e) { return intVar(e); }}, // + "|0"  ??
-    {w: 1,  v: function(d, e) { return e.globalEnv.foreignFunctions.length ? asmFfiCall(d, e) + "|0" : "1"; }},
-    {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + signedExpr(d - 2, e); }},
-    {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + unsignedExpr(d - 2, e); }},
-    {w: 1,  v: function(d, e) { return doubleExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + doubleExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return intLiteralRange(-0x8000000, 0xffffffff); }},
+  {w: 1,  v: function(d, e) { return intExpr(d - 3, e) + " ? " + intExpr(d - 3, e) + " : " + intExpr(d - 3, e); }},
+  {w: 1,  v: function(d, e) { return "!" + intExpr(d - 1, e); }},
+  {w: 1,  v: function(d, e) { return signedExpr(d - 1, e); }},
+  {w: 1,  v: function(d, e) { return unsignedExpr(d - 1, e); }},
+  {w: 10, v: function(d, e) { return intVar(e); }}, // + "|0"  ??
+  {w: 1,  v: function(d, e) { return e.globalEnv.foreignFunctions.length ? asmFfiCall(d, e) + "|0" : "1"; }},
+  {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + signedExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + unsignedExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return doubleExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + doubleExpr(d - 2, e); }},
 ]));
 
 var intishExpr = autoExpr(Random.weighted([
-    {w: 10, v: function(d, e) { return intExpr(d, e); }},
-    {w: 1,  v: function(d, e) { return intishMemberExpr(d, e); }},
-    // Add two or more ints
-    {w: 10, v: function(d, e) { return intExpr(d - 1, e) + Random.index(additive) + intExpr(d - 1, e); }},
-    {w: 5,  v: function(d, e) { return intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e); }},
-    // Multiply by a small int literal
-    {w: 2,  v: function(d, e) { return intExpr(d - 1, e) + "*" + intLiteralRange(-0xfffff, 0xfffff); }},
-    {w: 2,  v: function(d, e) { return intLiteralRange(-0xfffff, 0xfffff) + "*" + intExpr(d - 1, e); }},
-    {w: 1,  v: function(d, e) { return "-" + intExpr(d - 1, e); }},
-    {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + " / " + signedExpr(d - 2, e); }},
-    {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + " / " + unsignedExpr(d - 2, e); }},
-    {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + " % " + signedExpr(d - 2, e); }},
-    {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + " % " + unsignedExpr(d - 2, e); }},
+  {w: 10, v: function(d, e) { return intExpr(d, e); }},
+  {w: 1,  v: function(d, e) { return intishMemberExpr(d, e); }},
+  // Add two or more ints
+  {w: 10, v: function(d, e) { return intExpr(d - 1, e) + Random.index(additive) + intExpr(d - 1, e); }},
+  {w: 5,  v: function(d, e) { return intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e); }},
+  // Multiply by a small int literal
+  {w: 2,  v: function(d, e) { return intExpr(d - 1, e) + "*" + intLiteralRange(-0xfffff, 0xfffff); }},
+  {w: 2,  v: function(d, e) { return intLiteralRange(-0xfffff, 0xfffff) + "*" + intExpr(d - 1, e); }},
+  {w: 1,  v: function(d, e) { return "-" + intExpr(d - 1, e); }},
+  {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + " / " + signedExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + " / " + unsignedExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + " % " + signedExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + " % " + unsignedExpr(d - 2, e); }},
 ]));
 
 var signedExpr = autoExpr(Random.weighted([
-    {w: 1,  v: function(d, e) { return intLiteralRange(-0x8000000, 0x7fffffff); }},
-    {w: 1,  v: function(d, e) { return "~" + intishExpr(d - 1, e); }},
-    {w: 1,  v: function(d, e) { return "~~" + doubleExpr(d - 1, e); }},
-    {w: 1,  v: function(d, e) { return intishExpr(d - 1, e) + "|0"; }}, // this isn't a special form, but it's common for a good reason
-    {w: 1,  v: function(d, e) { return ensureMathImport(e, "imul") + "(" + intExpr(d - 2, e) + ", " + intExpr(d - 2, e) + ")|0"; }},
-    {w: 1,  v: function(d, e) { return ensureMathImport(e, "abs") + "(" + signedExpr(d - 1, e) + ")|0"; }},
-    {w: 5,  v: function(d, e) { return intishExpr(d - 2, e) + Random.index([" | ", " & ", " ^ ", " << ", " >> "]) + intishExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return intLiteralRange(-0x8000000, 0x7fffffff); }},
+  {w: 1,  v: function(d, e) { return "~" + intishExpr(d - 1, e); }},
+  {w: 1,  v: function(d, e) { return "~~" + doubleExpr(d - 1, e); }},
+  {w: 1,  v: function(d, e) { return intishExpr(d - 1, e) + "|0"; }}, // this isn't a special form, but it's common for a good reason
+  {w: 1,  v: function(d, e) { return ensureMathImport(e, "imul") + "(" + intExpr(d - 2, e) + ", " + intExpr(d - 2, e) + ")|0"; }},
+  {w: 1,  v: function(d, e) { return ensureMathImport(e, "abs") + "(" + signedExpr(d - 1, e) + ")|0"; }},
+  {w: 5,  v: function(d, e) { return intishExpr(d - 2, e) + Random.index([" | ", " & ", " ^ ", " << ", " >> "]) + intishExpr(d - 2, e); }},
 ]));
 
 var unsignedExpr = autoExpr(Random.weighted([
-    {w: 1,  v: function(d, e) { return intLiteralRange(0, 0xffffffff); }},
-    {w: 1,  v: function(d, e) { return intishExpr(d - 2, e) + ">>>" + intishExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return intLiteralRange(0, 0xffffffff); }},
+  {w: 1,  v: function(d, e) { return intishExpr(d - 2, e) + ">>>" + intishExpr(d - 2, e); }},
 ]));
 
 var doublishExpr = autoExpr(Random.weighted([
-    {w: 10, v: function(d, e) { return doubleExpr(d, e); }},
-    {w: 1,  v: function(d, e) { return doublishMemberExpr(d, e); }},
-    // Read from a doublish typed array view
+  {w: 10, v: function(d, e) { return doubleExpr(d, e); }},
+  {w: 1,  v: function(d, e) { return doublishMemberExpr(d, e); }},
+  // Read from a doublish typed array view
 ]));
 
 var doubleExpr = autoExpr(Random.weighted([
-    {w: 1,  v: function(d, e) { return doubleLiteral(); }},
-    {w: 20, v: function(d, e) { return doubleVar(e); }},
-    {w: 1,  v: function(d, e) { return e.globalEnv.foreignFunctions.length ? "+" + asmFfiCall(d, e) : "1.0"; }},
-    {w: 1,  v: function(d, e) { return "+(1.0/0.0)"; }},
-    {w: 1,  v: function(d, e) { return "+(0.0/0.0)"; }},
-    {w: 1,  v: function(d, e) { return "+(-1.0/0.0)"; }},
-    // Unary ops that return double
-    {w: 1,  v: function(d, e) { return "+" + signedExpr(d - 1, e); }},
-    {w: 1,  v: function(d, e) { return "+" + unsignedExpr(d - 1, e); }},
-    {w: 1,  v: function(d, e) { return "+" + doublishExpr(d - 1, e); }},
-    {w: 1,  v: function(d, e) { return "-" + doublishExpr(d - 1, e); }},
-    // Binary ops that return double
-    {w: 1,  v: function(d, e) { return doubleExpr(d - 2, e) + " + " + doubleExpr(d - 2, e); }},
-    {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " - " + doublishExpr(d - 2, e); }},
-    {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " * " + doublishExpr(d - 2, e); }},
-    {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " / " + doublishExpr(d - 2, e); }},
-    {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " % " + doublishExpr(d - 2, e); }},
-    {w: 1,  v: function(d, e) { return intExpr(d - 3, e) + " ? " + doubleExpr(d - 3, e) + " : " + doubleExpr(d - 3, e); }},
-    // with stdlib
-    {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["acos", "asin", "atan", "cos", "sin", "tan", "ceil", "floor", "exp", "log", "sqrt"])) + "(" + doublishExpr(d - 1, e) + ")"; }},
-    {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, "abs") + "(" + doublishExpr(d - 1, e) + ")"; }},
-    {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["atan2", "pow"])) + "(" + doublishExpr(d - 2, e) + ", " + doublishExpr(d - 2, e) + ")"; }},
-    {w: 1,  v: function(d, e) { return ensureImport(e, "Infinity"); }},
-    {w: 1,  v: function(d, e) { return ensureImport(e, "NaN"); }},
+  {w: 1,  v: function(d, e) { return doubleLiteral(); }},
+  {w: 20, v: function(d, e) { return doubleVar(e); }},
+  {w: 1,  v: function(d, e) { return e.globalEnv.foreignFunctions.length ? "+" + asmFfiCall(d, e) : "1.0"; }},
+  {w: 1,  v: function(d, e) { return "+(1.0/0.0)"; }},
+  {w: 1,  v: function(d, e) { return "+(0.0/0.0)"; }},
+  {w: 1,  v: function(d, e) { return "+(-1.0/0.0)"; }},
+  // Unary ops that return double
+  {w: 1,  v: function(d, e) { return "+" + signedExpr(d - 1, e); }},
+  {w: 1,  v: function(d, e) { return "+" + unsignedExpr(d - 1, e); }},
+  {w: 1,  v: function(d, e) { return "+" + doublishExpr(d - 1, e); }},
+  {w: 1,  v: function(d, e) { return "-" + doublishExpr(d - 1, e); }},
+  // Binary ops that return double
+  {w: 1,  v: function(d, e) { return doubleExpr(d - 2, e) + " + " + doubleExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " - " + doublishExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " * " + doublishExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " / " + doublishExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " % " + doublishExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return intExpr(d - 3, e) + " ? " + doubleExpr(d - 3, e) + " : " + doubleExpr(d - 3, e); }},
+  // with stdlib
+  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["acos", "asin", "atan", "cos", "sin", "tan", "ceil", "floor", "exp", "log", "sqrt"])) + "(" + doublishExpr(d - 1, e) + ")"; }},
+  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, "abs") + "(" + doublishExpr(d - 1, e) + ")"; }},
+  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["atan2", "pow"])) + "(" + doublishExpr(d - 2, e) + ", " + doublishExpr(d - 2, e) + ")"; }},
+  {w: 1,  v: function(d, e) { return ensureImport(e, "Infinity"); }},
+  {w: 1,  v: function(d, e) { return ensureImport(e, "NaN"); }},
 ]));
 
 var externExpr = autoExpr(Random.weighted([
-    {w: 1,  v: function(d, e) { return doubleExpr(d, e); } },
-    {w: 1,  v: function(d, e) { return signedExpr(d, e); } },
+  {w: 1,  v: function(d, e) { return doubleExpr(d, e); } },
+  {w: 1,  v: function(d, e) { return signedExpr(d, e); } },
 ]));
 
 var intishMemberExpr = autoExpr(Random.weighted([
-    {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int8Array",  "Uint8Array" ])) + "[" + asmIndex(d, e, 0) + "]"; }},
-    {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int16Array", "Uint16Array"])) + "[" + asmIndex(d, e, 1) + "]"; }},
-    {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int32Array", "Uint32Array"])) + "[" + asmIndex(d, e, 2) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int8Array",  "Uint8Array" ])) + "[" + asmIndex(d, e, 0) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int16Array", "Uint16Array"])) + "[" + asmIndex(d, e, 1) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int32Array", "Uint32Array"])) + "[" + asmIndex(d, e, 2) + "]"; }},
 ]), true);
 
 var doublishMemberExpr = autoExpr(Random.weighted([
-    {w: 1,  v: function(d, e) { return ensureView(e, "Float32Array") + "[" + asmIndex(d, e, 2) + "]"; }},
-    {w: 1,  v: function(d, e) { return ensureView(e, "Float64Array") + "[" + asmIndex(d, e, 3) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, "Float32Array") + "[" + asmIndex(d, e, 2) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, "Float64Array") + "[" + asmIndex(d, e, 3) + "]"; }},
 ]), true);
 
 function asmIndex(d, e, logSize)
@@ -322,9 +322,9 @@ function autoExpr(funs, avoidSubst)
 {
   return function(d, e) {
     var f = d < 1 ? funs[0] :
-            rnd(50) === 0 && !e.globalEnv.sanePlease ? function(_d, _e) { return makeExpr(5, ["x"]); } :
-            rnd(50) === 0 && !avoidSubst ? Random.index(anyAsmExpr) :
-            Random.index(funs);
+      rnd(50) === 0 && !e.globalEnv.sanePlease ? function(_d, _e) { return makeExpr(5, ["x"]); } :
+        rnd(50) === 0 && !avoidSubst ? Random.index(anyAsmExpr) :
+          Random.index(funs);
     return "(" + f(d, e) + ")";
   };
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -44,9 +44,9 @@ function asmJSInterior(foreignFunctions, sanePlease)
 function importForeign(foreignFunctions)
 {
   var s = "";
-  for (let h of foreignFunctions) 
+  for (let h of foreignFunctions) {
     s += "  var " + h + " = foreign." + h + ";\n";
-  
+  }
   return s;
 }
 
@@ -70,11 +70,11 @@ function asmJsFunction(globalEnv, name, ret, args)
   var env = {globalEnv: globalEnv, locals: locals, ret: ret};
 
   // Add assignment statements
-  if (locals.length) 
-    while (rnd(5)) 
+  if (locals.length) {
+    while (rnd(5)) {
       s += asmStatement("    ", env, 6);
-    
-  
+    }
+  }
 
   // Add the required return statement at the end of the function
   if (ret != "void" || rnd(2))
@@ -90,18 +90,18 @@ function asmStatement(indent, env, d)
   if (!env.globalEnv.sanePlease && rnd(100) === 0)
     return makeStatement(3, ["x"]);
 
-  if (rnd(5) === 0 && d > 0) 
+  if (rnd(5) === 0 && d > 0) {
     return indent + "{\n" + asmStatement(indent + "  ", env, d - 1) + indent + "}\n";
-  
-  if (rnd(20) === 0 && d > 3) 
+  }
+  if (rnd(20) === 0 && d > 3) {
     return asmSwitchStatement(indent, env, d);
-  
-  if (rnd(10) === 0) 
+  }
+  if (rnd(10) === 0) {
     return asmReturnStatement(indent, env);
-  
-  if (rnd(50) === 0 && env.globalEnv.foreignFunctions.length) 
+  }
+  if (rnd(50) === 0 && env.globalEnv.foreignFunctions.length) {
     return asmVoidCallStatement(indent, env);
-  
+  }
   if (rnd(100) === 0)
     return ";";
   return asmAssignmentStatement(indent, env);
@@ -114,20 +114,20 @@ function asmVoidCallStatement(indent, env)
 
 function asmAssignmentStatement(indent, env)
 {
-  if (rnd(5) === 0 || !env.locals.length) 
+  if (rnd(5) === 0 || !env.locals.length) {
     if (rnd(2)) {
       return indent + intishMemberExpr(8, env) + " = " + intishExpr(10, env) + ";\n";
     } else {
       return indent + doublishMemberExpr(8, env) + " = " + doublishExpr(10, env) + ";\n";
     }
-  
+  }
 
   var local = Random.index(env.locals);
-  if (local.charAt(0) == "d") 
+  if (local.charAt(0) == "d") {
     return indent + local + " = " + doubleExpr(10, env) + ";\n";
-  else 
+  } else {
     return indent + local + " = " + intExpr(10, env) + ";\n";
-  
+  }
 }
 
 function asmReturnStatement(indent, env)
@@ -382,24 +382,24 @@ function doubleLiteral()
 
 function positiveDoubleLiteral()
 {
-  if (rnd(3) === 0) 
+  if (rnd(3) === 0) {
     Random.index(["0.0", "1.0", "1.2345e60"]);
-  
+  }
 
   // A power of two
   var value = Math.pow(2, rnd(100) - 10);
 
   // One more or one less
-  if (rnd(3)) 
+  if (rnd(3)) {
     value += 1;
-  else if (value > 1 && rnd(2)) 
+  } else if (value > 1 && rnd(2)) {
     value -= 1;
-  
+  }
 
   var str = value + "";
-  if (str.indexOf(".") == -1) 
+  if (str.indexOf(".") == -1) {
     return str + ".0";
-  
+  }
   // Numbers with decimal parts, or numbers serialized with exponential notation
   return str;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -69,7 +69,7 @@ function asmJsFunction (globalEnv, name, ret, args) { // eslint-disable-line req
   }
 
   // Add the required return statement at the end of the function
-  if (ret != "void" || rnd(2)) { s += asmReturnStatement("    ", env); }
+  if (ret !== "void" || rnd(2)) { s += asmReturnStatement("    ", env); }
 
   s += "  }\n";
 
@@ -109,7 +109,7 @@ function asmAssignmentStatement (indent, env) { // eslint-disable-line require-j
   }
 
   var local = Random.index(env.locals);
-  if (local.charAt(0) == "d") {
+  if (local.charAt(0) === "d") {
     return indent + local + " = " + doubleExpr(10, env) + ";\n";
   } else {
     return indent + local + " = " + intExpr(10, env) + ";\n";
@@ -118,9 +118,9 @@ function asmAssignmentStatement (indent, env) { // eslint-disable-line require-j
 
 function asmReturnStatement (indent, env) { // eslint-disable-line require-jsdoc
   var ret = rnd(2) ? env.ret : Random.index(["double", "signed", "void"]); // eslint-disable-line no-unused-vars
-  if (env.ret == "double") {
+  if (env.ret === "double") {
     return indent + "return +" + doublishExpr(10, env) + ";\n";
-  } else if (env.ret == "signed") {
+  } else if (env.ret === "signed") {
     return indent + "return (" + intishExpr(10, env) + ")|0;\n";
   } else { // (env.ret == "void")
     return indent + "return;\n";
@@ -146,7 +146,7 @@ function parameterTypeAnnotations (args) { // eslint-disable-line require-jsdoc
   var s = "";
   for (var a = 0; a < args.length; ++a) {
     var arg = args[a];
-    if (arg.charAt(0) == "i") { s += "    " + arg + " = " + arg + "|0;\n"; } else { s += "    " + arg + " = " + "+" + arg + ";\n"; }
+    if (arg.charAt(0) === "i") { s += "    " + arg + " = " + arg + "|0;\n"; } else { s += "    " + arg + " = " + "+" + arg + ";\n"; }
   }
   return s;
 }
@@ -305,7 +305,7 @@ function intVar (e) { // eslint-disable-line require-jsdoc
   var locals = e.locals;
   if (!locals.length) { return intLiteralRange(-0x8000000, 0xffffffff); }
   var local = Random.index(locals);
-  if (local.charAt(0) == "i") { return local; }
+  if (local.charAt(0) === "i") { return local; }
   return intLiteralRange(-0x8000000, 0xffffffff);
 }
 
@@ -313,7 +313,7 @@ function doubleVar (e) { // eslint-disable-line require-jsdoc
   var locals = e.locals;
   if (!locals.length) { return doubleLiteral(); }
   var local = Random.index(locals);
-  if (local.charAt(0) == "d") { return local; }
+  if (local.charAt(0) === "d") { return local; }
   return doubleLiteral();
 }
 
@@ -337,7 +337,7 @@ function positiveDoubleLiteral () { // eslint-disable-line require-jsdoc
   }
 
   var str = value + "";
-  if (str.indexOf(".") == -1) {
+  if (str.indexOf(".") === -1) {
     return str + ".0";
   }
   // Numbers with decimal parts, or numbers serialized with exponential notation

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -44,9 +44,9 @@ function asmJSInterior(foreignFunctions, sanePlease)
 function importForeign(foreignFunctions)
 {
   var s = "";
-  for (let h of foreignFunctions) {
+  for (let h of foreignFunctions) 
     s += "  var " + h + " = foreign." + h + ";\n";
-  }
+  
   return s;
 }
 
@@ -70,11 +70,11 @@ function asmJsFunction(globalEnv, name, ret, args)
   var env = {globalEnv: globalEnv, locals: locals, ret: ret};
 
   // Add assignment statements
-  if (locals.length) {
-    while (rnd(5)) {
+  if (locals.length) 
+    while (rnd(5)) 
       s += asmStatement("    ", env, 6);
-    }
-  }
+    
+  
 
   // Add the required return statement at the end of the function
   if (ret != "void" || rnd(2))
@@ -90,18 +90,18 @@ function asmStatement(indent, env, d)
   if (!env.globalEnv.sanePlease && rnd(100) === 0)
     return makeStatement(3, ["x"]);
 
-  if (rnd(5) === 0 && d > 0) {
+  if (rnd(5) === 0 && d > 0) 
     return indent + "{\n" + asmStatement(indent + "  ", env, d - 1) + indent + "}\n";
-  }
-  if (rnd(20) === 0 && d > 3) {
+  
+  if (rnd(20) === 0 && d > 3) 
     return asmSwitchStatement(indent, env, d);
-  }
-  if (rnd(10) === 0) {
+  
+  if (rnd(10) === 0) 
     return asmReturnStatement(indent, env);
-  }
-  if (rnd(50) === 0 && env.globalEnv.foreignFunctions.length) {
+  
+  if (rnd(50) === 0 && env.globalEnv.foreignFunctions.length) 
     return asmVoidCallStatement(indent, env);
-  }
+  
   if (rnd(100) === 0)
     return ";";
   return asmAssignmentStatement(indent, env);
@@ -114,20 +114,20 @@ function asmVoidCallStatement(indent, env)
 
 function asmAssignmentStatement(indent, env)
 {
-  if (rnd(5) === 0 || !env.locals.length) {
+  if (rnd(5) === 0 || !env.locals.length) 
     if (rnd(2)) {
       return indent + intishMemberExpr(8, env) + " = " + intishExpr(10, env) + ";\n";
     } else {
       return indent + doublishMemberExpr(8, env) + " = " + doublishExpr(10, env) + ";\n";
     }
-  }
+  
 
   var local = Random.index(env.locals);
-  if (local.charAt(0) == "d") {
+  if (local.charAt(0) == "d") 
     return indent + local + " = " + doubleExpr(10, env) + ";\n";
-  } else {
+  else 
     return indent + local + " = " + intExpr(10, env) + ";\n";
-  }
+  
 }
 
 function asmReturnStatement(indent, env)
@@ -382,24 +382,24 @@ function doubleLiteral()
 
 function positiveDoubleLiteral()
 {
-  if (rnd(3) === 0) {
+  if (rnd(3) === 0) 
     Random.index(["0.0", "1.0", "1.2345e60"]);
-  }
+  
 
   // A power of two
   var value = Math.pow(2, rnd(100) - 10);
 
   // One more or one less
-  if (rnd(3)) {
+  if (rnd(3)) 
     value += 1;
-  } else if (value > 1 && rnd(2)) {
+  else if (value > 1 && rnd(2)) 
     value -= 1;
-  }
+  
 
   var str = value + "";
-  if (str.indexOf(".") == -1) {
+  if (str.indexOf(".") == -1) 
     return str + ".0";
-  }
+  
   // Numbers with decimal parts, or numbers serialized with exponential notation
   return str;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -117,7 +117,7 @@ function asmAssignmentStatement (indent, env) { // eslint-disable-line require-j
 }
 
 function asmReturnStatement (indent, env) { // eslint-disable-line require-jsdoc
-  var ret = rnd(2) ? env.ret : Random.index(["double", "signed", "void"]);
+  var ret = rnd(2) ? env.ret : Random.index(["double", "signed", "void"]); // eslint-disable-line no-unused-vars
   if (env.ret == "double") { return indent + "return +" + doublishExpr(10, env) + ";\n"; } else if (env.ret == "signed") { return indent + "return (" + intishExpr(10, env) + ")|0;\n"; } else // (env.ret == "void")
   { return indent + "return;\n"; }
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -27,8 +27,11 @@ function asmJSInterior(foreignFunctions, sanePlease)
     return "";
   }
 
-  var globalEnv = {stdlibImported: {}, stdlibImports: "", heapImported: {}, heapImports: "", foreignFunctions: foreignFunctions, sanePlease: !!sanePlease};
-  var asmFunDecl = asmJsFunction(globalEnv, "f", rnd(2) ? "signed" : "double", [rnd(2) ? "i0" : "d0", rnd(2) ? "i1" : "d1"]);
+  var globalEnv = {stdlibImported: {}, stdlibImports: "", heapImported: {}, heapImports: "",
+    foreignFunctions: foreignFunctions, sanePlease: !!sanePlease};
+  var asmFunDecl = asmJsFunction(globalEnv, "f", rnd(2) ? "signed" : "double",
+    [rnd(2) ? "i0" : "d0", rnd(2) ? "i1" : "d1"]
+  );
   var interior = mess() + globalEnv.stdlibImports +
                  mess() + importForeign(foreignFunctions) +
                  mess() + globalEnv.heapImports +
@@ -184,9 +187,15 @@ var intExpr = autoExpr(Random.weighted([
   {w: 1,  v: function(d, e) { return unsignedExpr(d - 1, e); }},
   {w: 10, v: function(d, e) { return intVar(e); }}, // + "|0"  ??
   {w: 1,  v: function(d, e) { return e.globalEnv.foreignFunctions.length ? asmFfiCall(d, e) + "|0" : "1"; }},
-  {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + signedExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + unsignedExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return doubleExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + doubleExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + Random.index([
+    " < ", " <= ", " > ", " >= ", " == ", " != "
+  ]) + signedExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + Random.index([
+    " < ", " <= ", " > ", " >= ", " == ", " != "
+  ]) + unsignedExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return doubleExpr(d - 2, e) + Random.index([
+    " < ", " <= ", " > ", " >= ", " == ", " != "
+  ]) + doubleExpr(d - 2, e); }},
 ]));
 
 var intishExpr = autoExpr(Random.weighted([
@@ -194,7 +203,9 @@ var intishExpr = autoExpr(Random.weighted([
   {w: 1,  v: function(d, e) { return intishMemberExpr(d, e); }},
   // Add two or more ints
   {w: 10, v: function(d, e) { return intExpr(d - 1, e) + Random.index(additive) + intExpr(d - 1, e); }},
-  {w: 5,  v: function(d, e) { return intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e); }},
+  {w: 5,  v: function(d, e) { return intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e)
+        + Random.index(additive) + intExpr(d - 2, e);
+  }},
   // Multiply by a small int literal
   {w: 2,  v: function(d, e) { return intExpr(d - 1, e) + "*" + intLiteralRange(-0xfffff, 0xfffff); }},
   {w: 2,  v: function(d, e) { return intLiteralRange(-0xfffff, 0xfffff) + "*" + intExpr(d - 1, e); }},
@@ -209,10 +220,15 @@ var signedExpr = autoExpr(Random.weighted([
   {w: 1,  v: function(d, e) { return intLiteralRange(-0x8000000, 0x7fffffff); }},
   {w: 1,  v: function(d, e) { return "~" + intishExpr(d - 1, e); }},
   {w: 1,  v: function(d, e) { return "~~" + doubleExpr(d - 1, e); }},
-  {w: 1,  v: function(d, e) { return intishExpr(d - 1, e) + "|0"; }}, // this isn't a special form, but it's common for a good reason
-  {w: 1,  v: function(d, e) { return ensureMathImport(e, "imul") + "(" + intExpr(d - 2, e) + ", " + intExpr(d - 2, e) + ")|0"; }},
+  // The following line isn't a special form, but it's common for a good reason
+  {w: 1,  v: function(d, e) { return intishExpr(d - 1, e) + "|0"; }},
+  {w: 1,  v: function(d, e) { return ensureMathImport(e, "imul") + "(" + intExpr(d - 2, e) + ", "
+    + intExpr(d - 2, e) + ")|0";
+  }},
   {w: 1,  v: function(d, e) { return ensureMathImport(e, "abs") + "(" + signedExpr(d - 1, e) + ")|0"; }},
-  {w: 5,  v: function(d, e) { return intishExpr(d - 2, e) + Random.index([" | ", " & ", " ^ ", " << ", " >> "]) + intishExpr(d - 2, e); }},
+  {w: 5,  v: function(d, e) { return intishExpr(d - 2, e) + Random.index([" | ", " & ", " ^ ", " << ", " >> "])
+    + intishExpr(d - 2, e);
+  }},
 ]));
 
 var unsignedExpr = autoExpr(Random.weighted([
@@ -244,11 +260,15 @@ var doubleExpr = autoExpr(Random.weighted([
   {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " * " + doublishExpr(d - 2, e); }},
   {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " / " + doublishExpr(d - 2, e); }},
   {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " % " + doublishExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return intExpr(d - 3, e) + " ? " + doubleExpr(d - 3, e) + " : " + doubleExpr(d - 3, e); }},
+  {w: 1,  v: function(d, e) { return intExpr(d-3, e) + " ? " + doubleExpr(d-3, e) + " : " + doubleExpr(d-3, e); }},
   // with stdlib
-  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["acos", "asin", "atan", "cos", "sin", "tan", "ceil", "floor", "exp", "log", "sqrt"])) + "(" + doublishExpr(d - 1, e) + ")"; }},
+  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index([
+    "acos", "asin", "atan", "cos", "sin", "tan", "ceil", "floor", "exp", "log", "sqrt"
+  ])) + "(" + doublishExpr(d - 1, e) + ")"; }},
   {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, "abs") + "(" + doublishExpr(d - 1, e) + ")"; }},
-  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["atan2", "pow"])) + "(" + doublishExpr(d - 2, e) + ", " + doublishExpr(d - 2, e) + ")"; }},
+  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["atan2", "pow"]))
+    + "(" + doublishExpr(d - 2, e) + ", " + doublishExpr(d - 2, e) + ")";
+  }},
   {w: 1,  v: function(d, e) { return ensureImport(e, "Infinity"); }},
   {w: 1,  v: function(d, e) { return ensureImport(e, "NaN"); }},
 ]));
@@ -259,9 +279,12 @@ var externExpr = autoExpr(Random.weighted([
 ]));
 
 var intishMemberExpr = autoExpr(Random.weighted([
-  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int8Array",  "Uint8Array" ])) + "[" + asmIndex(d, e, 0) + "]"; }},
-  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int16Array", "Uint16Array"])) + "[" + asmIndex(d, e, 1) + "]"; }},
-  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int32Array", "Uint32Array"])) + "[" + asmIndex(d, e, 2) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int8Array",  "Uint8Array" ]))
+        + "[" + asmIndex(d, e, 0) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int16Array", "Uint16Array"]))
+        + "[" + asmIndex(d, e, 1) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int32Array", "Uint32Array"]))
+        + "[" + asmIndex(d, e, 2) + "]"; }},
 ]), true);
 
 var doublishMemberExpr = autoExpr(Random.weighted([

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported asmJSInterior */
 /* global makeExpr, makeStatement, Random, rnd, totallyRandom */
 
 /* *********************** *

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -118,8 +118,13 @@ function asmAssignmentStatement (indent, env) { // eslint-disable-line require-j
 
 function asmReturnStatement (indent, env) { // eslint-disable-line require-jsdoc
   var ret = rnd(2) ? env.ret : Random.index(["double", "signed", "void"]); // eslint-disable-line no-unused-vars
-  if (env.ret == "double") { return indent + "return +" + doublishExpr(10, env) + ";\n"; } else if (env.ret == "signed") { return indent + "return (" + intishExpr(10, env) + ")|0;\n"; } else // (env.ret == "void")
-  { return indent + "return;\n"; }
+  if (env.ret == "double") {
+    return indent + "return +" + doublishExpr(10, env) + ";\n";
+  } else if (env.ret == "signed") {
+    return indent + "return (" + intishExpr(10, env) + ")|0;\n";
+  } else { // (env.ret == "void")
+    return indent + "return;\n";
+  }
 }
 
 function asmSwitchStatement (indent, env, d) { // eslint-disable-line require-jsdoc

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -17,8 +17,8 @@
 // * function tables
 // * multiple exports
 
-function asmJSInterior (foreignFunctions, sanePlease) {
-  function mess () {
+function asmJSInterior (foreignFunctions, sanePlease) { // eslint-disable-line require-jsdoc
+  function mess () { // eslint-disable-line require-jsdoc
     if (!sanePlease && rnd(600) === 0) { return makeStatement(8, ["x"]) + "\n"; }
     if (!sanePlease && rnd(600) === 0) { return totallyRandom(8, ["x"]); }
     return "";
@@ -35,7 +35,7 @@ function asmJSInterior (foreignFunctions, sanePlease) {
   return interior;
 }
 
-function importForeign (foreignFunctions) {
+function importForeign (foreignFunctions) { // eslint-disable-line require-jsdoc
   var s = "";
   for (let h of foreignFunctions) {
     s += "  var " + h + " = foreign." + h + ";\n";
@@ -45,7 +45,7 @@ function importForeign (foreignFunctions) {
 
 // ret in ["signed", "double", "void"]
 // args looks like ["i0", "d1", "d2"] -- the first letter indicates int vs double
-function asmJsFunction (globalEnv, name, ret, args) {
+function asmJsFunction (globalEnv, name, ret, args) { // eslint-disable-line require-jsdoc
   var s = "  function " + name + "(" + args.join(", ") + ")\n";
   s += "  {\n";
   s += parameterTypeAnnotations(args);
@@ -76,7 +76,7 @@ function asmJsFunction (globalEnv, name, ret, args) {
   return s;
 }
 
-function asmStatement (indent, env, d) {
+function asmStatement (indent, env, d) { // eslint-disable-line require-jsdoc
   if (!env.globalEnv.sanePlease && rnd(100) === 0) { return makeStatement(3, ["x"]); }
 
   if (rnd(5) === 0 && d > 0) {
@@ -95,11 +95,11 @@ function asmStatement (indent, env, d) {
   return asmAssignmentStatement(indent, env);
 }
 
-function asmVoidCallStatement (indent, env) {
+function asmVoidCallStatement (indent, env) { // eslint-disable-line require-jsdoc
   return indent + asmFfiCall(8, env) + ";\n";
 }
 
-function asmAssignmentStatement (indent, env) {
+function asmAssignmentStatement (indent, env) { // eslint-disable-line require-jsdoc
   if (rnd(5) === 0 || !env.locals.length) {
     if (rnd(2)) {
       return indent + intishMemberExpr(8, env) + " = " + intishExpr(10, env) + ";\n";
@@ -116,13 +116,13 @@ function asmAssignmentStatement (indent, env) {
   }
 }
 
-function asmReturnStatement (indent, env) {
+function asmReturnStatement (indent, env) { // eslint-disable-line require-jsdoc
   var ret = rnd(2) ? env.ret : Random.index(["double", "signed", "void"]);
   if (env.ret == "double") { return indent + "return +" + doublishExpr(10, env) + ";\n"; } else if (env.ret == "signed") { return indent + "return (" + intishExpr(10, env) + ")|0;\n"; } else // (env.ret == "void")
   { return indent + "return;\n"; }
 }
 
-function asmSwitchStatement (indent, env, d) {
+function asmSwitchStatement (indent, env, d) { // eslint-disable-line require-jsdoc
   var s = indent + "switch (" + signedExpr(4, env) + ") {\n";
   while (rnd(3)) {
     s += indent + "  case " + (rnd(5) - 3) + ":\n";
@@ -137,7 +137,7 @@ function asmSwitchStatement (indent, env, d) {
   return s;
 }
 
-function parameterTypeAnnotations (args) {
+function parameterTypeAnnotations (args) { // eslint-disable-line require-jsdoc
   var s = "";
   for (var a = 0; a < args.length; ++a) {
     var arg = args[a];
@@ -246,13 +246,13 @@ var doublishMemberExpr = autoExpr(Random.weighted([
   { w: 1, v: function (d, e) { return ensureView(e, "Float64Array") + "[" + asmIndex(d, e, 3) + "]"; } }
 ]), true);
 
-function asmIndex (d, e, logSize) {
+function asmIndex (d, e, logSize) { // eslint-disable-line require-jsdoc
   if (rnd(2) || d < 2) { return Random.index(["0", "1", "2", "4096"]); }
 
   return intishExpr(d - 2, e) + " >> " + logSize;
 }
 
-function asmFfiCall (d, e) {
+function asmFfiCall (d, e) { // eslint-disable-line require-jsdoc
   var argList = "";
   while (rnd(6)) {
     if (argList) { argList += ", "; }
@@ -263,7 +263,7 @@ function asmFfiCall (d, e) {
   return "/*FFI*/" + Random.index(e.globalEnv.foreignFunctions) + "(" + argList + ")";
 }
 
-function ensureView (e, t) {
+function ensureView (e, t) { // eslint-disable-line require-jsdoc
   var varName = t + "View";
   if (!(varName in e.globalEnv.heapImported)) {
     e.globalEnv.heapImports += "  var " + varName + " = new stdlib." + t + "(heap);\n";
@@ -272,11 +272,11 @@ function ensureView (e, t) {
   return varName;
 }
 
-function ensureMathImport (e, f) {
+function ensureMathImport (e, f) { // eslint-disable-line require-jsdoc
   return ensureImport(e, f, "Math.");
 }
 
-function ensureImport (e, f, prefix) {
+function ensureImport (e, f, prefix) { // eslint-disable-line require-jsdoc
   if (!(f in e.globalEnv.stdlibImported)) {
     e.globalEnv.stdlibImports += "  var " + f + " = stdlib." + (prefix || "") + f + ";\n";
     e.globalEnv.stdlibImported[f] = true;
@@ -286,7 +286,7 @@ function ensureImport (e, f, prefix) {
 
 var anyAsmExpr = [intExpr, intishExpr, signedExpr, doublishExpr, doubleExpr, intishMemberExpr, doublishMemberExpr];
 
-function autoExpr (funs, avoidSubst) {
+function autoExpr (funs, avoidSubst) { // eslint-disable-line require-jsdoc
   return function (d, e) {
     var f = d < 1 ? funs[0] :
       rnd(50) === 0 && !e.globalEnv.sanePlease ? function (_d, _e) { return makeExpr(5, ["x"]); } :
@@ -296,7 +296,7 @@ function autoExpr (funs, avoidSubst) {
   };
 }
 
-function intVar (e) {
+function intVar (e) { // eslint-disable-line require-jsdoc
   var locals = e.locals;
   if (!locals.length) { return intLiteralRange(-0x8000000, 0xffffffff); }
   var local = Random.index(locals);
@@ -304,7 +304,7 @@ function intVar (e) {
   return intLiteralRange(-0x8000000, 0xffffffff);
 }
 
-function doubleVar (e) {
+function doubleVar (e) { // eslint-disable-line require-jsdoc
   var locals = e.locals;
   if (!locals.length) { return doubleLiteral(); }
   var local = Random.index(locals);
@@ -312,11 +312,11 @@ function doubleVar (e) {
   return doubleLiteral();
 }
 
-function doubleLiteral () {
+function doubleLiteral () { // eslint-disable-line require-jsdoc
   return Random.index(["-", ""]) + positiveDoubleLiteral();
 }
 
-function positiveDoubleLiteral () {
+function positiveDoubleLiteral () { // eslint-disable-line require-jsdoc
   if (rnd(3) === 0) {
     Random.index(["0.0", "1.0", "1.2345e60"]);
   }
@@ -339,7 +339,7 @@ function positiveDoubleLiteral () {
   return str;
 }
 
-function fuzzyRange (min, max) {
+function fuzzyRange (min, max) { // eslint-disable-line require-jsdoc
   if (rnd(10000) === 0) { return min - 1; }
   if (rnd(10000) === 0) { return max + 1; }
   if (rnd(10) === 0) { return min; }
@@ -350,7 +350,7 @@ function fuzzyRange (min, max) {
   return min + rnd(max - min + 1);
 }
 
-function intLiteralRange (min, max) {
+function intLiteralRange (min, max) { // eslint-disable-line require-jsdoc
   var val = fuzzyRange(min, max);
   var sign = val < 0 ? "-" : "";
   return sign + "0x" + Math.abs(val).toString(16);

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -27,11 +27,8 @@ function asmJSInterior(foreignFunctions, sanePlease)
     return "";
   }
 
-  var globalEnv = {stdlibImported: {}, stdlibImports: "", heapImported: {}, heapImports: "",
-    foreignFunctions: foreignFunctions, sanePlease: !!sanePlease};
-  var asmFunDecl = asmJsFunction(globalEnv, "f", rnd(2) ? "signed" : "double",
-    [rnd(2) ? "i0" : "d0", rnd(2) ? "i1" : "d1"]
-  );
+  var globalEnv = {stdlibImported: {}, stdlibImports: "", heapImported: {}, heapImports: "", foreignFunctions: foreignFunctions, sanePlease: !!sanePlease};
+  var asmFunDecl = asmJsFunction(globalEnv, "f", rnd(2) ? "signed" : "double", [rnd(2) ? "i0" : "d0", rnd(2) ? "i1" : "d1"]);
   var interior = mess() + globalEnv.stdlibImports +
                  mess() + importForeign(foreignFunctions) +
                  mess() + globalEnv.heapImports +
@@ -187,15 +184,9 @@ var intExpr = autoExpr(Random.weighted([
   {w: 1,  v: function(d, e) { return unsignedExpr(d - 1, e); }},
   {w: 10, v: function(d, e) { return intVar(e); }}, // + "|0"  ??
   {w: 1,  v: function(d, e) { return e.globalEnv.foreignFunctions.length ? asmFfiCall(d, e) + "|0" : "1"; }},
-  {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + Random.index([
-    " < ", " <= ", " > ", " >= ", " == ", " != "
-  ]) + signedExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + Random.index([
-    " < ", " <= ", " > ", " >= ", " == ", " != "
-  ]) + unsignedExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return doubleExpr(d - 2, e) + Random.index([
-    " < ", " <= ", " > ", " >= ", " == ", " != "
-  ]) + doubleExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + signedExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + unsignedExpr(d - 2, e); }},
+  {w: 1,  v: function(d, e) { return doubleExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + doubleExpr(d - 2, e); }},
 ]));
 
 var intishExpr = autoExpr(Random.weighted([
@@ -203,9 +194,7 @@ var intishExpr = autoExpr(Random.weighted([
   {w: 1,  v: function(d, e) { return intishMemberExpr(d, e); }},
   // Add two or more ints
   {w: 10, v: function(d, e) { return intExpr(d - 1, e) + Random.index(additive) + intExpr(d - 1, e); }},
-  {w: 5,  v: function(d, e) { return intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e)
-        + Random.index(additive) + intExpr(d - 2, e);
-  }},
+  {w: 5,  v: function(d, e) { return intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e); }},
   // Multiply by a small int literal
   {w: 2,  v: function(d, e) { return intExpr(d - 1, e) + "*" + intLiteralRange(-0xfffff, 0xfffff); }},
   {w: 2,  v: function(d, e) { return intLiteralRange(-0xfffff, 0xfffff) + "*" + intExpr(d - 1, e); }},
@@ -220,15 +209,10 @@ var signedExpr = autoExpr(Random.weighted([
   {w: 1,  v: function(d, e) { return intLiteralRange(-0x8000000, 0x7fffffff); }},
   {w: 1,  v: function(d, e) { return "~" + intishExpr(d - 1, e); }},
   {w: 1,  v: function(d, e) { return "~~" + doubleExpr(d - 1, e); }},
-  // The following line isn't a special form, but it's common for a good reason
-  {w: 1,  v: function(d, e) { return intishExpr(d - 1, e) + "|0"; }},
-  {w: 1,  v: function(d, e) { return ensureMathImport(e, "imul") + "(" + intExpr(d - 2, e) + ", "
-    + intExpr(d - 2, e) + ")|0";
-  }},
+  {w: 1,  v: function(d, e) { return intishExpr(d - 1, e) + "|0"; }}, // this isn't a special form, but it's common for a good reason
+  {w: 1,  v: function(d, e) { return ensureMathImport(e, "imul") + "(" + intExpr(d - 2, e) + ", " + intExpr(d - 2, e) + ")|0"; }},
   {w: 1,  v: function(d, e) { return ensureMathImport(e, "abs") + "(" + signedExpr(d - 1, e) + ")|0"; }},
-  {w: 5,  v: function(d, e) { return intishExpr(d - 2, e) + Random.index([" | ", " & ", " ^ ", " << ", " >> "])
-    + intishExpr(d - 2, e);
-  }},
+  {w: 5,  v: function(d, e) { return intishExpr(d - 2, e) + Random.index([" | ", " & ", " ^ ", " << ", " >> "]) + intishExpr(d - 2, e); }},
 ]));
 
 var unsignedExpr = autoExpr(Random.weighted([
@@ -260,15 +244,11 @@ var doubleExpr = autoExpr(Random.weighted([
   {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " * " + doublishExpr(d - 2, e); }},
   {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " / " + doublishExpr(d - 2, e); }},
   {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " % " + doublishExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return intExpr(d-3, e) + " ? " + doubleExpr(d-3, e) + " : " + doubleExpr(d-3, e); }},
+  {w: 1,  v: function(d, e) { return intExpr(d - 3, e) + " ? " + doubleExpr(d - 3, e) + " : " + doubleExpr(d - 3, e); }},
   // with stdlib
-  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index([
-    "acos", "asin", "atan", "cos", "sin", "tan", "ceil", "floor", "exp", "log", "sqrt"
-  ])) + "(" + doublishExpr(d - 1, e) + ")"; }},
+  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["acos", "asin", "atan", "cos", "sin", "tan", "ceil", "floor", "exp", "log", "sqrt"])) + "(" + doublishExpr(d - 1, e) + ")"; }},
   {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, "abs") + "(" + doublishExpr(d - 1, e) + ")"; }},
-  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["atan2", "pow"]))
-    + "(" + doublishExpr(d - 2, e) + ", " + doublishExpr(d - 2, e) + ")";
-  }},
+  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["atan2", "pow"])) + "(" + doublishExpr(d - 2, e) + ", " + doublishExpr(d - 2, e) + ")"; }},
   {w: 1,  v: function(d, e) { return ensureImport(e, "Infinity"); }},
   {w: 1,  v: function(d, e) { return ensureImport(e, "NaN"); }},
 ]));
@@ -279,12 +259,9 @@ var externExpr = autoExpr(Random.weighted([
 ]));
 
 var intishMemberExpr = autoExpr(Random.weighted([
-  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int8Array",  "Uint8Array" ]))
-        + "[" + asmIndex(d, e, 0) + "]"; }},
-  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int16Array", "Uint16Array"]))
-        + "[" + asmIndex(d, e, 1) + "]"; }},
-  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int32Array", "Uint32Array"]))
-        + "[" + asmIndex(d, e, 2) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int8Array",  "Uint8Array" ])) + "[" + asmIndex(d, e, 0) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int16Array", "Uint16Array"])) + "[" + asmIndex(d, e, 1) + "]"; }},
+  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int32Array", "Uint32Array"])) + "[" + asmIndex(d, e, 2) + "]"; }},
 ]), true);
 
 var doublishMemberExpr = autoExpr(Random.weighted([

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -69,7 +69,7 @@ function asmJsFunction (globalEnv, name, ret, args) { // eslint-disable-line req
   }
 
   // Add the required return statement at the end of the function
-  if (ret !== "void" || rnd(2)) { s += asmReturnStatement("    ", env); }
+  if (ret != "void" || rnd(2)) { s += asmReturnStatement("    ", env); }
 
   s += "  }\n";
 
@@ -109,7 +109,7 @@ function asmAssignmentStatement (indent, env) { // eslint-disable-line require-j
   }
 
   var local = Random.index(env.locals);
-  if (local.charAt(0) === "d") {
+  if (local.charAt(0) == "d") {
     return indent + local + " = " + doubleExpr(10, env) + ";\n";
   } else {
     return indent + local + " = " + intExpr(10, env) + ";\n";
@@ -118,9 +118,9 @@ function asmAssignmentStatement (indent, env) { // eslint-disable-line require-j
 
 function asmReturnStatement (indent, env) { // eslint-disable-line require-jsdoc
   var ret = rnd(2) ? env.ret : Random.index(["double", "signed", "void"]); // eslint-disable-line no-unused-vars
-  if (env.ret === "double") {
+  if (env.ret == "double") {
     return indent + "return +" + doublishExpr(10, env) + ";\n";
-  } else if (env.ret === "signed") {
+  } else if (env.ret == "signed") {
     return indent + "return (" + intishExpr(10, env) + ")|0;\n";
   } else { // (env.ret == "void")
     return indent + "return;\n";
@@ -146,7 +146,7 @@ function parameterTypeAnnotations (args) { // eslint-disable-line require-jsdoc
   var s = "";
   for (var a = 0; a < args.length; ++a) {
     var arg = args[a];
-    if (arg.charAt(0) === "i") { s += "    " + arg + " = " + arg + "|0;\n"; } else { s += "    " + arg + " = " + "+" + arg + ";\n"; }
+    if (arg.charAt(0) == "i") { s += "    " + arg + " = " + arg + "|0;\n"; } else { s += "    " + arg + " = " + "+" + arg + ";\n"; }
   }
   return s;
 }
@@ -305,7 +305,7 @@ function intVar (e) { // eslint-disable-line require-jsdoc
   var locals = e.locals;
   if (!locals.length) { return intLiteralRange(-0x8000000, 0xffffffff); }
   var local = Random.index(locals);
-  if (local.charAt(0) === "i") { return local; }
+  if (local.charAt(0) == "i") { return local; }
   return intLiteralRange(-0x8000000, 0xffffffff);
 }
 
@@ -313,7 +313,7 @@ function doubleVar (e) { // eslint-disable-line require-jsdoc
   var locals = e.locals;
   if (!locals.length) { return doubleLiteral(); }
   var local = Random.index(locals);
-  if (local.charAt(0) === "d") { return local; }
+  if (local.charAt(0) == "d") { return local; }
   return doubleLiteral();
 }
 
@@ -337,7 +337,7 @@ function positiveDoubleLiteral () { // eslint-disable-line require-jsdoc
   }
 
   var str = value + "";
-  if (str.indexOf(".") === -1) {
+  if (str.indexOf(".") == -1) {
     return str + ".0";
   }
   // Numbers with decimal parts, or numbers serialized with exponential notation

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -17,18 +17,14 @@
 // * function tables
 // * multiple exports
 
-function asmJSInterior(foreignFunctions, sanePlease)
-{
-  function mess()
-  {
-    if (!sanePlease && rnd(600) === 0)
-      return makeStatement(8, ["x"]) + "\n";
-    if (!sanePlease && rnd(600) === 0)
-      return totallyRandom(8, ["x"]);
+function asmJSInterior (foreignFunctions, sanePlease) {
+  function mess () {
+    if (!sanePlease && rnd(600) === 0) { return makeStatement(8, ["x"]) + "\n"; }
+    if (!sanePlease && rnd(600) === 0) { return totallyRandom(8, ["x"]); }
     return "";
   }
 
-  var globalEnv = {stdlibImported: {}, stdlibImports: "", heapImported: {}, heapImports: "", foreignFunctions: foreignFunctions, sanePlease: !!sanePlease};
+  var globalEnv = { stdlibImported: {}, stdlibImports: "", heapImported: {}, heapImports: "", foreignFunctions: foreignFunctions, sanePlease: !!sanePlease };
   var asmFunDecl = asmJsFunction(globalEnv, "f", rnd(2) ? "signed" : "double", [rnd(2) ? "i0" : "d0", rnd(2) ? "i1" : "d1"]);
   var interior = mess() + globalEnv.stdlibImports +
                  mess() + importForeign(foreignFunctions) +
@@ -39,8 +35,7 @@ function asmJSInterior(foreignFunctions, sanePlease)
   return interior;
 }
 
-function importForeign(foreignFunctions)
-{
+function importForeign (foreignFunctions) {
   var s = "";
   for (let h of foreignFunctions) {
     s += "  var " + h + " = foreign." + h + ";\n";
@@ -50,8 +45,7 @@ function importForeign(foreignFunctions)
 
 // ret in ["signed", "double", "void"]
 // args looks like ["i0", "d1", "d2"] -- the first letter indicates int vs double
-function asmJsFunction(globalEnv, name, ret, args)
-{
+function asmJsFunction (globalEnv, name, ret, args) {
   var s = "  function " + name + "(" + args.join(", ") + ")\n";
   s += "  {\n";
   s += parameterTypeAnnotations(args);
@@ -65,7 +59,7 @@ function asmJsFunction(globalEnv, name, ret, args)
     locals.push(local);
   }
 
-  var env = {globalEnv: globalEnv, locals: locals, ret: ret};
+  var env = { globalEnv: globalEnv, locals: locals, ret: ret };
 
   // Add assignment statements
   if (locals.length) {
@@ -75,18 +69,15 @@ function asmJsFunction(globalEnv, name, ret, args)
   }
 
   // Add the required return statement at the end of the function
-  if (ret != "void" || rnd(2))
-    s += asmReturnStatement("    ", env);
+  if (ret != "void" || rnd(2)) { s += asmReturnStatement("    ", env); }
 
   s += "  }\n";
 
   return s;
 }
 
-function asmStatement(indent, env, d)
-{
-  if (!env.globalEnv.sanePlease && rnd(100) === 0)
-    return makeStatement(3, ["x"]);
+function asmStatement (indent, env, d) {
+  if (!env.globalEnv.sanePlease && rnd(100) === 0) { return makeStatement(3, ["x"]); }
 
   if (rnd(5) === 0 && d > 0) {
     return indent + "{\n" + asmStatement(indent + "  ", env, d - 1) + indent + "}\n";
@@ -100,18 +91,15 @@ function asmStatement(indent, env, d)
   if (rnd(50) === 0 && env.globalEnv.foreignFunctions.length) {
     return asmVoidCallStatement(indent, env);
   }
-  if (rnd(100) === 0)
-    return ";";
+  if (rnd(100) === 0) { return ";"; }
   return asmAssignmentStatement(indent, env);
 }
 
-function asmVoidCallStatement(indent, env)
-{
+function asmVoidCallStatement (indent, env) {
   return indent + asmFfiCall(8, env) + ";\n";
 }
 
-function asmAssignmentStatement(indent, env)
-{
+function asmAssignmentStatement (indent, env) {
   if (rnd(5) === 0 || !env.locals.length) {
     if (rnd(2)) {
       return indent + intishMemberExpr(8, env) + " = " + intishExpr(10, env) + ";\n";
@@ -128,25 +116,18 @@ function asmAssignmentStatement(indent, env)
   }
 }
 
-function asmReturnStatement(indent, env)
-{
+function asmReturnStatement (indent, env) {
   var ret = rnd(2) ? env.ret : Random.index(["double", "signed", "void"]);
-  if (env.ret == "double")
-    return indent + "return +" + doublishExpr(10, env) + ";\n";
-  else if (env.ret == "signed")
-    return indent + "return (" + intishExpr(10, env) + ")|0;\n";
-  else // (env.ret == "void")
-    return indent + "return;\n";
+  if (env.ret == "double") { return indent + "return +" + doublishExpr(10, env) + ";\n"; } else if (env.ret == "signed") { return indent + "return (" + intishExpr(10, env) + ")|0;\n"; } else // (env.ret == "void")
+  { return indent + "return;\n"; }
 }
 
-function asmSwitchStatement(indent, env, d)
-{
+function asmSwitchStatement (indent, env, d) {
   var s = indent + "switch (" + signedExpr(4, env) + ") {\n";
   while (rnd(3)) {
-    s += indent + "  case " + (rnd(5)-3) + ":\n";
+    s += indent + "  case " + (rnd(5) - 3) + ":\n";
     s += asmStatement(indent + "    ", env, d - 2);
-    if (rnd(4))
-      s += indent + "    break;\n";
+    if (rnd(4)) { s += indent + "    break;\n"; }
   }
   if (rnd(2)) {
     s += indent + "  default:\n";
@@ -156,19 +137,14 @@ function asmSwitchStatement(indent, env, d)
   return s;
 }
 
-function parameterTypeAnnotations(args)
-{
+function parameterTypeAnnotations (args) {
   var s = "";
   for (var a = 0; a < args.length; ++a) {
     var arg = args[a];
-    if (arg.charAt(0) == "i")
-      s += "    " + arg + " = " + arg + "|0;\n";
-    else
-      s += "    " + arg + " = " + "+" + arg + ";\n";
+    if (arg.charAt(0) == "i") { s += "    " + arg + " = " + arg + "|0;\n"; } else { s += "    " + arg + " = " + "+" + arg + ";\n"; }
   }
   return s;
 }
-
 
 var additive = ["+", "-"];
 
@@ -178,112 +154,108 @@ var additive = ["+", "-"];
 // * We're allowed to write to some fields of |e|
 
 var intExpr = autoExpr(Random.weighted([
-  {w: 1,  v: function(d, e) { return intLiteralRange(-0x8000000, 0xffffffff); }},
-  {w: 1,  v: function(d, e) { return intExpr(d - 3, e) + " ? " + intExpr(d - 3, e) + " : " + intExpr(d - 3, e); }},
-  {w: 1,  v: function(d, e) { return "!" + intExpr(d - 1, e); }},
-  {w: 1,  v: function(d, e) { return signedExpr(d - 1, e); }},
-  {w: 1,  v: function(d, e) { return unsignedExpr(d - 1, e); }},
-  {w: 10, v: function(d, e) { return intVar(e); }}, // + "|0"  ??
-  {w: 1,  v: function(d, e) { return e.globalEnv.foreignFunctions.length ? asmFfiCall(d, e) + "|0" : "1"; }},
-  {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + signedExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + unsignedExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return doubleExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + doubleExpr(d - 2, e); }},
+  { w: 1, v: function (d, e) { return intLiteralRange(-0x8000000, 0xffffffff); } },
+  { w: 1, v: function (d, e) { return intExpr(d - 3, e) + " ? " + intExpr(d - 3, e) + " : " + intExpr(d - 3, e); } },
+  { w: 1, v: function (d, e) { return "!" + intExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return signedExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return unsignedExpr(d - 1, e); } },
+  { w: 10, v: function (d, e) { return intVar(e); } }, // + "|0"  ??
+  { w: 1, v: function (d, e) { return e.globalEnv.foreignFunctions.length ? asmFfiCall(d, e) + "|0" : "1"; } },
+  { w: 1, v: function (d, e) { return signedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + signedExpr(d - 2, e); } },
+  { w: 1, v: function (d, e) { return unsignedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + unsignedExpr(d - 2, e); } },
+  { w: 1, v: function (d, e) { return doubleExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + doubleExpr(d - 2, e); } }
 ]));
 
 var intishExpr = autoExpr(Random.weighted([
-  {w: 10, v: function(d, e) { return intExpr(d, e); }},
-  {w: 1,  v: function(d, e) { return intishMemberExpr(d, e); }},
+  { w: 10, v: function (d, e) { return intExpr(d, e); } },
+  { w: 1, v: function (d, e) { return intishMemberExpr(d, e); } },
   // Add two or more ints
-  {w: 10, v: function(d, e) { return intExpr(d - 1, e) + Random.index(additive) + intExpr(d - 1, e); }},
-  {w: 5,  v: function(d, e) { return intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e); }},
+  { w: 10, v: function (d, e) { return intExpr(d - 1, e) + Random.index(additive) + intExpr(d - 1, e); } },
+  { w: 5, v: function (d, e) { return intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e); } },
   // Multiply by a small int literal
-  {w: 2,  v: function(d, e) { return intExpr(d - 1, e) + "*" + intLiteralRange(-0xfffff, 0xfffff); }},
-  {w: 2,  v: function(d, e) { return intLiteralRange(-0xfffff, 0xfffff) + "*" + intExpr(d - 1, e); }},
-  {w: 1,  v: function(d, e) { return "-" + intExpr(d - 1, e); }},
-  {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + " / " + signedExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + " / " + unsignedExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return signedExpr(d - 2, e) + " % " + signedExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return unsignedExpr(d - 2, e) + " % " + unsignedExpr(d - 2, e); }},
+  { w: 2, v: function (d, e) { return intExpr(d - 1, e) + "*" + intLiteralRange(-0xfffff, 0xfffff); } },
+  { w: 2, v: function (d, e) { return intLiteralRange(-0xfffff, 0xfffff) + "*" + intExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return "-" + intExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return signedExpr(d - 2, e) + " / " + signedExpr(d - 2, e); } },
+  { w: 1, v: function (d, e) { return unsignedExpr(d - 2, e) + " / " + unsignedExpr(d - 2, e); } },
+  { w: 1, v: function (d, e) { return signedExpr(d - 2, e) + " % " + signedExpr(d - 2, e); } },
+  { w: 1, v: function (d, e) { return unsignedExpr(d - 2, e) + " % " + unsignedExpr(d - 2, e); } }
 ]));
 
 var signedExpr = autoExpr(Random.weighted([
-  {w: 1,  v: function(d, e) { return intLiteralRange(-0x8000000, 0x7fffffff); }},
-  {w: 1,  v: function(d, e) { return "~" + intishExpr(d - 1, e); }},
-  {w: 1,  v: function(d, e) { return "~~" + doubleExpr(d - 1, e); }},
-  {w: 1,  v: function(d, e) { return intishExpr(d - 1, e) + "|0"; }}, // this isn't a special form, but it's common for a good reason
-  {w: 1,  v: function(d, e) { return ensureMathImport(e, "imul") + "(" + intExpr(d - 2, e) + ", " + intExpr(d - 2, e) + ")|0"; }},
-  {w: 1,  v: function(d, e) { return ensureMathImport(e, "abs") + "(" + signedExpr(d - 1, e) + ")|0"; }},
-  {w: 5,  v: function(d, e) { return intishExpr(d - 2, e) + Random.index([" | ", " & ", " ^ ", " << ", " >> "]) + intishExpr(d - 2, e); }},
+  { w: 1, v: function (d, e) { return intLiteralRange(-0x8000000, 0x7fffffff); } },
+  { w: 1, v: function (d, e) { return "~" + intishExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return "~~" + doubleExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return intishExpr(d - 1, e) + "|0"; } }, // this isn't a special form, but it's common for a good reason
+  { w: 1, v: function (d, e) { return ensureMathImport(e, "imul") + "(" + intExpr(d - 2, e) + ", " + intExpr(d - 2, e) + ")|0"; } },
+  { w: 1, v: function (d, e) { return ensureMathImport(e, "abs") + "(" + signedExpr(d - 1, e) + ")|0"; } },
+  { w: 5, v: function (d, e) { return intishExpr(d - 2, e) + Random.index([" | ", " & ", " ^ ", " << ", " >> "]) + intishExpr(d - 2, e); } }
 ]));
 
 var unsignedExpr = autoExpr(Random.weighted([
-  {w: 1,  v: function(d, e) { return intLiteralRange(0, 0xffffffff); }},
-  {w: 1,  v: function(d, e) { return intishExpr(d - 2, e) + ">>>" + intishExpr(d - 2, e); }},
+  { w: 1, v: function (d, e) { return intLiteralRange(0, 0xffffffff); } },
+  { w: 1, v: function (d, e) { return intishExpr(d - 2, e) + ">>>" + intishExpr(d - 2, e); } }
 ]));
 
 var doublishExpr = autoExpr(Random.weighted([
-  {w: 10, v: function(d, e) { return doubleExpr(d, e); }},
-  {w: 1,  v: function(d, e) { return doublishMemberExpr(d, e); }},
+  { w: 10, v: function (d, e) { return doubleExpr(d, e); } },
+  { w: 1, v: function (d, e) { return doublishMemberExpr(d, e); } }
   // Read from a doublish typed array view
 ]));
 
 var doubleExpr = autoExpr(Random.weighted([
-  {w: 1,  v: function(d, e) { return doubleLiteral(); }},
-  {w: 20, v: function(d, e) { return doubleVar(e); }},
-  {w: 1,  v: function(d, e) { return e.globalEnv.foreignFunctions.length ? "+" + asmFfiCall(d, e) : "1.0"; }},
-  {w: 1,  v: function(d, e) { return "+(1.0/0.0)"; }},
-  {w: 1,  v: function(d, e) { return "+(0.0/0.0)"; }},
-  {w: 1,  v: function(d, e) { return "+(-1.0/0.0)"; }},
+  { w: 1, v: function (d, e) { return doubleLiteral(); } },
+  { w: 20, v: function (d, e) { return doubleVar(e); } },
+  { w: 1, v: function (d, e) { return e.globalEnv.foreignFunctions.length ? "+" + asmFfiCall(d, e) : "1.0"; } },
+  { w: 1, v: function (d, e) { return "+(1.0/0.0)"; } },
+  { w: 1, v: function (d, e) { return "+(0.0/0.0)"; } },
+  { w: 1, v: function (d, e) { return "+(-1.0/0.0)"; } },
   // Unary ops that return double
-  {w: 1,  v: function(d, e) { return "+" + signedExpr(d - 1, e); }},
-  {w: 1,  v: function(d, e) { return "+" + unsignedExpr(d - 1, e); }},
-  {w: 1,  v: function(d, e) { return "+" + doublishExpr(d - 1, e); }},
-  {w: 1,  v: function(d, e) { return "-" + doublishExpr(d - 1, e); }},
+  { w: 1, v: function (d, e) { return "+" + signedExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return "+" + unsignedExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return "+" + doublishExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return "-" + doublishExpr(d - 1, e); } },
   // Binary ops that return double
-  {w: 1,  v: function(d, e) { return doubleExpr(d - 2, e) + " + " + doubleExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " - " + doublishExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " * " + doublishExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " / " + doublishExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return doublishExpr(d - 2, e) + " % " + doublishExpr(d - 2, e); }},
-  {w: 1,  v: function(d, e) { return intExpr(d - 3, e) + " ? " + doubleExpr(d - 3, e) + " : " + doubleExpr(d - 3, e); }},
+  { w: 1, v: function (d, e) { return doubleExpr(d - 2, e) + " + " + doubleExpr(d - 2, e); } },
+  { w: 1, v: function (d, e) { return doublishExpr(d - 2, e) + " - " + doublishExpr(d - 2, e); } },
+  { w: 1, v: function (d, e) { return doublishExpr(d - 2, e) + " * " + doublishExpr(d - 2, e); } },
+  { w: 1, v: function (d, e) { return doublishExpr(d - 2, e) + " / " + doublishExpr(d - 2, e); } },
+  { w: 1, v: function (d, e) { return doublishExpr(d - 2, e) + " % " + doublishExpr(d - 2, e); } },
+  { w: 1, v: function (d, e) { return intExpr(d - 3, e) + " ? " + doubleExpr(d - 3, e) + " : " + doubleExpr(d - 3, e); } },
   // with stdlib
-  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["acos", "asin", "atan", "cos", "sin", "tan", "ceil", "floor", "exp", "log", "sqrt"])) + "(" + doublishExpr(d - 1, e) + ")"; }},
-  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, "abs") + "(" + doublishExpr(d - 1, e) + ")"; }},
-  {w: 1,  v: function(d, e) { return "+" + ensureMathImport(e, Random.index(["atan2", "pow"])) + "(" + doublishExpr(d - 2, e) + ", " + doublishExpr(d - 2, e) + ")"; }},
-  {w: 1,  v: function(d, e) { return ensureImport(e, "Infinity"); }},
-  {w: 1,  v: function(d, e) { return ensureImport(e, "NaN"); }},
+  { w: 1, v: function (d, e) { return "+" + ensureMathImport(e, Random.index(["acos", "asin", "atan", "cos", "sin", "tan", "ceil", "floor", "exp", "log", "sqrt"])) + "(" + doublishExpr(d - 1, e) + ")"; } },
+  { w: 1, v: function (d, e) { return "+" + ensureMathImport(e, "abs") + "(" + doublishExpr(d - 1, e) + ")"; } },
+  { w: 1, v: function (d, e) { return "+" + ensureMathImport(e, Random.index(["atan2", "pow"])) + "(" + doublishExpr(d - 2, e) + ", " + doublishExpr(d - 2, e) + ")"; } },
+  { w: 1, v: function (d, e) { return ensureImport(e, "Infinity"); } },
+  { w: 1, v: function (d, e) { return ensureImport(e, "NaN"); } }
 ]));
 
 var externExpr = autoExpr(Random.weighted([
-  {w: 1,  v: function(d, e) { return doubleExpr(d, e); } },
-  {w: 1,  v: function(d, e) { return signedExpr(d, e); } },
+  { w: 1, v: function (d, e) { return doubleExpr(d, e); } },
+  { w: 1, v: function (d, e) { return signedExpr(d, e); } }
 ]));
 
 var intishMemberExpr = autoExpr(Random.weighted([
-  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int8Array",  "Uint8Array" ])) + "[" + asmIndex(d, e, 0) + "]"; }},
-  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int16Array", "Uint16Array"])) + "[" + asmIndex(d, e, 1) + "]"; }},
-  {w: 1,  v: function(d, e) { return ensureView(e, Random.index(["Int32Array", "Uint32Array"])) + "[" + asmIndex(d, e, 2) + "]"; }},
+  { w: 1, v: function (d, e) { return ensureView(e, Random.index(["Int8Array", "Uint8Array" ])) + "[" + asmIndex(d, e, 0) + "]"; } },
+  { w: 1, v: function (d, e) { return ensureView(e, Random.index(["Int16Array", "Uint16Array"])) + "[" + asmIndex(d, e, 1) + "]"; } },
+  { w: 1, v: function (d, e) { return ensureView(e, Random.index(["Int32Array", "Uint32Array"])) + "[" + asmIndex(d, e, 2) + "]"; } }
 ]), true);
 
 var doublishMemberExpr = autoExpr(Random.weighted([
-  {w: 1,  v: function(d, e) { return ensureView(e, "Float32Array") + "[" + asmIndex(d, e, 2) + "]"; }},
-  {w: 1,  v: function(d, e) { return ensureView(e, "Float64Array") + "[" + asmIndex(d, e, 3) + "]"; }},
+  { w: 1, v: function (d, e) { return ensureView(e, "Float32Array") + "[" + asmIndex(d, e, 2) + "]"; } },
+  { w: 1, v: function (d, e) { return ensureView(e, "Float64Array") + "[" + asmIndex(d, e, 3) + "]"; } }
 ]), true);
 
-function asmIndex(d, e, logSize)
-{
-  if (rnd(2) || d < 2)
-    return Random.index(["0", "1", "2", "4096"]);
+function asmIndex (d, e, logSize) {
+  if (rnd(2) || d < 2) { return Random.index(["0", "1", "2", "4096"]); }
 
   return intishExpr(d - 2, e) + " >> " + logSize;
 }
 
-function asmFfiCall(d, e)
-{
+function asmFfiCall (d, e) {
   var argList = "";
   while (rnd(6)) {
-    if (argList)
-      argList += ", ";
+    if (argList) { argList += ", "; }
     d -= 1;
     argList += externExpr(d, e);
   }
@@ -291,9 +263,7 @@ function asmFfiCall(d, e)
   return "/*FFI*/" + Random.index(e.globalEnv.foreignFunctions) + "(" + argList + ")";
 }
 
-
-function ensureView(e, t)
-{
+function ensureView (e, t) {
   var varName = t + "View";
   if (!(varName in e.globalEnv.heapImported)) {
     e.globalEnv.heapImports += "  var " + varName + " = new stdlib." + t + "(heap);\n";
@@ -302,64 +272,51 @@ function ensureView(e, t)
   return varName;
 }
 
-function ensureMathImport(e, f)
-{
+function ensureMathImport (e, f) {
   return ensureImport(e, f, "Math.");
 }
 
-function ensureImport(e, f, prefix)
-{
+function ensureImport (e, f, prefix) {
   if (!(f in e.globalEnv.stdlibImported)) {
-    e.globalEnv.stdlibImports += "  var " + f + " = stdlib." + (prefix||"") + f + ";\n";
+    e.globalEnv.stdlibImports += "  var " + f + " = stdlib." + (prefix || "") + f + ";\n";
     e.globalEnv.stdlibImported[f] = true;
   }
   return f;
 }
 
-
 var anyAsmExpr = [intExpr, intishExpr, signedExpr, doublishExpr, doubleExpr, intishMemberExpr, doublishMemberExpr];
 
-function autoExpr(funs, avoidSubst)
-{
-  return function(d, e) {
+function autoExpr (funs, avoidSubst) {
+  return function (d, e) {
     var f = d < 1 ? funs[0] :
-      rnd(50) === 0 && !e.globalEnv.sanePlease ? function(_d, _e) { return makeExpr(5, ["x"]); } :
+      rnd(50) === 0 && !e.globalEnv.sanePlease ? function (_d, _e) { return makeExpr(5, ["x"]); } :
         rnd(50) === 0 && !avoidSubst ? Random.index(anyAsmExpr) :
           Random.index(funs);
     return "(" + f(d, e) + ")";
   };
 }
 
-function intVar(e)
-{
+function intVar (e) {
   var locals = e.locals;
-  if (!locals.length)
-    return intLiteralRange(-0x8000000, 0xffffffff);
+  if (!locals.length) { return intLiteralRange(-0x8000000, 0xffffffff); }
   var local = Random.index(locals);
-  if (local.charAt(0) == "i")
-    return local;
+  if (local.charAt(0) == "i") { return local; }
   return intLiteralRange(-0x8000000, 0xffffffff);
 }
 
-function doubleVar(e)
-{
+function doubleVar (e) {
   var locals = e.locals;
-  if (!locals.length)
-    return doubleLiteral();
+  if (!locals.length) { return doubleLiteral(); }
   var local = Random.index(locals);
-  if (local.charAt(0) == "d")
-    return local;
+  if (local.charAt(0) == "d") { return local; }
   return doubleLiteral();
 }
 
-
-function doubleLiteral()
-{
+function doubleLiteral () {
   return Random.index(["-", ""]) + positiveDoubleLiteral();
 }
 
-function positiveDoubleLiteral()
-{
+function positiveDoubleLiteral () {
   if (rnd(3) === 0) {
     Random.index(["0.0", "1.0", "1.2345e60"]);
   }
@@ -382,28 +339,19 @@ function positiveDoubleLiteral()
   return str;
 }
 
-function fuzzyRange(min, max)
-{
-  if (rnd(10000) === 0)
-    return min - 1;
-  if (rnd(10000) === 0)
-    return max + 1;
-  if (rnd(10) === 0)
-    return min;
-  if (rnd(10) === 0)
-    return max;
+function fuzzyRange (min, max) {
+  if (rnd(10000) === 0) { return min - 1; }
+  if (rnd(10000) === 0) { return max + 1; }
+  if (rnd(10) === 0) { return min; }
+  if (rnd(10) === 0) { return max; }
 
   // rnd() is limited to 2^32. (It also skews toward lower numbers, oh well.)
-  if (max > min + 0x100000000 && rnd(3) === 0)
-    return min + 0x100000000 + rnd(max - (min + 0x100000000) + 1);
+  if (max > min + 0x100000000 && rnd(3) === 0) { return min + 0x100000000 + rnd(max - (min + 0x100000000) + 1); }
   return min + rnd(max - min + 1);
 }
 
-function intLiteralRange(min, max)
-{
+function intLiteralRange (min, max) {
   var val = fuzzyRange(min, max);
   var sign = val < 0 ? "-" : "";
   return sign + "0x" + Math.abs(val).toString(16);
 }
-
-

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -241,7 +241,7 @@ var externExpr = autoExpr(Random.weighted([
 ]));
 
 var intishMemberExpr = autoExpr(Random.weighted([
-  { w: 1, v: function (d, e) { return ensureView(e, Random.index(["Int8Array", "Uint8Array" ])) + "[" + asmIndex(d, e, 0) + "]"; } },
+  { w: 1, v: function (d, e) { return ensureView(e, Random.index(["Int8Array", "Uint8Array"])) + "[" + asmIndex(d, e, 0) + "]"; } },
   { w: 1, v: function (d, e) { return ensureView(e, Random.index(["Int16Array", "Uint16Array"])) + "[" + asmIndex(d, e, 1) + "]"; } },
   { w: 1, v: function (d, e) { return ensureView(e, Random.index(["Int32Array", "Uint32Array"])) + "[" + asmIndex(d, e, 2) + "]"; } }
 ]), true);

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -5,9 +5,9 @@
 
 /* global makeExpr, makeStatement, Random, rnd, totallyRandom */
 
-/***************************
+/* *********************** *
  * GENERATE ASM.JS MODULES *
- ***************************/
+ * *********************** */
 
 // Not yet tested:
 // * loops (avoiding hangs with special forms, counters, and/or not executing)

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -172,17 +172,25 @@ var statementMakers = Random.weighted([
   { w: 15, v: function(d, b) { return cat([makeStatement(d - 1, b),       makeStatement(d - 1, b)      ]); } },
   { w: 15, v: function(d, b) { return cat([makeStatement(d - 1, b), "\n", makeStatement(d - 1, b), "\n"]); } },
 
-  // Stripping semilcolons.  What happens if semicolons are missing?  Especially with line breaks used in place of semicolons (semicolon insertion).
+  // Stripping semicolons.  What happens if semicolons are missing?
+  // Especially with line breaks used in place of semicolons (semicolon insertion).
   { w: 1, v: function(d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n", makeStatement(d, b)]); } },
   { w: 1, v: function(d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n"                   ]); } },
-  { w: 1, v: function(d, b) { return stripSemicolon(makeStatement(d, b)); } }, // usually invalid, but can be ok e.g. at the end of a block with curly braces
+  // usually invalid, but can be ok e.g. at the end of a block with curly braces
+  { w: 1, v: function(d, b) { return stripSemicolon(makeStatement(d, b)); } },
 
   // Simple variable declarations, followed (or preceded) by statements using those variables
-  { w: 4, v: function(d, b) { var v = makeNewId(d, b); return cat([Random.index(varBinder), v, " = ", makeExpr(d, b), ";", makeStatement(d - 1, b.concat([v]))]); } },
-  { w: 4, v: function(d, b) { var v = makeNewId(d, b); return cat([makeStatement(d - 1, b.concat([v])), Random.index(varBinder), v, " = ", makeExpr(d, b), ";"]); } },
+  { w: 4, v: function(d, b) { var v = makeNewId(d, b); return cat([
+    Random.index(varBinder), v, " = ", makeExpr(d, b), ";", makeStatement(d - 1, b.concat([v]))
+  ]); } },
+  { w: 4, v: function(d, b) { var v = makeNewId(d, b); return cat([
+    makeStatement(d - 1, b.concat([v])), Random.index(varBinder), v, " = ", makeExpr(d, b), ";"
+  ]); } },
 
   // Complex variable declarations, e.g. "const [a,b] = [3,4];" or "var a,b,c,d=4,e;"
-  { w: 10, v: function(d, b) { return cat([Random.index(varBinder), makeLetHead(d, b), ";", makeStatement(d - 1, b)]); } },
+  { w: 10, v: function(d, b) { return cat([
+    Random.index(varBinder), makeLetHead(d, b), ";", makeStatement(d - 1, b)
+  ]); } },
 
   // Blocks
   { w: 2, v: function(d, b) { return cat(["{", makeStatement(d, b), " }"]); } },
@@ -190,18 +198,33 @@ var statementMakers = Random.weighted([
 
   /* eslint-disable no-multi-spaces */
   // "with" blocks
-  { w: 2, v: function(d, b) {                          return cat([maybeLabel(), "with", "(", makeExpr(d, b), ")",                    makeStatementOrBlock(d, b)]);             } },
-  { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat([maybeLabel(), "with", "(", "{", v, ": ", makeExpr(d, b), "}", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 2, v: function(d, b) {                          return cat([maybeLabel(), "with", "(", makeExpr(d, b), ")",
+    makeStatementOrBlock(d, b)
+  ]); } },
+  { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat([
+    maybeLabel(), "with", "(", "{", v, ": ", makeExpr(d, b), "}", ")", makeStatementOrBlock(d, b.concat([v]))
+  ]); } },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // C-style "for" loops
-  // Two kinds of "for" loops: one with an expression as the first part, one with a var or let binding 'statement' as the first part.
+  // Two kinds of "for" loops: one with an expression as the first part,
+  // one with a var or let binding 'statement' as the first part.
   // I'm not sure if arbitrary statements are allowed there; I think not.
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                                                    "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v, " = ", makeExpr(d, b),                             "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeDestructuringLValue(d, b), " = ", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
+    "for", "(", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(),
+    "for", "(", Random.index(varBinderFor), v, "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ",
+    makeStatementOrBlock(d, b.concat([v]))
+  ]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(),
+    "for", "(", Random.index(varBinderFor), v, " = ", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ",
+    makeStatementOrBlock(d, b.concat([v]))
+  ]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
+    "for", "(", Random.index(varBinderFor), makeDestructuringLValue(d, b), " = ", makeExpr(d, b), "; ", makeExpr(d, b),
+    "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)
+  ]); } },
   /* eslint-enable no-multi-spaces */
 
   // Various types of "for" loops, specially set up to test tracing, carefully avoiding infinite loops
@@ -214,61 +237,129 @@ var statementMakers = Random.weighted([
   // "for..in" loops
   // arbitrary-LHS marked as infloop because
   // -- for (key in obj)
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
+    "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", makeExpr(d - 2, b), ") ",
+    makeStatementOrBlock(d, b)
+  ]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(),
+    "for", "(", Random.index(varBinderFor), v,                  " in ", makeExpr(d - 2, b), ") ",
+    makeStatementOrBlock(d, b.concat([v]))
+  ]); } },
   // -- for (key in generator())
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
+    "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", "(",
+    "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b)
+  ]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(),
+    "for", "(", Random.index(varBinderFor), v,                  " in ", "(",
+    "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b.concat([v]))
+  ]); } },
   // -- for (element of arraylike)
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
+    " for ", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ",
+    makeStatementOrBlock(d, b)
+  ]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(),
+    " for ", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ",
+    makeStatementOrBlock(d, b.concat([v]))
+  ]); } },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // -- for-await-of
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
+    " for ", "await", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ",
+    makeStatementOrBlock(d, b)
+  ]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(),
+    " for ", "await", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ",
+    makeStatementOrBlock(d, b.concat([v]))
+  ]); } },
   /* eslint-enable no-multi-spaces */
 
   // Modify something during a loop -- perhaps the thing being looped over
   // Since we use "let" to bind the for-variables, and only do wacky stuff once, I *think* this is unlikely to hang.
-  //  function(d, b) { return "let forCount = 0; for (let " + makeId(d, b) + " in " + makeExpr(d, b) + ") { if (forCount++ == " + rnd(3) + ") { " + makeStatement(d - 1, b) + " } }"; },
+  //  function(d, b) { return "let forCount = 0; for (let " + makeId(d, b) + " in " +
+  //  makeExpr(d, b) + ") { if (forCount++ == " + rnd(3) + ") { " + makeStatement(d - 1, b) + " } }"; },
 
   /* eslint-disable no-multi-spaces */
-  // Hoisty "for..in" loops.  I don't know why this construct exists, but it does, and it hoists the initial-value expression above the loop.
+  // Hoisty "for..in" loops.  I don't know why this construct exists, but it does,
+  // and it hoists the initial-value expression above the loop.
   // With "var" or "const", the entire thing is hoisted.
   // With "let", only the value is hoisted, and it can be elim'ed as a useless statement.
   // The last form is specific to JavaScript 1.7 (only).
-  { w: 1, v: function(d, b) {                                                   return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeId(d, b),         " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b);                          return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                    " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); var w = makeNewId(d, b); return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), "[", v, ", ", w, "]", " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v, w]))]); } },
+  { w: 1, v: function(d, b) {                                                   return cat([maybeLabel(),
+    "for", "(", Random.index(varBinderFor), makeId(d, b),         " = ", makeExpr(d, b), " in ",
+    makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)
+  ]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b);                          return cat([maybeLabel(),
+    "for", "(", Random.index(varBinderFor), v,                    " = ", makeExpr(d, b), " in ",
+    makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))
+  ]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); var w = makeNewId(d, b); return cat([maybeLabel(),
+    "for", "(", Random.index(varBinderFor), "[", v, ", ", w, "]", " = ", makeExpr(d, b), " in ",
+    makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v, w]))
+  ]); } },
   /* eslint-enable no-multi-spaces */
 
   // do..while
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(), "while", "(", makeExpr(d, b), ")", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, ";"]); } },
-  { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while", "(", makeExpr(d, b), ");"]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(),
+    "while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */,
+    makeStatementOrBlock(d, b)
+  ]); } },
+  { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(),
+    "while", "(", makeExpr(d, b), ")", makeStatementOrBlock(d, b)
+  ]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(),
+    "do ", makeStatementOrBlock(d, b), " while((",
+    makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, ";"
+  ]); } },
+  { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(),
+    "do ", makeStatementOrBlock(d, b), " while", "(", makeExpr(d, b), ");"
+  ]); } },
 
   // Switch statement
-  { w: 3, v: function(d, b) { return cat([maybeLabel(), "switch", "(", makeExpr(d, b), ")", " { ", makeSwitchBody(d, b), " }"]); } },
+  { w: 3, v: function(d, b) { return cat([maybeLabel(),
+    "switch", "(", makeExpr(d, b), ")", " { ", makeSwitchBody(d, b), " }"
+  ]); } },
 
   // "let" blocks, with bound variable used inside the block
-  { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v, ")", " { ", makeStatement(d, b.concat([v])), " }"]); } },
+  { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat([
+    "let ", "(", v, ")", " { ", makeStatement(d, b.concat([v])), " }"
+  ]); } },
 
   // "let" blocks, with and without multiple bindings, with and without initial values
-  { w: 2, v: function(d, b) { return cat(["let ", "(", makeLetHead(d, b), ")", " { ", makeStatement(d, b), " }"]); } },
+  { w: 2, v: function(d, b) { return cat([
+    "let ", "(", makeLetHead(d, b), ")", " { ", makeStatement(d, b), " }"
+  ]); } },
 
   // Conditionals, perhaps with 'else if' / 'else'
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b)]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b)]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b)]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(),
+    "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d, b)
+  ]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(),
+    "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b)
+  ]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(),
+    "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b),
+    " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b)
+  ]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(),
+    "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b),
+    " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b),
+    " else ", makeStatementOrBlock(d - 1, b)
+  ]); } },
 
   // A tricky pair of if/else cases.
   // In the SECOND case, braces must be preserved to keep the final "else" associated with the first "if".
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b), "}"]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), "}", " else ", makeStatementOrBlock(d - 1, b)]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(),
+    "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b),
+    " else ", makeStatementOrBlock(d - 1, b), "}"
+  ]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(),
+    "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), "}",
+    " else ", makeStatementOrBlock(d - 1, b)
+  ]); } },
 
   // Expression statements
   { w: 5, v: function(d, b) { return cat([makeExpr(d, b), ";"]); } },
@@ -282,7 +373,9 @@ var statementMakers = Random.weighted([
   { w: 1, v: function(d, b) { return cat(["L", ": ", makeStatementOrBlock(d, b)]); } },
 
   // Function-declaration-statements with shared names
-  { w: 10, v: function(d, b) { return cat([makeStatement(d-2, b), "function ", makeId(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d - 1, b), makeStatement(d-2, b)]); } },
+  { w: 10, v: function(d, b) { return cat([makeStatement(d-2, b),
+    "function ", makeId(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d - 1, b), makeStatement(d-2, b)
+  ]); } },
 
   // Function-declaration-statements with unique names, along with calls to those functions
   { w: 8, v: makeNamedFunctionAndUse },
@@ -290,12 +383,17 @@ var statementMakers = Random.weighted([
   // Long script -- can confuse Spidermonkey's short vs long jmp or something like that.
   // Spidermonkey's regexp engine is so slow for long strings that we have to bypass whatToTest :(
   // { w: 1, v: function(d, b) { return strTimes("try{}catch(e){}", rnd(10000)); } },
-  { w: 1, v: function(d, b) { if (rnd(200)==0) return "/*DUPTRY" + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";"; } },
+  { w: 1, v: function(d, b) { if (rnd(200)==0) return "/*DUPTRY"
+    + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";";
+  } },
 
   { w: 1, v: function(d, b) { return makeShapeyConstructorLoop(d, b); } },
 
-  // Replace a variable with a long linked list pointing to it.  (Forces SpiderMonkey's GC marker into a stackless mode.)
-  { w: 1, v: function(d, b) { var x = makeId(d, b); return x + " = linkedList(" + x + ", " + (rnd(100) * rnd(100)) + ");"; } },
+  // Replace a variable with a long linked list pointing to it.
+  // (Forces SpiderMonkey's GC marker into a stackless mode.)
+  { w: 1, v: function(d, b) { var x = makeId(d, b); return x
+    + " = linkedList(" + x + ", " + (rnd(100) * rnd(100)) + ");";
+  } },
 
   // Oddly placed "use strict" or "use asm"
   { w: 1, v: function(d, b) { return directivePrologue() + makeStatement(d - 1, b); } },
@@ -318,7 +416,8 @@ var statementMakers = Random.weighted([
 
   // Discover properties to add to the allPropertyNames list
   // { w: 3, v: function(d, b) { return "for (var p in " + makeId(d, b) + ") { addPropertyName(p); }"; } },
-  // { w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" + makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
+  // { w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" +
+  // makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
 ]);
 
 if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
@@ -364,7 +463,8 @@ function makeUseRegressionTest(d, b)
       // run it using load()
         s += "/* regression-test-load */ " + "load(" + simpleSource(file) + ");";
         break;
-      // NB: these scripts will also be run through eval(), evalcx(), evaluate() thanks to other parts of the fuzzer using makeScriptForEval or makeStatement
+      // NB: these scripts will also be run through eval(), evalcx(), evaluate()
+      // thanks to other parts of the fuzzer using makeScriptForEval or makeStatement
     }
   }
   return s;
@@ -385,7 +485,8 @@ function regressionTestIsEvil(contents)
 
 function inlineTest(filename)
 {
-  // Inline a regression test, adding NODIFF (to disable differential testing) if it calls a testing function that might throw.
+  // Inline a regression test, adding NODIFF (to disable differential testing)
+  // if it calls a testing function that might throw.
 
   const s = "/* " + filename + " */ " + read(filename) + "\n";
 
@@ -398,7 +499,8 @@ function inlineTest(filename)
     "enableSingleStepProfiling",
     // These return values depending on command-line options, and some regression tests check them
     "isAsmJSCompilationAvailable",
-    "isSimdAvailable", // in 32-bit x86 builds, it depends on whether --no-fpu is passed in, because --no-fpu also disables SSE
+    // in 32-bit x86 builds, it depends on whether --no-fpu is passed in, because --no-fpu also disables SSE
+    "isSimdAvailable",
     "hasChild",
     "PerfMeasurement",
   ];
@@ -575,8 +677,10 @@ var littleStatementMakers =
 
   // Return, yield, await
   function(d, b) { return cat(["return ", makeExpr(d, b), ";"]); },
-  function(d, b) { return "return;"; }, // return without a value is allowed in generators; return with a value is not.
-  function(d, b) { return cat(["yield ", makeExpr(d, b), ";"]); }, // note: yield can also be a left-unary operator, or something like that
+  // return without a value is allowed in generators; return with a value is not.
+  function(d, b) { return "return;"; },
+  // note: yield can also be a left-unary operator, or something like that
+  function(d, b) { return cat(["yield ", makeExpr(d, b), ";"]); },
   function(d, b) { return "yield;"; },
   function(d, b) { return cat(["await ", makeExpr(d, b), ";"]); },
 
@@ -649,17 +753,27 @@ var exceptionyStatementMakers = [
 
   // Iteration is also useful to test because it asserts that there is no pending exception.
   function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " in []);"; },
-  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " in " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
-  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
-  function(d, b) { var v = makeNewId(d, b); return "for await(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
+  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " in " + makeIterable(d, b) + ") "
+    + makeExceptionyStatement(d, b.concat([v]));
+  },
+  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " of " + makeIterable(d, b) + ") "
+    + makeExceptionyStatement(d, b.concat([v]));
+  },
+  function(d, b) { var v = makeNewId(d, b); return "for await(let " + v + " of " + makeIterable(d, b) + ") "
+    + makeExceptionyStatement(d, b.concat([v]));
+  },
 
   /* eslint-disable no-multi-spaces */
   // Brendan says these are scary places to throw: with, let block, lambda called immediately in let expr.
   // And I think he was right.
   function(d, b) { return "with({}) "   + makeExceptionyStatement(d, b);         },
   function(d, b) { return "with({}) { " + makeExceptionyStatement(d, b) + " } "; },
-  function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") { " + makeExceptionyStatement(d, b.concat([v])) + "}"; },
-  function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") ((function(){" + makeExceptionyStatement(d, b.concat([v])) + "})());"; },
+  function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") { "
+    + makeExceptionyStatement(d, b.concat([v])) + "}";
+  },
+  function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") ((function(){"
+    + makeExceptionyStatement(d, b.concat([v])) + "})());";
+  },
   function(d, b) { return "let(" + makeLetHead(d, b) + ") { " + makeExceptionyStatement(d, b) + "}"; },
   function(d, b) { return "let(" + makeLetHead(d, b) + ") ((function(){" + makeExceptionyStatement(d, b) + "})());"; },
   /* eslint-enable no-multi-spaces */
@@ -667,12 +781,16 @@ var exceptionyStatementMakers = [
   // Commented out due to causing too much noise on stderr and causing a nonzero exit code :/
 /*
   // Generator close hooks: called during GC in this case!!!
-  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " } finally { " + makeStatement(d, b) + " } })().next()"; },
+  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " }
+    finally { " + makeStatement(d, b) + " } })().next()"; },
 
-  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " } finally { " + makeStatement(d, b) + " } })()"; },
-  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " } finally { " + makeStatement(d, b) + " } })"; },
+  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " }
+    finally { " + makeStatement(d, b) + " } })()"; },
+  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " }
+    finally { " + makeStatement(d, b) + " } })"; },
   function(d, b) {
-    return "function gen() { try { yield 1; } finally { " + makeStatement(d, b) + " } } var i = gen(); i.next(); i = null;";
+    return "function gen() { try { yield 1; } finally { " + makeStatement(d, b) + " } }
+      var i = gen(); i.next(); i = null;";
   }
 
 */
@@ -700,9 +818,11 @@ function makeTryBlock(d, b)
     var catchId = makeId(d, b);
     var catchBlock = makeExceptionyStatement(d, b.concat([catchId]));
     if (rnd(2))
-      s += cat(["catch", "(", catchId, " if ",                 makeExpr(d, b),                    ")", " { ", catchBlock, " } "]);
+      s += cat(["catch", "(", catchId, " if ",
+        makeExpr(d, b), ")", " { ", catchBlock, " } "]);
     else
-      s += cat(["catch", "(", catchId, " if ", "(function(){", makeExceptionyStatement(d, b), "})())", " { ", catchBlock, " } "]);
+      s += cat(["catch", "(", catchId, " if ", "(function(){",
+        makeExceptionyStatement(d, b), "})())", " { ", catchBlock, " } "]);
   }
 
   if (rnd(2)) {
@@ -710,7 +830,7 @@ function makeTryBlock(d, b)
     ++numCatches;
     var catchId = makeId(d, b);
     var catchBlock = makeExceptionyStatement(d, b.concat([catchId]));
-    s +=   cat(["catch", "(", catchId,                                                          ")", " { ", catchBlock, " } "]);
+    s +=   cat(["catch", "(", catchId, ")", " { ", catchBlock, " } "]);
   }
 
   if (numCatches == 0 || rnd(2) === 1) {
@@ -758,7 +878,9 @@ var leftUnaryOps = [
   "!", "+", "-", "~",
   "void ", "typeof ", "delete ",
   "new ", // but note that "new" can also be a very strange left-binary operator
-  "yield ", // see http://www.python.org/dev/peps/pep-0342/ .  Often needs to be parenthesized, so there's also a special exprMaker for it.
+  // see http://www.python.org/dev/peps/pep-0342/ .
+  // Often needs to be parenthesized, so there's also a special exprMaker for it.
+  "yield ",
   "await ",
 ];
 
@@ -803,10 +925,18 @@ var exprMakers =
   function(d, b) { return cat([Random.index(leftUnaryOps), makeExpr(d, b)]); },
 
   // Methods
-  function(d, b) { var id = makeId(d, b); return cat(["/*UUV1*/", "(", id, ".", Random.index(allMethodNames), " = ", makeFunction(d, b), ")"]); },
-  function(d, b) { var id = makeId(d, b); return cat(["/*UUV2*/", "(", id, ".", Random.index(allMethodNames), " = ", id, ".", Random.index(allMethodNames), ")"]); },
-  function(d, b) { return cat([makeExpr(d, b), ".", Random.index(allMethodNames), "(", makeActualArgList(d, b), ")"]); },
-  function(d, b) { return cat([makeExpr(d, b), ".", "valueOf", "(", uneval("number"), ")"]); },
+  function(d, b) { var id = makeId(d, b); return cat([
+    "/*UUV1*/", "(", id, ".", Random.index(allMethodNames), " = ", makeFunction(d, b), ")"
+  ]); },
+  function(d, b) { var id = makeId(d, b); return cat([
+    "/*UUV2*/", "(", id, ".", Random.index(allMethodNames), " = ", id, ".", Random.index(allMethodNames), ")"
+  ]); },
+  function(d, b) { return cat([makeExpr(d, b),
+    ".", Random.index(allMethodNames), "(", makeActualArgList(d, b), ")"
+  ]); },
+  function(d, b) { return cat([makeExpr(d, b),
+    ".", "valueOf", "(", uneval("number"), ")"
+  ]); },
 
   // Binary operators
   function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
@@ -829,7 +959,8 @@ var exprMakers =
   function(d, b) { return cat([makeExpr(d, b), " ? ", makeExpr(d, b), " : ", makeExpr(d, b)]); },
   function(d, b) { return cat([makeExpr(d, b), " ? ", makeExpr(d, b), " : ", makeExpr(d, b)]); },
 
-  // In most contexts, yield expressions must be parenthesized, so including explicitly parenthesized yields makes actually-compiling yields appear more often.
+  // In most contexts, yield expressions must be parenthesized,
+  // so including explicitly parenthesized yields makes actually-compiling yields appear more often.
   function(d, b) { return cat(["yield ", makeExpr(d, b)]); },
   function(d, b) { return cat(["(", "yield ", makeExpr(d, b), ")"]); },
 
@@ -845,15 +976,23 @@ var exprMakers =
   function(d, b) { return cat(["dumpScopeChain", "(", makeFunction(d, b), ")"]); },
 
   // Array functions (including extras).  The most interesting are map and filter, I think.
-  // These are mostly interesting to fuzzers in the sense of "what happens if i do strange things from a filter function?"  e.g. modify the array.. :)
-  // This fuzzer isn't the best for attacking this kind of thing, since it's unlikely that the code in the function will attempt to modify the array or make it go away.
+  // These are mostly interesting to fuzzers in the sense of
+  // "what happens if i do strange things from a filter function?"  e.g. modify the array.. :)
+  // This fuzzer isn't the best for attacking this kind of thing,
+  // since it's unlikely that the code in the function will attempt to modify the array or make it go away.
   // The second parameter to "map" is used as the "this" for the function.
   function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]) ]); },
-  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ", ", makeExpr(d, b), ")"]); },
-  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ")"]); },
+  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]),
+    "(", makeFunction(d, b), ", ", makeExpr(d, b), ")"
+  ]); },
+  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]),
+    "(", makeFunction(d, b), ")"
+  ]); },
 
   // RegExp replace.  This is interesting for the same reason as array extras.
-  function(d, b) { return cat(["'fafafa'", ".", "replace", "(", "/", "a", "/", "g", ", ", makeFunction(d, b), ")"]); },
+  function(d, b) { return cat(["'fafafa'", ".", "replace",
+    "(", "/", "a", "/", "g", ", ", makeFunction(d, b), ")"
+  ]); },
 
   // Containment in an array or object (or, if this happens to end up on the LHS of an assignment, destructuring)
   function(d, b) { return cat(["[", makeExpr(d, b), "]"]); },
@@ -870,7 +1009,9 @@ var exprMakers =
   function(d, b) { return cat([     makeFunction(d, b),      "(", makeActualArgList(d, b), ")"]); },
 
   // Try to test function.call heavily.
-  function(d, b) { return cat(["(", makeFunction(d, b), ")", ".", "call", "(", makeExpr(d, b), ", ", makeActualArgList(d, b), ")"]); },
+  function(d, b) { return cat(["(", makeFunction(d, b), ")", ".", "call", "(", makeExpr(d, b), ", ",
+    makeActualArgList(d, b), ")"
+  ]); },
 
   // Binary "new", with and without clarifying parentheses, with expressions or functions
   function(d, b) { return cat(["new ",      makeExpr(d, b),          "(", makeActualArgList(d, b), ")"]); },
@@ -879,15 +1020,22 @@ var exprMakers =
   function(d, b) { return cat(["new ",      makeFunction(d, b),      "(", makeActualArgList(d, b), ")"]); },
   function(d, b) { return cat(["new ", "(", makeFunction(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
 
-  // Sometimes we do crazy stuff, like putting a statement where an expression should go.  This frequently causes a syntax error.
+  // Sometimes we do crazy stuff, like putting a statement where an expression should go.
+  // This frequently causes a syntax error.
   function(d, b) { return stripSemicolon(makeLittleStatement(d, b)); },
   function(d, b) { return ""; },
 
   /* eslint-disable no-multi-spaces */
   // Let expressions -- note the lack of curly braces.
-  function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v,                            ") ", makeExpr(d - 1, b.concat([v]))]); },
-  function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v, " = ", makeExpr(d - 1, b), ") ", makeExpr(d - 1, b.concat([v]))]); },
-  function(d, b) {                          return cat(["let ", "(", makeLetHead(d, b),            ") ", makeExpr(d, b)]); },
+  function(d, b) { var v = makeNewId(d, b); return cat([
+    "let ", "(", v, ") ", makeExpr(d - 1, b.concat([v]))
+  ]); },
+  function(d, b) { var v = makeNewId(d, b); return cat([
+    "let ", "(", v, " = ", makeExpr(d - 1, b), ") ", makeExpr(d - 1, b.concat([v]))
+  ]); },
+  function(d, b) {                          return cat([
+    "let ", "(", makeLetHead(d, b), ") ", makeExpr(d, b)
+  ]); },
   /* eslint-enable no-multi-spaces */
 
   // Comments and whitespace
@@ -917,7 +1065,9 @@ var exprMakers =
   function(d, b) { return cat([makeLValue(d, b), Random.index(["|=", "%=", "+=", "-="]), makeExpr(d, b)]); },
 
   // ES5 getter/setter syntax, imperative (added in Gecko 1.9.3?)
-  function(d, b) { return cat(["Object.defineProperty", "(", makeId(d, b), ", ", makePropertyName(d, b), ", ", makePropertyDescriptor(d, b), ")"]); },
+  function(d, b) { return cat([
+    "Object.defineProperty", "(", makeId(d, b), ", ", makePropertyName(d, b), ", ", makePropertyDescriptor(d, b), ")"
+  ]); },
 
   // Test the prototype of a particular object
   function(d, b) { return cat(["Object.getPrototypeOf", "(", makeId(d, b), ")"]); },
@@ -927,10 +1077,18 @@ var exprMakers =
   function(d, b) { return cat(["Object.values", "(", makeId(d, b), ")"]); },
 
   // Old getter/setter syntax, imperative
-  function(d, b) { return cat([makeExpr(d, b), ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
-  function(d, b) { return cat([makeExpr(d, b), ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
-  function(d, b) { return cat(["this", ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
-  function(d, b) { return cat(["this", ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
+  function(d, b) { return cat([
+    makeExpr(d, b), ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"
+  ]); },
+  function(d, b) { return cat([
+    makeExpr(d, b), ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"
+  ]); },
+  function(d, b) { return cat([
+    "this", ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"
+  ]); },
+  function(d, b) { return cat([
+    "this", ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"
+  ]); },
 
   // Object literal
   function(d, b) { return cat(["(", "{", makeObjLiteralPart(d, b), " }", ")"]); },
@@ -951,7 +1109,8 @@ var exprMakers =
   function(d, b) { return "eval(" + uneval(makeScriptForEval(d, b)) + ")"; },
   function(d, b) { return "eval(" + uneval(makeScriptForEval(d, b)) + ", " + makeExpr(d, b) + ")"; },
 
-  // Uneval needs more testing than it will get accidentally.  No cat() because I don't want uneval clobbered (assigned to) accidentally.
+  // Uneval needs more testing than it will get accidentally.
+  // No cat() because I don't want uneval clobbered (assigned to) accidentally.
   function(d, b) { return "(uneval(" + makeExpr(d, b) + "))"; },
 
   /* eslint-disable no-multi-spaces */
@@ -968,16 +1127,31 @@ var exprMakers =
 
   /* eslint-disable no-multi-spaces */
   // Binary Math functions
-  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeExpr(d, b)   + ")"; },
-  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeNumber(d, b) + ")"; },
-  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeExpr(d, b)   + ")"; },
-  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeNumber(d, b) + ")"; },
+  function(d, b) { return "Math."
+    + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeExpr(d, b)   + ")";
+  },
+  function(d, b) { return "Math."
+    + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeNumber(d, b) + ")";
+  },
+  function(d, b) { return "Math."
+    + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeExpr(d, b)   + ")";
+  },
+  function(d, b) { return "Math."
+    + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeNumber(d, b) + ")";
+  },
   /* eslint-enable no-multi-spaces */
 
   // Harmony proxy creation: object, function without constructTrap, function with constructTrap
-  function(d, b) { return makeId(d, b) + " = " + "Proxy.create(" + makeProxyHandler(d, b) + ", " + makeExpr(d, b) + ")"; },
-  function(d, b) { return makeId(d, b) + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ")"; },
-  function(d, b) { return makeId(d, b) + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ", " + makeFunction(d, b) + ")"; },
+  function(d, b) { return makeId(d, b)
+    + " = " + "Proxy.create(" + makeProxyHandler(d, b) + ", " + makeExpr(d, b) + ")";
+  },
+  function(d, b) { return makeId(d, b)
+    + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ")";
+  },
+  function(d, b) { return makeId(d, b)
+    + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ", "
+    + makeFunction(d, b) + ")";
+  },
 
   function(d, b) { return cat(["delete", " ", makeId(d, b), ".", makeId(d, b)]); },
 
@@ -988,12 +1162,14 @@ var exprMakers =
   function(d, b) { return "(void options('strict'))"; },
 
   // More special Spidermonkey shell functions
-  // (Note: functions without returned objects or visible side effects go in testing-functions.js, in order to allow presence/absence differential testing.)
+  // (Note: functions without returned objects or visible side effects go in testing-functions.js,
+  // in order to allow presence/absence differential testing.)
   //  function(d, b) { return "dumpObject(" + makeExpr(d, b) + ")" } }, // crashes easily, bug 836603
   function(d, b) { return "(void shapeOf(" + makeExpr(d, b) + "))"; },
   function(d, b) { return "intern(" + makeExpr(d, b) + ")"; },
   function(d, b) { return "allocationMarker()"; },
-  function(d, b) { return "timeout(1800)"; }, // see https://bugzilla.mozilla.org/show_bug.cgi?id=840284#c12 -- replace when bug 831046 is fixed
+  // see https://bugzilla.mozilla.org/show_bug.cgi?id=840284#c12 -- replace when bug 831046 is fixed
+  function(d, b) { return "timeout(1800)"; },
   function(d, b) { return "(makeFinalizeObserver('tenured'))"; },
   function(d, b) { return "(makeFinalizeObserver('nursery'))"; },
 
@@ -1008,7 +1184,8 @@ var fuzzTestingFunctions = fuzzTestingFunctionsCtor(!jsshell, fuzzTestingFunctio
 
 // Ensure that even if makeExpr returns "" or "1, 2", we only pass one argument to functions like schedulegc
 // (null || (" + makeExpr(d - 2, b) + "))
-// Darn, only |this| and local variables are safe: an expression with side effects breaks the statement-level compare_jit hack
+// Darn, only |this| and local variables are safe:
+// an expression with side effects breaks the statement-level compare_jit hack
 function fuzzTestingFunctionArg(d, b) { return "this"; }
 
 function makeTestingFunctionCall(d, b)
@@ -1106,7 +1283,9 @@ if (xpcshell) {
     function(d, b) { var n = rnd(4); return "newGeckoSandbox(" + n + ")"; },
     function(d, b) { var n = rnd(4); return "s" + n + " = newGeckoSandbox(" + n + ")"; },
     // FIXME: Doesn't this need to be Components.utils.evalInSandbox?
-    function(d, b) { var n = rnd(4); return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", newGeckoSandbox(" + n + "))"; },
+    function(d, b) { var n = rnd(4); return "evalInSandbox("
+      + uneval(makeStatement(d, b)) + ", newGeckoSandbox(" + n + "))";
+    },
     function(d, b) { var n = rnd(4); return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", s" + n + ")"; },
     function(d, b) { return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", " + makeExpr(d, b) + ")"; },
     function(d, b) { return "(Components.classes ? quit() : gc()); }"; },
@@ -1138,12 +1317,14 @@ function makeShapeyConstructor(d, b)
     switch (rnd(8)) {
       /* eslint-disable no-multi-spaces */
       case 0:  funText += "delete " + tprop + ";"; break;
-      case 1:  funText += "Object.defineProperty(" + t + ", " + (rnd(2) ? propName : makePropertyName(d, b)) + ", " + makePropertyDescriptor(d, bp) + ");"; break;
+      case 1:  funText += "Object.defineProperty(" + t + ", "
+        + (rnd(2) ? propName : makePropertyName(d, b)) + ", " + makePropertyDescriptor(d, bp) + ");"; break;
       case 2:  funText += "{ " + makeStatement(d, bp) + " } "; break;
       case 3:  funText += tprop + " = " + makeExpr(d, bp)        + ";"; break;
       case 4:  funText += tprop + " = " + makeFunction(d, bp)    + ";"; break;
       case 5:  funText += "for (var ytq" + uniqueVarName() + " in " + t + ") { }"; break;
-      case 6:  funText += "Object." + Random.index(["preventExtensions", "seal", "freeze"]) + "(" + t + ");"; break;
+      case 6:  funText += "Object." + Random.index(["preventExtensions", "seal", "freeze"])
+        + "(" + t + ");"; break;
       default: funText += tprop + " = " + makeShapeyValue(d, bp) + ";"; break;
       /* eslint-enable no-multi-spaces */
     }
@@ -1228,7 +1409,8 @@ function makeBoolean(d, b)
     case 0:   return "true";
     case 1:   return "false";
     case 2:   return makeExpr(d - 2, b);
-    default:  var m = loopModulo(); return "(" + Random.index(b) + " % " + m + Random.index([" == ", " != "]) + rnd(m) + ")";
+    default:  var m = loopModulo(); return "(" + Random.index(b) + " % " + m + Random.index([" == ", " != "])
+      + rnd(m) + ")";
     /* eslint-enable no-multi-spaces */
   }
 }
@@ -1243,10 +1425,16 @@ function makeObjLiteralPart(d, b)
   // Literal getter/setter
   // Surprisingly, string literals, integer literals, and float literals are also good!
   // (See https://bugzilla.mozilla.org/show_bug.cgi?id=520696.)
-    case 2: return cat([" get ", makeObjLiteralName(d, b), maybeName(d, b), "(", makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)]);
-    case 3: return cat([" set ", makeObjLiteralName(d, b), maybeName(d, b), "(", makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)]);
+    case 2: return cat([" get ", makeObjLiteralName(d, b), maybeName(d, b), "(",
+      makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)
+    ]);
+    case 3: return cat([" set ", makeObjLiteralName(d, b), maybeName(d, b), "(",
+      makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)
+    ]);
 
-    case 4: return "/*toXFun*/" + cat([Random.index(["toString", "valueOf"]), ": ", makeToXFunction(d - 1, b)]);
+    case 4: return "/*toXFun*/" + cat([
+      Random.index(["toString", "valueOf"]), ": ", makeToXFunction(d - 1, b)
+    ]);
 
     default: return cat([makeObjLiteralName(d, b), ": ", makeExpr(d, b)]);
   }
@@ -1349,49 +1537,73 @@ var functionMakers = [
 
   /* eslint-disable no-multi-spaces */
   // Functions and expression closures
-  function(d, b) { var v = makeNewId(d, b); return cat([functionPrefix(), " ", maybeName(d, b), "(", v,                       ")", makeFunctionBody(d, b.concat([v]))]); },
-  function(d, b) {                          return cat([functionPrefix(), " ", maybeName(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d, b)]); },
+  function(d, b) { var v = makeNewId(d, b); return cat([functionPrefix(), " ", maybeName(d, b), "(",
+    v, ")", makeFunctionBody(d, b.concat([v]))
+  ]); },
+  function(d, b) {                          return cat([functionPrefix(), " ", maybeName(d, b), "(",
+    makeFormalArgList(d, b), ")", makeFunctionBody(d, b)
+  ]); },
   /* eslint-enable no-multi-spaces */
 
-  /* eslint-disable no-multi-spaces */
   // Arrow functions with one argument (no parens needed) (no destructuring allowed in this form?)
-  function(d, b) { var v = makeNewId(d, b); return cat([     v,                            " => ", makeFunctionBody(d, b.concat([v]))]); },
-  /* eslint-enable no-multi-spaces */
+  function(d, b) { var v = makeNewId(d, b); return cat([
+    v, " => ", makeFunctionBody(d, b.concat([v]))
+  ]); },
 
-  /* eslint-disable no-multi-spaces */
   // Arrow functions with multiple arguments
-  function(d, b) {                          return cat(["(", makeFormalArgList(d, b), ")", " => ", makeFunctionBody(d, b)]); },
-  /* eslint-enable no-multi-spaces */
+  function(d, b) { return cat(["(", makeFormalArgList(d, b), ")", " => ", makeFunctionBody(d, b)]); },
 
   // The identity function
   function(d, b) { return functionPrefix() + "(q) { " + directivePrologue() + "return q; }"; },
   function(d, b) { return "q => q"; },
 
   // A function that does something
-  function(d, b) { return functionPrefix() + "(y) { " + directivePrologue() + makeStatement(d, b.concat(["y"])) + " }"; },
+  function(d, b) { return functionPrefix() + "(y) { " + directivePrologue()
+    + makeStatement(d, b.concat(["y"])) + " }";
+  },
 
   // A function that computes something
-  function(d, b) { return functionPrefix() + "(y) { " + directivePrologue() + "return " + makeExpr(d, b.concat(["y"])) + " }"; },
+  function(d, b) { return functionPrefix() + "(y) { " + directivePrologue()
+    + "return " + makeExpr(d, b.concat(["y"])) + " }";
+  },
 
   // A generator that does something
-  function(d, b) { return "function(y) { " + directivePrologue() + "yield y; " + makeStatement(d, b.concat(["y"])) + "; yield y; }"; },
-  function(d, b) { return "function*(y) { " + directivePrologue() + "yield y; " + makeStatement(d, b.concat(["y"])) + "; yield y; }"; },
+  function(d, b) { return "function(y) { " + directivePrologue() + "yield y; "
+    + makeStatement(d, b.concat(["y"])) + "; yield y; }";
+  },
+  function(d, b) { return "function*(y) { " + directivePrologue() + "yield y; "
+    + makeStatement(d, b.concat(["y"])) + "; yield y; }";
+  },
 
   // An async function that does something
-  function(d, b) { return "async function (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
+  function(d, b) { return "async function (y) { " + directivePrologue() + "await y; "
+    + makeStatement(d, b.concat(["y"])) + "; await y; }";
+  },
 
   // An async generator that does something
-  function(d, b) { return "async function* (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
-  function(d, b) { return "async function* (y) { " + directivePrologue() + "yield y; await y; " + makeStatement(d, b.concat(["y"])) + "; yield y; await y; }"; },
+  function(d, b) { return "async function* (y) { " + directivePrologue() + "await y; "
+    + makeStatement(d, b.concat(["y"])) + "; await y; }";
+  },
+  function(d, b) { return "async function* (y) { " + directivePrologue() + "yield y; await y; "
+    + makeStatement(d, b.concat(["y"])) + "; yield y; await y; }";
+  },
 
   // A simple wrapping pattern
-  function(d, b) { return "/*wrap1*/(" + functionPrefix() + "(){ " + directivePrologue() + makeStatement(d, b) + "return " + makeFunction(d, b) + "})()"; },
+  function(d, b) { return "/*wrap1*/(" + functionPrefix() + "(){ " + directivePrologue() + makeStatement(d, b)
+    + "return " + makeFunction(d, b) + "})()";
+  },
 
   // Wrapping with upvar: escaping, may or may not be modified
-  function(d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap2*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; var " + v2 + " = " + makeFunction(d, b.concat([v1])) + "; return " + v2 + ";})()"; },
+  function(d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap2*/(" + functionPrefix() + "(){ "
+    + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b)
+    + "; var " + v2 + " = " + makeFunction(d, b.concat([v1])) + "; return " + v2 + ";})()";
+  },
 
   // Wrapping with upvar: non-escaping
-  function(d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap3*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; (" + makeFunction(d, b.concat([v1])) + ")(); })"; },
+  function(d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap3*/(" + functionPrefix() + "(){ "
+    + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b)
+    + "; (" + makeFunction(d, b.concat([v1])) + ")(); })";
+  },
 
   // Apply, call
   function(d, b) { return "(" + makeFunction(d-1, b) + ").apply"; },
@@ -1404,10 +1616,14 @@ var functionMakers = [
   // Methods with known names
   function(d, b) { return cat([makeExpr(d, b), ".", Random.index(allMethodNames)]); },
 
-  // Special functions that might have interesting results, especially when called "directly" by things like string.replace or array.map.
-  function(d, b) { return "eval"; }, // eval is interesting both for its "no indirect calls" feature and for the way it's implemented in spidermonkey (a special bytecode).
+  // Special functions that might have interesting results,
+  // especially when called "directly" by things like string.replace or array.map.
+  // eval is interesting both for its "no indirect calls" feature
+  // and for the way it's implemented in spidermonkey (a special bytecode).
+  function(d, b) { return "eval"; },
   function(d, b) { return "(let (e=eval) e)"; },
-  function(d, b) { return "new Function"; }, // this won't be interpreted the same way for each caller of makeFunction, but that's ok
+  // this won't be interpreted the same way for each caller of makeFunction, but that's ok
+  function(d, b) { return "new Function"; },
   function(d, b) { return "(new Function(" + uneval(makeStatement(d, b)) + "))"; },
   function(d, b) { return "Function"; }, // without "new"
   function(d, b) { return "decodeURI"; },
@@ -1648,7 +1864,8 @@ function makeId(d, b)
 
   // window is a const (in the browser), so some attempts to redeclare it will cause errors
 
-  // eval is interesting because it cannot be called indirectly. and maybe also because it has its own opcode in jsopcode.tbl.
+  // eval is interesting because it cannot be called indirectly
+  // and maybe also because it has its own opcode in jsopcode.tbl.
   // but bad things happen if you have "eval setter". so let's not put eval in this list.
 }
 
@@ -1664,13 +1881,17 @@ function makeComprehension(d, b)
     case 0:
       return "";
     case 1:
-      return cat([" for ",          "(", makeForInLHS(d, b), " in ", makeExpr(d - 2, b),     ")"]) + makeComprehension(d - 1, b);
+      return cat([" for ", "(", makeForInLHS(d, b), " in ", makeExpr(d - 2, b),     ")"])
+        + makeComprehension(d - 1, b);
     case 2:
-      return cat([" for ",          "(", makeId(d, b),       " of ", makeExpr(d - 2, b),     ")"]) + makeComprehension(d - 1, b);
+      return cat([" for ", "(", makeId(d, b),       " of ", makeExpr(d - 2, b),     ")"])
+        + makeComprehension(d - 1, b);
     case 3:
-      return cat([" for ",          "(", makeId(d, b),       " of ", makeIterable(d - 2, b), ")"]) + makeComprehension(d - 1, b);
+      return cat([" for ", "(", makeId(d, b),       " of ", makeIterable(d - 2, b), ")"])
+        + makeComprehension(d - 1, b);
     default:
-      return cat([" if ", "(", makeExpr(d - 2, b), ")"]); // this is always last (and must be preceded by a "for", oh well)
+      // this is always last (and must be preceded by a "for", oh well)
+      return cat([" if ", "(", makeExpr(d - 2, b), ")"]);
   }
 }
 
@@ -1892,8 +2113,10 @@ function makeCrazyToken()
     "...", "=>",
 
     // most real keywords plus a few reserved keywords
-    " in ", " instanceof ", " let ", " new ", " get ", " for ", " if ", " else ", " else if ", " try ", " catch ", " finally ", " export ", " import ", " void ", " with ",
-    " default ", " goto ", " case ", " switch ", " do ", " /*infloop*/while ", " return ", " yield ", " await ", " break ", " continue ", " typeof ", " var ", " const ",
+    " in ", " instanceof ", " let ", " new ", " get ", " for ", " if ", " else ", " else if ",
+    " try ", " catch ", " finally ", " export ", " import ", " void ", " with ",
+    " default ", " goto ", " case ", " switch ", " do ", " /*infloop*/while ", " return ",
+    " yield ", " await ", " break ", " continue ", " typeof ", " var ", " const ",
 
     // reserved when found in strict mode code
     " package ",
@@ -1932,7 +2155,8 @@ function makeShapeyValue(d, b)
       "1.2e3", "1e81", "1e+81", "1e-81", "1e4", "-0", "(-0)",
       "-1", "(-1)", "0x99", "033", "3/0", "-3/0", "0/0",
       "Math.PI",
-      "0x2D413CCC", "0x5a827999", "0xB504F332", "-0x2D413CCC", "-0x5a827999", "-0xB504F332", "0x50505050", "(0x50505050 >> 1)",
+      "0x2D413CCC", "0x5a827999", "0xB504F332", "-0x2D413CCC", "-0x5a827999", "-0xB504F332",
+      "0x50505050", "(0x50505050 >> 1)",
 
       // various powers of two, with values near JSVAL_INT_MAX especially tested
       "0x10000000", "0x20000000", "0x3FFFFFFE", "0x3FFFFFFF", "0x40000000", "0x40000001",
@@ -1992,7 +2216,8 @@ function makeShapeyValue(d, b)
 
     // Fun stuff
     [ "function(){}" ],
-    [ "{}", "[]", "[1]", "['z']", "[undefined]", "this", "eval", "arguments", "arguments.caller", "arguments.callee" ],
+    [ "{}", "[]", "[1]", "['z']", "[undefined]", "this", "eval",
+      "arguments", "arguments.caller", "arguments.callee" ],
     [ "objectEmulatingUndefined()" ],
 
     // Actual variables (slightly dangerous)
@@ -2057,7 +2282,8 @@ function makeArrayLiteralElem(d, b)
 
   switch (rnd(5)) {
     /* eslint-disable no-multi-spaces */
-    case 0:  return "..." + makeIterable(d - 1, b); // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Spread_operator
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Spread_operator
+    case 0:  return "..." + makeIterable(d - 1, b);
     case 1:  return ""; // hole
     default: return makeExpr(d - 1, b);
     /* eslint-enable no-multi-spaces */
@@ -2083,18 +2309,32 @@ var iterableExprMakers = Random.weighted([
   { w: 1, v: function(d, b) { return cat(["[", makeExpr(d, b), makeComprehension(d, b), "]"]); } },
 
   // A generator that yields once
-  { w: 1, v: function(d, b) { return "(function() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },
-  { w: 1, v: function(d, b) { return "(function*() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },
+  { w: 1, v: function(d, b) { return "(function() { " + directivePrologue()
+    + "yield " + makeExpr(d - 1, b) + "; } })()";
+  } },
+  { w: 1, v: function(d, b) { return "(function*() { " + directivePrologue()
+    + "yield " + makeExpr(d - 1, b) + "; } })()";
+  } },
   // A pass-through generator
-  { w: 1, v: function(d, b) { return "/*PTHR*/(function() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
-  { w: 1, v: function(d, b) { return "/*PTHR*/(function*() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
+  { w: 1, v: function(d, b) { return "/*PTHR*/(function() { " + directivePrologue()
+    + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()";
+  } },
+  { w: 1, v: function(d, b) { return "/*PTHR*/(function*() { " + directivePrologue()
+    + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()";
+  } },
 
   // An async function that awaits once
-  { w: 1, v: function(d, b) { return "(async function() { " + directivePrologue() + "await " + makeExpr(d - 1, b) + "; } })()"; } },
+  { w: 1, v: function(d, b) { return "(async function() { " + directivePrologue()
+    + "await " + makeExpr(d - 1, b) + "; } })()";
+  } },
 
   // A pass-through async generator
-  { w: 1, v: function(d, b) { return "/*PTHR*/(async function*() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
-  { w: 1, v: function(d, b) { return "/*PTHR*/(async function*() { " + directivePrologue() + "for await (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
+  { w: 1, v: function(d, b) { return "/*PTHR*/(async function*() { " + directivePrologue()
+    + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()";
+  } },
+  { w: 1, v: function(d, b) { return "/*PTHR*/(async function*() { " + directivePrologue()
+    + "for await (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()";
+  } },
 
   { w: 1, v: makeFunction },
   { w: 1, v: makeExpr },
@@ -2125,5 +2365,6 @@ function makeAsmJSFunction(d, b)
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior(["ff"]);
-  return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })(this, {ff: " + makeFunction(d - 2, b) + "}, new " + arrayBufferType() + "(4096))";
+  return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })(this, {ff: "
+    + makeFunction(d - 2, b) + "}, new " + arrayBufferType() + "(4096))";
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -150,12 +150,12 @@ function makeFunOnCallChain (d, b) { // eslint-disable-line require-jsdoc
 var statementMakers = Random.weighted([
 
   // Any two statements in sequence
-  { w: 15, v: function (d, b) { return cat([makeStatement(d - 1, b), makeStatement(d - 1, b) ]); } },
+  { w: 15, v: function (d, b) { return cat([makeStatement(d - 1, b), makeStatement(d - 1, b)]); } },
   { w: 15, v: function (d, b) { return cat([makeStatement(d - 1, b), "\n", makeStatement(d - 1, b), "\n"]); } },
 
   // Stripping semilcolons.  What happens if semicolons are missing?  Especially with line breaks used in place of semicolons (semicolon insertion).
   { w: 1, v: function (d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n", makeStatement(d, b)]); } },
-  { w: 1, v: function (d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n" ]); } },
+  { w: 1, v: function (d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n"]); } },
   { w: 1, v: function (d, b) { return stripSemicolon(makeStatement(d, b)); } }, // usually invalid, but can be ok e.g. at the end of a block with curly braces
 
   // Simple variable declarations, followed (or preceded) by statements using those variables
@@ -777,7 +777,7 @@ var exprMakers =
   // These are mostly interesting to fuzzers in the sense of "what happens if i do strange things from a filter function?"  e.g. modify the array.. :)
   // This fuzzer isn't the best for attacking this kind of thing, since it's unlikely that the code in the function will attempt to modify the array or make it go away.
   // The second parameter to "map" is used as the "this" for the function.
-  function (d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]) ]); },
+  function (d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"])]); },
   function (d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ", ", makeExpr(d, b), ")"]); },
   function (d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ")"]); },
 
@@ -794,9 +794,9 @@ var exprMakers =
   function (d, b) { return cat(["(", makeFunction(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
 
   // Try to call things that may or may not be functions.
-  function (d, b) { return cat([ makeExpr(d, b), "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat([makeExpr(d, b), "(", makeActualArgList(d, b), ")"]); },
   function (d, b) { return cat(["(", makeExpr(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
-  function (d, b) { return cat([ makeFunction(d, b), "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat([makeFunction(d, b), "(", makeActualArgList(d, b), ")"]); },
 
   // Try to test function.call heavily.
   function (d, b) { return cat(["(", makeFunction(d, b), ")", ".", "call", "(", makeExpr(d, b), ", ", makeActualArgList(d, b), ")"]); },
@@ -831,13 +831,13 @@ var exprMakers =
   function (d, b) { return cat([ makeLValue(d, b), " = ", makeExpr(d, b) ]); },
   function (d, b) { return cat([ makeLValue(d, b), " = ", makeExpr(d, b) ]); },
   function (d, b) { return cat(["(", makeLValue(d, b), " = ", makeExpr(d, b), ")"]); },
-  function (d, b) { return cat(["(", makeLValue(d, b), ")", " = ", makeExpr(d, b) ]); },
+  function (d, b) { return cat(["(", makeLValue(d, b), ")", " = ", makeExpr(d, b)]); },
 
   // Destructuring assignment
   function (d, b) { return cat([ makeDestructuringLValue(d, b), " = ", makeExpr(d, b) ]); },
   function (d, b) { return cat([ makeDestructuringLValue(d, b), " = ", makeExpr(d, b) ]); },
   function (d, b) { return cat(["(", makeDestructuringLValue(d, b), " = ", makeExpr(d, b), ")"]); },
-  function (d, b) { return cat(["(", makeDestructuringLValue(d, b), ")", " = ", makeExpr(d, b) ]); },
+  function (d, b) { return cat(["(", makeDestructuringLValue(d, b), ")", " = ", makeExpr(d, b)]); },
 
   // Destructuring assignment with lots of group assignment
   function (d, b) { return cat([makeDestructuringLValue(d, b), " = ", makeDestructuringLValue(d, b)]); },
@@ -1242,10 +1242,8 @@ var functionMakers = [
   function (d, b) {                          return cat([functionPrefix(), " ", maybeName(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d, b)]); },
   /* eslint-enable no-multi-spaces */
 
-  /* eslint-disable no-multi-spaces */
   // Arrow functions with one argument (no parens needed) (no destructuring allowed in this form?)
-  function (d, b) { var v = makeNewId(d, b); return cat([     v,                            " => ", makeFunctionBody(d, b.concat([v]))]); },
-  /* eslint-enable no-multi-spaces */
+  function (d, b) { var v = makeNewId(d, b); return cat([v, " => ", makeFunctionBody(d, b.concat([v]))]); },
 
   /* eslint-disable no-multi-spaces */
   // Arrow functions with multiple arguments
@@ -1679,8 +1677,8 @@ var termMakers = [
     ]);
   },
   makeNumber,
-  function (d, b) { return Random.index([ "true", "false", "undefined", "null"]); },
-  function (d, b) { return Random.index([ "this", "window" ]); },
+  function (d, b) { return Random.index(["true", "false", "undefined", "null"]); },
+  function (d, b) { return Random.index(["this", "window"]); },
   function (d, b) { return Random.index([" \"\" ", " '' "]); },
   randomUnitStringLiteral, // unicode escaped
   function (d, b) { return Random.index([" /x/ ", " /x/g "]); },
@@ -1798,7 +1796,7 @@ function makeShapeyValue (d, b) { // eslint-disable-line require-jsdoc
     [" \"\" ", " '' ", " 'A' ", " '\\0' ", ' "use strict" '],
 
     // Regular expression literals
-    [ " /x/ ", " /x/g "],
+    [ " /x/ ", " /x/g " ],
 
     // Booleans
     [ "true", "false" ],
@@ -1810,7 +1808,7 @@ function makeShapeyValue (d, b) { // eslint-disable-line require-jsdoc
     [ "[]", "[1]", "[(void 0)]", "{}", "{x:3}", "({})", "({x:3})" ],
 
     // Variables that really should have been constants in the ecmascript spec
-    [ "NaN", "Infinity", "-Infinity", "undefined"],
+    [ "NaN", "Infinity", "-Infinity", "undefined" ],
 
     // Boxed booleans
     [ "new Boolean(true)", "new Boolean(false)" ],

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -172,25 +172,17 @@ var statementMakers = Random.weighted([
   { w: 15, v: function(d, b) { return cat([makeStatement(d - 1, b),       makeStatement(d - 1, b)      ]); } },
   { w: 15, v: function(d, b) { return cat([makeStatement(d - 1, b), "\n", makeStatement(d - 1, b), "\n"]); } },
 
-  // Stripping semicolons.  What happens if semicolons are missing?
-  // Especially with line breaks used in place of semicolons (semicolon insertion).
+  // Stripping semilcolons.  What happens if semicolons are missing?  Especially with line breaks used in place of semicolons (semicolon insertion).
   { w: 1, v: function(d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n", makeStatement(d, b)]); } },
   { w: 1, v: function(d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n"                   ]); } },
-  // usually invalid, but can be ok e.g. at the end of a block with curly braces
-  { w: 1, v: function(d, b) { return stripSemicolon(makeStatement(d, b)); } },
+  { w: 1, v: function(d, b) { return stripSemicolon(makeStatement(d, b)); } }, // usually invalid, but can be ok e.g. at the end of a block with curly braces
 
   // Simple variable declarations, followed (or preceded) by statements using those variables
-  { w: 4, v: function(d, b) { var v = makeNewId(d, b); return cat([
-    Random.index(varBinder), v, " = ", makeExpr(d, b), ";", makeStatement(d - 1, b.concat([v]))
-  ]); } },
-  { w: 4, v: function(d, b) { var v = makeNewId(d, b); return cat([
-    makeStatement(d - 1, b.concat([v])), Random.index(varBinder), v, " = ", makeExpr(d, b), ";"
-  ]); } },
+  { w: 4, v: function(d, b) { var v = makeNewId(d, b); return cat([Random.index(varBinder), v, " = ", makeExpr(d, b), ";", makeStatement(d - 1, b.concat([v]))]); } },
+  { w: 4, v: function(d, b) { var v = makeNewId(d, b); return cat([makeStatement(d - 1, b.concat([v])), Random.index(varBinder), v, " = ", makeExpr(d, b), ";"]); } },
 
   // Complex variable declarations, e.g. "const [a,b] = [3,4];" or "var a,b,c,d=4,e;"
-  { w: 10, v: function(d, b) { return cat([
-    Random.index(varBinder), makeLetHead(d, b), ";", makeStatement(d - 1, b)
-  ]); } },
+  { w: 10, v: function(d, b) { return cat([Random.index(varBinder), makeLetHead(d, b), ";", makeStatement(d - 1, b)]); } },
 
   // Blocks
   { w: 2, v: function(d, b) { return cat(["{", makeStatement(d, b), " }"]); } },
@@ -198,33 +190,18 @@ var statementMakers = Random.weighted([
 
   /* eslint-disable no-multi-spaces */
   // "with" blocks
-  { w: 2, v: function(d, b) {                          return cat([maybeLabel(), "with", "(", makeExpr(d, b), ")",
-    makeStatementOrBlock(d, b)
-  ]); } },
-  { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat([
-    maybeLabel(), "with", "(", "{", v, ": ", makeExpr(d, b), "}", ")", makeStatementOrBlock(d, b.concat([v]))
-  ]); } },
+  { w: 2, v: function(d, b) {                          return cat([maybeLabel(), "with", "(", makeExpr(d, b), ")",                    makeStatementOrBlock(d, b)]);             } },
+  { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat([maybeLabel(), "with", "(", "{", v, ": ", makeExpr(d, b), "}", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // C-style "for" loops
-  // Two kinds of "for" loops: one with an expression as the first part,
-  // one with a var or let binding 'statement' as the first part.
+  // Two kinds of "for" loops: one with an expression as the first part, one with a var or let binding 'statement' as the first part.
   // I'm not sure if arbitrary statements are allowed there; I think not.
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
-    "for", "(", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(),
-    "for", "(", Random.index(varBinderFor), v, "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ",
-    makeStatementOrBlock(d, b.concat([v]))
-  ]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(),
-    "for", "(", Random.index(varBinderFor), v, " = ", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ",
-    makeStatementOrBlock(d, b.concat([v]))
-  ]); } },
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
-    "for", "(", Random.index(varBinderFor), makeDestructuringLValue(d, b), " = ", makeExpr(d, b), "; ", makeExpr(d, b),
-    "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)
-  ]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                                                    "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v, " = ", makeExpr(d, b),                             "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeDestructuringLValue(d, b), " = ", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
   /* eslint-enable no-multi-spaces */
 
   // Various types of "for" loops, specially set up to test tracing, carefully avoiding infinite loops
@@ -237,129 +214,61 @@ var statementMakers = Random.weighted([
   // "for..in" loops
   // arbitrary-LHS marked as infloop because
   // -- for (key in obj)
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
-    "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", makeExpr(d - 2, b), ") ",
-    makeStatementOrBlock(d, b)
-  ]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(),
-    "for", "(", Random.index(varBinderFor), v,                  " in ", makeExpr(d - 2, b), ") ",
-    makeStatementOrBlock(d, b.concat([v]))
-  ]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   // -- for (key in generator())
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
-    "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", "(",
-    "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b)
-  ]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(),
-    "for", "(", Random.index(varBinderFor), v,                  " in ", "(",
-    "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b.concat([v]))
-  ]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
   // -- for (element of arraylike)
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
-    " for ", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ",
-    makeStatementOrBlock(d, b)
-  ]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(),
-    " for ", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ",
-    makeStatementOrBlock(d, b.concat([v]))
-  ]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // -- for-await-of
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(),
-    " for ", "await", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ",
-    makeStatementOrBlock(d, b)
-  ]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(),
-    " for ", "await", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ",
-    makeStatementOrBlock(d, b.concat([v]))
-  ]); } },
+  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   /* eslint-enable no-multi-spaces */
 
   // Modify something during a loop -- perhaps the thing being looped over
   // Since we use "let" to bind the for-variables, and only do wacky stuff once, I *think* this is unlikely to hang.
-  //  function(d, b) { return "let forCount = 0; for (let " + makeId(d, b) + " in " +
-  //  makeExpr(d, b) + ") { if (forCount++ == " + rnd(3) + ") { " + makeStatement(d - 1, b) + " } }"; },
+  //  function(d, b) { return "let forCount = 0; for (let " + makeId(d, b) + " in " + makeExpr(d, b) + ") { if (forCount++ == " + rnd(3) + ") { " + makeStatement(d - 1, b) + " } }"; },
 
   /* eslint-disable no-multi-spaces */
-  // Hoisty "for..in" loops.  I don't know why this construct exists, but it does,
-  // and it hoists the initial-value expression above the loop.
+  // Hoisty "for..in" loops.  I don't know why this construct exists, but it does, and it hoists the initial-value expression above the loop.
   // With "var" or "const", the entire thing is hoisted.
   // With "let", only the value is hoisted, and it can be elim'ed as a useless statement.
   // The last form is specific to JavaScript 1.7 (only).
-  { w: 1, v: function(d, b) {                                                   return cat([maybeLabel(),
-    "for", "(", Random.index(varBinderFor), makeId(d, b),         " = ", makeExpr(d, b), " in ",
-    makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)
-  ]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b);                          return cat([maybeLabel(),
-    "for", "(", Random.index(varBinderFor), v,                    " = ", makeExpr(d, b), " in ",
-    makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))
-  ]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); var w = makeNewId(d, b); return cat([maybeLabel(),
-    "for", "(", Random.index(varBinderFor), "[", v, ", ", w, "]", " = ", makeExpr(d, b), " in ",
-    makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v, w]))
-  ]); } },
+  { w: 1, v: function(d, b) {                                                   return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeId(d, b),         " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b);                          return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                    " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); var w = makeNewId(d, b); return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), "[", v, ", ", w, "]", " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v, w]))]); } },
   /* eslint-enable no-multi-spaces */
 
   // do..while
-  { w: 1, v: function(d, b) { return cat([maybeLabel(),
-    "while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */,
-    makeStatementOrBlock(d, b)
-  ]); } },
-  { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(),
-    "while", "(", makeExpr(d, b), ")", makeStatementOrBlock(d, b)
-  ]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(),
-    "do ", makeStatementOrBlock(d, b), " while((",
-    makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, ";"
-  ]); } },
-  { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(),
-    "do ", makeStatementOrBlock(d, b), " while", "(", makeExpr(d, b), ");"
-  ]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(), "while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(), "while", "(", makeExpr(d, b), ")", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, ";"]); } },
+  { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while", "(", makeExpr(d, b), ");"]); } },
 
   // Switch statement
-  { w: 3, v: function(d, b) { return cat([maybeLabel(),
-    "switch", "(", makeExpr(d, b), ")", " { ", makeSwitchBody(d, b), " }"
-  ]); } },
+  { w: 3, v: function(d, b) { return cat([maybeLabel(), "switch", "(", makeExpr(d, b), ")", " { ", makeSwitchBody(d, b), " }"]); } },
 
   // "let" blocks, with bound variable used inside the block
-  { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat([
-    "let ", "(", v, ")", " { ", makeStatement(d, b.concat([v])), " }"
-  ]); } },
+  { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v, ")", " { ", makeStatement(d, b.concat([v])), " }"]); } },
 
   // "let" blocks, with and without multiple bindings, with and without initial values
-  { w: 2, v: function(d, b) { return cat([
-    "let ", "(", makeLetHead(d, b), ")", " { ", makeStatement(d, b), " }"
-  ]); } },
+  { w: 2, v: function(d, b) { return cat(["let ", "(", makeLetHead(d, b), ")", " { ", makeStatement(d, b), " }"]); } },
 
   // Conditionals, perhaps with 'else if' / 'else'
-  { w: 1, v: function(d, b) { return cat([maybeLabel(),
-    "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d, b)
-  ]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(),
-    "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b)
-  ]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(),
-    "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b),
-    " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b)
-  ]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(),
-    "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b),
-    " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b),
-    " else ", makeStatementOrBlock(d - 1, b)
-  ]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b)]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b)]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b)]); } },
 
   // A tricky pair of if/else cases.
   // In the SECOND case, braces must be preserved to keep the final "else" associated with the first "if".
-  { w: 1, v: function(d, b) { return cat([maybeLabel(),
-    "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b),
-    " else ", makeStatementOrBlock(d - 1, b), "}"
-  ]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(),
-    "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), "}",
-    " else ", makeStatementOrBlock(d - 1, b)
-  ]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b), "}"]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), "}", " else ", makeStatementOrBlock(d - 1, b)]); } },
 
   // Expression statements
   { w: 5, v: function(d, b) { return cat([makeExpr(d, b), ";"]); } },
@@ -373,9 +282,7 @@ var statementMakers = Random.weighted([
   { w: 1, v: function(d, b) { return cat(["L", ": ", makeStatementOrBlock(d, b)]); } },
 
   // Function-declaration-statements with shared names
-  { w: 10, v: function(d, b) { return cat([makeStatement(d-2, b),
-    "function ", makeId(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d - 1, b), makeStatement(d-2, b)
-  ]); } },
+  { w: 10, v: function(d, b) { return cat([makeStatement(d-2, b), "function ", makeId(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d - 1, b), makeStatement(d-2, b)]); } },
 
   // Function-declaration-statements with unique names, along with calls to those functions
   { w: 8, v: makeNamedFunctionAndUse },
@@ -383,17 +290,12 @@ var statementMakers = Random.weighted([
   // Long script -- can confuse Spidermonkey's short vs long jmp or something like that.
   // Spidermonkey's regexp engine is so slow for long strings that we have to bypass whatToTest :(
   // { w: 1, v: function(d, b) { return strTimes("try{}catch(e){}", rnd(10000)); } },
-  { w: 1, v: function(d, b) { if (rnd(200)==0) return "/*DUPTRY"
-    + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";";
-  } },
+  { w: 1, v: function(d, b) { if (rnd(200)==0) return "/*DUPTRY" + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";"; } },
 
   { w: 1, v: function(d, b) { return makeShapeyConstructorLoop(d, b); } },
 
-  // Replace a variable with a long linked list pointing to it.
-  // (Forces SpiderMonkey's GC marker into a stackless mode.)
-  { w: 1, v: function(d, b) { var x = makeId(d, b); return x
-    + " = linkedList(" + x + ", " + (rnd(100) * rnd(100)) + ");";
-  } },
+  // Replace a variable with a long linked list pointing to it.  (Forces SpiderMonkey's GC marker into a stackless mode.)
+  { w: 1, v: function(d, b) { var x = makeId(d, b); return x + " = linkedList(" + x + ", " + (rnd(100) * rnd(100)) + ");"; } },
 
   // Oddly placed "use strict" or "use asm"
   { w: 1, v: function(d, b) { return directivePrologue() + makeStatement(d - 1, b); } },
@@ -416,8 +318,7 @@ var statementMakers = Random.weighted([
 
   // Discover properties to add to the allPropertyNames list
   // { w: 3, v: function(d, b) { return "for (var p in " + makeId(d, b) + ") { addPropertyName(p); }"; } },
-  // { w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" +
-  // makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
+  // { w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" + makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
 ]);
 
 if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
@@ -463,8 +364,7 @@ function makeUseRegressionTest(d, b)
       // run it using load()
         s += "/* regression-test-load */ " + "load(" + simpleSource(file) + ");";
         break;
-      // NB: these scripts will also be run through eval(), evalcx(), evaluate()
-      // thanks to other parts of the fuzzer using makeScriptForEval or makeStatement
+      // NB: these scripts will also be run through eval(), evalcx(), evaluate() thanks to other parts of the fuzzer using makeScriptForEval or makeStatement
     }
   }
   return s;
@@ -485,8 +385,7 @@ function regressionTestIsEvil(contents)
 
 function inlineTest(filename)
 {
-  // Inline a regression test, adding NODIFF (to disable differential testing)
-  // if it calls a testing function that might throw.
+  // Inline a regression test, adding NODIFF (to disable differential testing) if it calls a testing function that might throw.
 
   const s = "/* " + filename + " */ " + read(filename) + "\n";
 
@@ -499,8 +398,7 @@ function inlineTest(filename)
     "enableSingleStepProfiling",
     // These return values depending on command-line options, and some regression tests check them
     "isAsmJSCompilationAvailable",
-    // in 32-bit x86 builds, it depends on whether --no-fpu is passed in, because --no-fpu also disables SSE
-    "isSimdAvailable",
+    "isSimdAvailable", // in 32-bit x86 builds, it depends on whether --no-fpu is passed in, because --no-fpu also disables SSE
     "hasChild",
     "PerfMeasurement",
   ];
@@ -677,10 +575,8 @@ var littleStatementMakers =
 
   // Return, yield, await
   function(d, b) { return cat(["return ", makeExpr(d, b), ";"]); },
-  // return without a value is allowed in generators; return with a value is not.
-  function(d, b) { return "return;"; },
-  // note: yield can also be a left-unary operator, or something like that
-  function(d, b) { return cat(["yield ", makeExpr(d, b), ";"]); },
+  function(d, b) { return "return;"; }, // return without a value is allowed in generators; return with a value is not.
+  function(d, b) { return cat(["yield ", makeExpr(d, b), ";"]); }, // note: yield can also be a left-unary operator, or something like that
   function(d, b) { return "yield;"; },
   function(d, b) { return cat(["await ", makeExpr(d, b), ";"]); },
 
@@ -753,27 +649,17 @@ var exceptionyStatementMakers = [
 
   // Iteration is also useful to test because it asserts that there is no pending exception.
   function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " in []);"; },
-  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " in " + makeIterable(d, b) + ") "
-    + makeExceptionyStatement(d, b.concat([v]));
-  },
-  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " of " + makeIterable(d, b) + ") "
-    + makeExceptionyStatement(d, b.concat([v]));
-  },
-  function(d, b) { var v = makeNewId(d, b); return "for await(let " + v + " of " + makeIterable(d, b) + ") "
-    + makeExceptionyStatement(d, b.concat([v]));
-  },
+  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " in " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
+  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
+  function(d, b) { var v = makeNewId(d, b); return "for await(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
 
   /* eslint-disable no-multi-spaces */
   // Brendan says these are scary places to throw: with, let block, lambda called immediately in let expr.
   // And I think he was right.
   function(d, b) { return "with({}) "   + makeExceptionyStatement(d, b);         },
   function(d, b) { return "with({}) { " + makeExceptionyStatement(d, b) + " } "; },
-  function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") { "
-    + makeExceptionyStatement(d, b.concat([v])) + "}";
-  },
-  function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") ((function(){"
-    + makeExceptionyStatement(d, b.concat([v])) + "})());";
-  },
+  function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") { " + makeExceptionyStatement(d, b.concat([v])) + "}"; },
+  function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") ((function(){" + makeExceptionyStatement(d, b.concat([v])) + "})());"; },
   function(d, b) { return "let(" + makeLetHead(d, b) + ") { " + makeExceptionyStatement(d, b) + "}"; },
   function(d, b) { return "let(" + makeLetHead(d, b) + ") ((function(){" + makeExceptionyStatement(d, b) + "})());"; },
   /* eslint-enable no-multi-spaces */
@@ -781,16 +667,12 @@ var exceptionyStatementMakers = [
   // Commented out due to causing too much noise on stderr and causing a nonzero exit code :/
 /*
   // Generator close hooks: called during GC in this case!!!
-  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " }
-    finally { " + makeStatement(d, b) + " } })().next()"; },
+  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " } finally { " + makeStatement(d, b) + " } })().next()"; },
 
-  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " }
-    finally { " + makeStatement(d, b) + " } })()"; },
-  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " }
-    finally { " + makeStatement(d, b) + " } })"; },
+  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " } finally { " + makeStatement(d, b) + " } })()"; },
+  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " } finally { " + makeStatement(d, b) + " } })"; },
   function(d, b) {
-    return "function gen() { try { yield 1; } finally { " + makeStatement(d, b) + " } }
-      var i = gen(); i.next(); i = null;";
+    return "function gen() { try { yield 1; } finally { " + makeStatement(d, b) + " } } var i = gen(); i.next(); i = null;";
   }
 
 */
@@ -818,11 +700,9 @@ function makeTryBlock(d, b)
     var catchId = makeId(d, b);
     var catchBlock = makeExceptionyStatement(d, b.concat([catchId]));
     if (rnd(2))
-      s += cat(["catch", "(", catchId, " if ",
-        makeExpr(d, b), ")", " { ", catchBlock, " } "]);
+      s += cat(["catch", "(", catchId, " if ",                 makeExpr(d, b),                    ")", " { ", catchBlock, " } "]);
     else
-      s += cat(["catch", "(", catchId, " if ", "(function(){",
-        makeExceptionyStatement(d, b), "})())", " { ", catchBlock, " } "]);
+      s += cat(["catch", "(", catchId, " if ", "(function(){", makeExceptionyStatement(d, b), "})())", " { ", catchBlock, " } "]);
   }
 
   if (rnd(2)) {
@@ -830,7 +710,7 @@ function makeTryBlock(d, b)
     ++numCatches;
     var catchId = makeId(d, b);
     var catchBlock = makeExceptionyStatement(d, b.concat([catchId]));
-    s +=   cat(["catch", "(", catchId, ")", " { ", catchBlock, " } "]);
+    s +=   cat(["catch", "(", catchId,                                                          ")", " { ", catchBlock, " } "]);
   }
 
   if (numCatches == 0 || rnd(2) === 1) {
@@ -878,9 +758,7 @@ var leftUnaryOps = [
   "!", "+", "-", "~",
   "void ", "typeof ", "delete ",
   "new ", // but note that "new" can also be a very strange left-binary operator
-  // see http://www.python.org/dev/peps/pep-0342/ .
-  // Often needs to be parenthesized, so there's also a special exprMaker for it.
-  "yield ",
+  "yield ", // see http://www.python.org/dev/peps/pep-0342/ .  Often needs to be parenthesized, so there's also a special exprMaker for it.
   "await ",
 ];
 
@@ -925,18 +803,10 @@ var exprMakers =
   function(d, b) { return cat([Random.index(leftUnaryOps), makeExpr(d, b)]); },
 
   // Methods
-  function(d, b) { var id = makeId(d, b); return cat([
-    "/*UUV1*/", "(", id, ".", Random.index(allMethodNames), " = ", makeFunction(d, b), ")"
-  ]); },
-  function(d, b) { var id = makeId(d, b); return cat([
-    "/*UUV2*/", "(", id, ".", Random.index(allMethodNames), " = ", id, ".", Random.index(allMethodNames), ")"
-  ]); },
-  function(d, b) { return cat([makeExpr(d, b),
-    ".", Random.index(allMethodNames), "(", makeActualArgList(d, b), ")"
-  ]); },
-  function(d, b) { return cat([makeExpr(d, b),
-    ".", "valueOf", "(", uneval("number"), ")"
-  ]); },
+  function(d, b) { var id = makeId(d, b); return cat(["/*UUV1*/", "(", id, ".", Random.index(allMethodNames), " = ", makeFunction(d, b), ")"]); },
+  function(d, b) { var id = makeId(d, b); return cat(["/*UUV2*/", "(", id, ".", Random.index(allMethodNames), " = ", id, ".", Random.index(allMethodNames), ")"]); },
+  function(d, b) { return cat([makeExpr(d, b), ".", Random.index(allMethodNames), "(", makeActualArgList(d, b), ")"]); },
+  function(d, b) { return cat([makeExpr(d, b), ".", "valueOf", "(", uneval("number"), ")"]); },
 
   // Binary operators
   function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
@@ -959,8 +829,7 @@ var exprMakers =
   function(d, b) { return cat([makeExpr(d, b), " ? ", makeExpr(d, b), " : ", makeExpr(d, b)]); },
   function(d, b) { return cat([makeExpr(d, b), " ? ", makeExpr(d, b), " : ", makeExpr(d, b)]); },
 
-  // In most contexts, yield expressions must be parenthesized,
-  // so including explicitly parenthesized yields makes actually-compiling yields appear more often.
+  // In most contexts, yield expressions must be parenthesized, so including explicitly parenthesized yields makes actually-compiling yields appear more often.
   function(d, b) { return cat(["yield ", makeExpr(d, b)]); },
   function(d, b) { return cat(["(", "yield ", makeExpr(d, b), ")"]); },
 
@@ -976,23 +845,15 @@ var exprMakers =
   function(d, b) { return cat(["dumpScopeChain", "(", makeFunction(d, b), ")"]); },
 
   // Array functions (including extras).  The most interesting are map and filter, I think.
-  // These are mostly interesting to fuzzers in the sense of
-  // "what happens if i do strange things from a filter function?"  e.g. modify the array.. :)
-  // This fuzzer isn't the best for attacking this kind of thing,
-  // since it's unlikely that the code in the function will attempt to modify the array or make it go away.
+  // These are mostly interesting to fuzzers in the sense of "what happens if i do strange things from a filter function?"  e.g. modify the array.. :)
+  // This fuzzer isn't the best for attacking this kind of thing, since it's unlikely that the code in the function will attempt to modify the array or make it go away.
   // The second parameter to "map" is used as the "this" for the function.
   function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]) ]); },
-  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]),
-    "(", makeFunction(d, b), ", ", makeExpr(d, b), ")"
-  ]); },
-  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]),
-    "(", makeFunction(d, b), ")"
-  ]); },
+  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ", ", makeExpr(d, b), ")"]); },
+  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ")"]); },
 
   // RegExp replace.  This is interesting for the same reason as array extras.
-  function(d, b) { return cat(["'fafafa'", ".", "replace",
-    "(", "/", "a", "/", "g", ", ", makeFunction(d, b), ")"
-  ]); },
+  function(d, b) { return cat(["'fafafa'", ".", "replace", "(", "/", "a", "/", "g", ", ", makeFunction(d, b), ")"]); },
 
   // Containment in an array or object (or, if this happens to end up on the LHS of an assignment, destructuring)
   function(d, b) { return cat(["[", makeExpr(d, b), "]"]); },
@@ -1009,9 +870,7 @@ var exprMakers =
   function(d, b) { return cat([     makeFunction(d, b),      "(", makeActualArgList(d, b), ")"]); },
 
   // Try to test function.call heavily.
-  function(d, b) { return cat(["(", makeFunction(d, b), ")", ".", "call", "(", makeExpr(d, b), ", ",
-    makeActualArgList(d, b), ")"
-  ]); },
+  function(d, b) { return cat(["(", makeFunction(d, b), ")", ".", "call", "(", makeExpr(d, b), ", ", makeActualArgList(d, b), ")"]); },
 
   // Binary "new", with and without clarifying parentheses, with expressions or functions
   function(d, b) { return cat(["new ",      makeExpr(d, b),          "(", makeActualArgList(d, b), ")"]); },
@@ -1020,22 +879,15 @@ var exprMakers =
   function(d, b) { return cat(["new ",      makeFunction(d, b),      "(", makeActualArgList(d, b), ")"]); },
   function(d, b) { return cat(["new ", "(", makeFunction(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
 
-  // Sometimes we do crazy stuff, like putting a statement where an expression should go.
-  // This frequently causes a syntax error.
+  // Sometimes we do crazy stuff, like putting a statement where an expression should go.  This frequently causes a syntax error.
   function(d, b) { return stripSemicolon(makeLittleStatement(d, b)); },
   function(d, b) { return ""; },
 
   /* eslint-disable no-multi-spaces */
   // Let expressions -- note the lack of curly braces.
-  function(d, b) { var v = makeNewId(d, b); return cat([
-    "let ", "(", v, ") ", makeExpr(d - 1, b.concat([v]))
-  ]); },
-  function(d, b) { var v = makeNewId(d, b); return cat([
-    "let ", "(", v, " = ", makeExpr(d - 1, b), ") ", makeExpr(d - 1, b.concat([v]))
-  ]); },
-  function(d, b) {                          return cat([
-    "let ", "(", makeLetHead(d, b), ") ", makeExpr(d, b)
-  ]); },
+  function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v,                            ") ", makeExpr(d - 1, b.concat([v]))]); },
+  function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v, " = ", makeExpr(d - 1, b), ") ", makeExpr(d - 1, b.concat([v]))]); },
+  function(d, b) {                          return cat(["let ", "(", makeLetHead(d, b),            ") ", makeExpr(d, b)]); },
   /* eslint-enable no-multi-spaces */
 
   // Comments and whitespace
@@ -1065,9 +917,7 @@ var exprMakers =
   function(d, b) { return cat([makeLValue(d, b), Random.index(["|=", "%=", "+=", "-="]), makeExpr(d, b)]); },
 
   // ES5 getter/setter syntax, imperative (added in Gecko 1.9.3?)
-  function(d, b) { return cat([
-    "Object.defineProperty", "(", makeId(d, b), ", ", makePropertyName(d, b), ", ", makePropertyDescriptor(d, b), ")"
-  ]); },
+  function(d, b) { return cat(["Object.defineProperty", "(", makeId(d, b), ", ", makePropertyName(d, b), ", ", makePropertyDescriptor(d, b), ")"]); },
 
   // Test the prototype of a particular object
   function(d, b) { return cat(["Object.getPrototypeOf", "(", makeId(d, b), ")"]); },
@@ -1077,18 +927,10 @@ var exprMakers =
   function(d, b) { return cat(["Object.values", "(", makeId(d, b), ")"]); },
 
   // Old getter/setter syntax, imperative
-  function(d, b) { return cat([
-    makeExpr(d, b), ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"
-  ]); },
-  function(d, b) { return cat([
-    makeExpr(d, b), ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"
-  ]); },
-  function(d, b) { return cat([
-    "this", ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"
-  ]); },
-  function(d, b) { return cat([
-    "this", ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"
-  ]); },
+  function(d, b) { return cat([makeExpr(d, b), ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
+  function(d, b) { return cat([makeExpr(d, b), ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
+  function(d, b) { return cat(["this", ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
+  function(d, b) { return cat(["this", ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
 
   // Object literal
   function(d, b) { return cat(["(", "{", makeObjLiteralPart(d, b), " }", ")"]); },
@@ -1109,8 +951,7 @@ var exprMakers =
   function(d, b) { return "eval(" + uneval(makeScriptForEval(d, b)) + ")"; },
   function(d, b) { return "eval(" + uneval(makeScriptForEval(d, b)) + ", " + makeExpr(d, b) + ")"; },
 
-  // Uneval needs more testing than it will get accidentally.
-  // No cat() because I don't want uneval clobbered (assigned to) accidentally.
+  // Uneval needs more testing than it will get accidentally.  No cat() because I don't want uneval clobbered (assigned to) accidentally.
   function(d, b) { return "(uneval(" + makeExpr(d, b) + "))"; },
 
   /* eslint-disable no-multi-spaces */
@@ -1127,31 +968,16 @@ var exprMakers =
 
   /* eslint-disable no-multi-spaces */
   // Binary Math functions
-  function(d, b) { return "Math."
-    + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeExpr(d, b)   + ")";
-  },
-  function(d, b) { return "Math."
-    + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeNumber(d, b) + ")";
-  },
-  function(d, b) { return "Math."
-    + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeExpr(d, b)   + ")";
-  },
-  function(d, b) { return "Math."
-    + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeNumber(d, b) + ")";
-  },
+  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeExpr(d, b)   + ")"; },
+  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeNumber(d, b) + ")"; },
+  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeExpr(d, b)   + ")"; },
+  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeNumber(d, b) + ")"; },
   /* eslint-enable no-multi-spaces */
 
   // Harmony proxy creation: object, function without constructTrap, function with constructTrap
-  function(d, b) { return makeId(d, b)
-    + " = " + "Proxy.create(" + makeProxyHandler(d, b) + ", " + makeExpr(d, b) + ")";
-  },
-  function(d, b) { return makeId(d, b)
-    + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ")";
-  },
-  function(d, b) { return makeId(d, b)
-    + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ", "
-    + makeFunction(d, b) + ")";
-  },
+  function(d, b) { return makeId(d, b) + " = " + "Proxy.create(" + makeProxyHandler(d, b) + ", " + makeExpr(d, b) + ")"; },
+  function(d, b) { return makeId(d, b) + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ")"; },
+  function(d, b) { return makeId(d, b) + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ", " + makeFunction(d, b) + ")"; },
 
   function(d, b) { return cat(["delete", " ", makeId(d, b), ".", makeId(d, b)]); },
 
@@ -1162,14 +988,12 @@ var exprMakers =
   function(d, b) { return "(void options('strict'))"; },
 
   // More special Spidermonkey shell functions
-  // (Note: functions without returned objects or visible side effects go in testing-functions.js,
-  // in order to allow presence/absence differential testing.)
+  // (Note: functions without returned objects or visible side effects go in testing-functions.js, in order to allow presence/absence differential testing.)
   //  function(d, b) { return "dumpObject(" + makeExpr(d, b) + ")" } }, // crashes easily, bug 836603
   function(d, b) { return "(void shapeOf(" + makeExpr(d, b) + "))"; },
   function(d, b) { return "intern(" + makeExpr(d, b) + ")"; },
   function(d, b) { return "allocationMarker()"; },
-  // see https://bugzilla.mozilla.org/show_bug.cgi?id=840284#c12 -- replace when bug 831046 is fixed
-  function(d, b) { return "timeout(1800)"; },
+  function(d, b) { return "timeout(1800)"; }, // see https://bugzilla.mozilla.org/show_bug.cgi?id=840284#c12 -- replace when bug 831046 is fixed
   function(d, b) { return "(makeFinalizeObserver('tenured'))"; },
   function(d, b) { return "(makeFinalizeObserver('nursery'))"; },
 
@@ -1184,8 +1008,7 @@ var fuzzTestingFunctions = fuzzTestingFunctionsCtor(!jsshell, fuzzTestingFunctio
 
 // Ensure that even if makeExpr returns "" or "1, 2", we only pass one argument to functions like schedulegc
 // (null || (" + makeExpr(d - 2, b) + "))
-// Darn, only |this| and local variables are safe:
-// an expression with side effects breaks the statement-level compare_jit hack
+// Darn, only |this| and local variables are safe: an expression with side effects breaks the statement-level compare_jit hack
 function fuzzTestingFunctionArg(d, b) { return "this"; }
 
 function makeTestingFunctionCall(d, b)
@@ -1285,9 +1108,7 @@ if (xpcshell) {
     function(d, b) { var n = rnd(4); return "newGeckoSandbox(" + n + ")"; },
     function(d, b) { var n = rnd(4); return "s" + n + " = newGeckoSandbox(" + n + ")"; },
     // FIXME: Doesn't this need to be Components.utils.evalInSandbox?
-    function(d, b) { var n = rnd(4); return "evalInSandbox("
-      + uneval(makeStatement(d, b)) + ", newGeckoSandbox(" + n + "))";
-    },
+    function(d, b) { var n = rnd(4); return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", newGeckoSandbox(" + n + "))"; },
     function(d, b) { var n = rnd(4); return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", s" + n + ")"; },
     function(d, b) { return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", " + makeExpr(d, b) + ")"; },
     function(d, b) { return "(Components.classes ? quit() : gc()); }"; },
@@ -1319,14 +1140,12 @@ function makeShapeyConstructor(d, b)
     switch (rnd(8)) {
       /* eslint-disable no-multi-spaces */
       case 0:  funText += "delete " + tprop + ";"; break;
-      case 1:  funText += "Object.defineProperty(" + t + ", "
-        + (rnd(2) ? propName : makePropertyName(d, b)) + ", " + makePropertyDescriptor(d, bp) + ");"; break;
+      case 1:  funText += "Object.defineProperty(" + t + ", " + (rnd(2) ? propName : makePropertyName(d, b)) + ", " + makePropertyDescriptor(d, bp) + ");"; break;
       case 2:  funText += "{ " + makeStatement(d, bp) + " } "; break;
       case 3:  funText += tprop + " = " + makeExpr(d, bp)        + ";"; break;
       case 4:  funText += tprop + " = " + makeFunction(d, bp)    + ";"; break;
       case 5:  funText += "for (var ytq" + uniqueVarName() + " in " + t + ") { }"; break;
-      case 6:  funText += "Object." + Random.index(["preventExtensions", "seal", "freeze"])
-        + "(" + t + ");"; break;
+      case 6:  funText += "Object." + Random.index(["preventExtensions", "seal", "freeze"]) + "(" + t + ");"; break;
       default: funText += tprop + " = " + makeShapeyValue(d, bp) + ";"; break;
       /* eslint-enable no-multi-spaces */
     }
@@ -1411,8 +1230,7 @@ function makeBoolean(d, b)
     case 0:   return "true";
     case 1:   return "false";
     case 2:   return makeExpr(d - 2, b);
-    default:  var m = loopModulo(); return "(" + Random.index(b) + " % " + m + Random.index([" == ", " != "])
-      + rnd(m) + ")";
+    default:  var m = loopModulo(); return "(" + Random.index(b) + " % " + m + Random.index([" == ", " != "]) + rnd(m) + ")";
     /* eslint-enable no-multi-spaces */
   }
 }
@@ -1427,16 +1245,10 @@ function makeObjLiteralPart(d, b)
   // Literal getter/setter
   // Surprisingly, string literals, integer literals, and float literals are also good!
   // (See https://bugzilla.mozilla.org/show_bug.cgi?id=520696.)
-    case 2: return cat([" get ", makeObjLiteralName(d, b), maybeName(d, b), "(",
-      makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)
-    ]);
-    case 3: return cat([" set ", makeObjLiteralName(d, b), maybeName(d, b), "(",
-      makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)
-    ]);
+    case 2: return cat([" get ", makeObjLiteralName(d, b), maybeName(d, b), "(", makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)]);
+    case 3: return cat([" set ", makeObjLiteralName(d, b), maybeName(d, b), "(", makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)]);
 
-    case 4: return "/*toXFun*/" + cat([
-      Random.index(["toString", "valueOf"]), ": ", makeToXFunction(d - 1, b)
-    ]);
+    case 4: return "/*toXFun*/" + cat([Random.index(["toString", "valueOf"]), ": ", makeToXFunction(d - 1, b)]);
 
     default: return cat([makeObjLiteralName(d, b), ": ", makeExpr(d, b)]);
   }
@@ -1539,73 +1351,49 @@ var functionMakers = [
 
   /* eslint-disable no-multi-spaces */
   // Functions and expression closures
-  function(d, b) { var v = makeNewId(d, b); return cat([functionPrefix(), " ", maybeName(d, b), "(",
-    v, ")", makeFunctionBody(d, b.concat([v]))
-  ]); },
-  function(d, b) {                          return cat([functionPrefix(), " ", maybeName(d, b), "(",
-    makeFormalArgList(d, b), ")", makeFunctionBody(d, b)
-  ]); },
+  function(d, b) { var v = makeNewId(d, b); return cat([functionPrefix(), " ", maybeName(d, b), "(", v,                       ")", makeFunctionBody(d, b.concat([v]))]); },
+  function(d, b) {                          return cat([functionPrefix(), " ", maybeName(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d, b)]); },
   /* eslint-enable no-multi-spaces */
 
+  /* eslint-disable no-multi-spaces */
   // Arrow functions with one argument (no parens needed) (no destructuring allowed in this form?)
-  function(d, b) { var v = makeNewId(d, b); return cat([
-    v, " => ", makeFunctionBody(d, b.concat([v]))
-  ]); },
+  function(d, b) { var v = makeNewId(d, b); return cat([     v,                            " => ", makeFunctionBody(d, b.concat([v]))]); },
+  /* eslint-enable no-multi-spaces */
 
+  /* eslint-disable no-multi-spaces */
   // Arrow functions with multiple arguments
-  function(d, b) { return cat(["(", makeFormalArgList(d, b), ")", " => ", makeFunctionBody(d, b)]); },
+  function(d, b) {                          return cat(["(", makeFormalArgList(d, b), ")", " => ", makeFunctionBody(d, b)]); },
+  /* eslint-enable no-multi-spaces */
 
   // The identity function
   function(d, b) { return functionPrefix() + "(q) { " + directivePrologue() + "return q; }"; },
   function(d, b) { return "q => q"; },
 
   // A function that does something
-  function(d, b) { return functionPrefix() + "(y) { " + directivePrologue()
-    + makeStatement(d, b.concat(["y"])) + " }";
-  },
+  function(d, b) { return functionPrefix() + "(y) { " + directivePrologue() + makeStatement(d, b.concat(["y"])) + " }"; },
 
   // A function that computes something
-  function(d, b) { return functionPrefix() + "(y) { " + directivePrologue()
-    + "return " + makeExpr(d, b.concat(["y"])) + " }";
-  },
+  function(d, b) { return functionPrefix() + "(y) { " + directivePrologue() + "return " + makeExpr(d, b.concat(["y"])) + " }"; },
 
   // A generator that does something
-  function(d, b) { return "function(y) { " + directivePrologue() + "yield y; "
-    + makeStatement(d, b.concat(["y"])) + "; yield y; }";
-  },
-  function(d, b) { return "function*(y) { " + directivePrologue() + "yield y; "
-    + makeStatement(d, b.concat(["y"])) + "; yield y; }";
-  },
+  function(d, b) { return "function(y) { " + directivePrologue() + "yield y; " + makeStatement(d, b.concat(["y"])) + "; yield y; }"; },
+  function(d, b) { return "function*(y) { " + directivePrologue() + "yield y; " + makeStatement(d, b.concat(["y"])) + "; yield y; }"; },
 
   // An async function that does something
-  function(d, b) { return "async function (y) { " + directivePrologue() + "await y; "
-    + makeStatement(d, b.concat(["y"])) + "; await y; }";
-  },
+  function(d, b) { return "async function (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
 
   // An async generator that does something
-  function(d, b) { return "async function* (y) { " + directivePrologue() + "await y; "
-    + makeStatement(d, b.concat(["y"])) + "; await y; }";
-  },
-  function(d, b) { return "async function* (y) { " + directivePrologue() + "yield y; await y; "
-    + makeStatement(d, b.concat(["y"])) + "; yield y; await y; }";
-  },
+  function(d, b) { return "async function* (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
+  function(d, b) { return "async function* (y) { " + directivePrologue() + "yield y; await y; " + makeStatement(d, b.concat(["y"])) + "; yield y; await y; }"; },
 
   // A simple wrapping pattern
-  function(d, b) { return "/*wrap1*/(" + functionPrefix() + "(){ " + directivePrologue() + makeStatement(d, b)
-    + "return " + makeFunction(d, b) + "})()";
-  },
+  function(d, b) { return "/*wrap1*/(" + functionPrefix() + "(){ " + directivePrologue() + makeStatement(d, b) + "return " + makeFunction(d, b) + "})()"; },
 
   // Wrapping with upvar: escaping, may or may not be modified
-  function(d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap2*/(" + functionPrefix() + "(){ "
-    + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b)
-    + "; var " + v2 + " = " + makeFunction(d, b.concat([v1])) + "; return " + v2 + ";})()";
-  },
+  function(d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap2*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; var " + v2 + " = " + makeFunction(d, b.concat([v1])) + "; return " + v2 + ";})()"; },
 
   // Wrapping with upvar: non-escaping
-  function(d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap3*/(" + functionPrefix() + "(){ "
-    + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b)
-    + "; (" + makeFunction(d, b.concat([v1])) + ")(); })";
-  },
+  function(d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap3*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; (" + makeFunction(d, b.concat([v1])) + ")(); })"; },
 
   // Apply, call
   function(d, b) { return "(" + makeFunction(d-1, b) + ").apply"; },
@@ -1618,14 +1406,10 @@ var functionMakers = [
   // Methods with known names
   function(d, b) { return cat([makeExpr(d, b), ".", Random.index(allMethodNames)]); },
 
-  // Special functions that might have interesting results,
-  // especially when called "directly" by things like string.replace or array.map.
-  // eval is interesting both for its "no indirect calls" feature
-  // and for the way it's implemented in spidermonkey (a special bytecode).
-  function(d, b) { return "eval"; },
+  // Special functions that might have interesting results, especially when called "directly" by things like string.replace or array.map.
+  function(d, b) { return "eval"; }, // eval is interesting both for its "no indirect calls" feature and for the way it's implemented in spidermonkey (a special bytecode).
   function(d, b) { return "(let (e=eval) e)"; },
-  // this won't be interpreted the same way for each caller of makeFunction, but that's ok
-  function(d, b) { return "new Function"; },
+  function(d, b) { return "new Function"; }, // this won't be interpreted the same way for each caller of makeFunction, but that's ok
   function(d, b) { return "(new Function(" + uneval(makeStatement(d, b)) + "))"; },
   function(d, b) { return "Function"; }, // without "new"
   function(d, b) { return "decodeURI"; },
@@ -1866,8 +1650,7 @@ function makeId(d, b)
 
   // window is a const (in the browser), so some attempts to redeclare it will cause errors
 
-  // eval is interesting because it cannot be called indirectly
-  // and maybe also because it has its own opcode in jsopcode.tbl.
+  // eval is interesting because it cannot be called indirectly. and maybe also because it has its own opcode in jsopcode.tbl.
   // but bad things happen if you have "eval setter". so let's not put eval in this list.
 }
 
@@ -1883,17 +1666,13 @@ function makeComprehension(d, b)
     case 0:
       return "";
     case 1:
-      return cat([" for ", "(", makeForInLHS(d, b), " in ", makeExpr(d - 2, b),     ")"])
-        + makeComprehension(d - 1, b);
+      return cat([" for ",          "(", makeForInLHS(d, b), " in ", makeExpr(d - 2, b),     ")"]) + makeComprehension(d - 1, b);
     case 2:
-      return cat([" for ", "(", makeId(d, b),       " of ", makeExpr(d - 2, b),     ")"])
-        + makeComprehension(d - 1, b);
+      return cat([" for ",          "(", makeId(d, b),       " of ", makeExpr(d - 2, b),     ")"]) + makeComprehension(d - 1, b);
     case 3:
-      return cat([" for ", "(", makeId(d, b),       " of ", makeIterable(d - 2, b), ")"])
-        + makeComprehension(d - 1, b);
+      return cat([" for ",          "(", makeId(d, b),       " of ", makeIterable(d - 2, b), ")"]) + makeComprehension(d - 1, b);
     default:
-      // this is always last (and must be preceded by a "for", oh well)
-      return cat([" if ", "(", makeExpr(d - 2, b), ")"]);
+      return cat([" if ", "(", makeExpr(d - 2, b), ")"]); // this is always last (and must be preceded by a "for", oh well)
   }
 }
 
@@ -2115,10 +1894,8 @@ function makeCrazyToken()
     "...", "=>",
 
     // most real keywords plus a few reserved keywords
-    " in ", " instanceof ", " let ", " new ", " get ", " for ", " if ", " else ", " else if ",
-    " try ", " catch ", " finally ", " export ", " import ", " void ", " with ",
-    " default ", " goto ", " case ", " switch ", " do ", " /*infloop*/while ", " return ",
-    " yield ", " await ", " break ", " continue ", " typeof ", " var ", " const ",
+    " in ", " instanceof ", " let ", " new ", " get ", " for ", " if ", " else ", " else if ", " try ", " catch ", " finally ", " export ", " import ", " void ", " with ",
+    " default ", " goto ", " case ", " switch ", " do ", " /*infloop*/while ", " return ", " yield ", " await ", " break ", " continue ", " typeof ", " var ", " const ",
 
     // reserved when found in strict mode code
     " package ",
@@ -2157,8 +1934,7 @@ function makeShapeyValue(d, b)
       "1.2e3", "1e81", "1e+81", "1e-81", "1e4", "-0", "(-0)",
       "-1", "(-1)", "0x99", "033", "3/0", "-3/0", "0/0",
       "Math.PI",
-      "0x2D413CCC", "0x5a827999", "0xB504F332", "-0x2D413CCC", "-0x5a827999", "-0xB504F332",
-      "0x50505050", "(0x50505050 >> 1)",
+      "0x2D413CCC", "0x5a827999", "0xB504F332", "-0x2D413CCC", "-0x5a827999", "-0xB504F332", "0x50505050", "(0x50505050 >> 1)",
 
       // various powers of two, with values near JSVAL_INT_MAX especially tested
       "0x10000000", "0x20000000", "0x3FFFFFFE", "0x3FFFFFFF", "0x40000000", "0x40000001",
@@ -2218,8 +1994,7 @@ function makeShapeyValue(d, b)
 
     // Fun stuff
     [ "function(){}" ],
-    [ "{}", "[]", "[1]", "['z']", "[undefined]", "this", "eval",
-      "arguments", "arguments.caller", "arguments.callee" ],
+    [ "{}", "[]", "[1]", "['z']", "[undefined]", "this", "eval", "arguments", "arguments.caller", "arguments.callee" ],
     [ "objectEmulatingUndefined()" ],
 
     // Actual variables (slightly dangerous)
@@ -2284,8 +2059,7 @@ function makeArrayLiteralElem(d, b)
 
   switch (rnd(5)) {
     /* eslint-disable no-multi-spaces */
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Spread_operator
-    case 0:  return "..." + makeIterable(d - 1, b);
+    case 0:  return "..." + makeIterable(d - 1, b); // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Spread_operator
     case 1:  return ""; // hole
     default: return makeExpr(d - 1, b);
     /* eslint-enable no-multi-spaces */
@@ -2311,32 +2085,18 @@ var iterableExprMakers = Random.weighted([
   { w: 1, v: function(d, b) { return cat(["[", makeExpr(d, b), makeComprehension(d, b), "]"]); } },
 
   // A generator that yields once
-  { w: 1, v: function(d, b) { return "(function() { " + directivePrologue()
-    + "yield " + makeExpr(d - 1, b) + "; } })()";
-  } },
-  { w: 1, v: function(d, b) { return "(function*() { " + directivePrologue()
-    + "yield " + makeExpr(d - 1, b) + "; } })()";
-  } },
+  { w: 1, v: function(d, b) { return "(function() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },
+  { w: 1, v: function(d, b) { return "(function*() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },
   // A pass-through generator
-  { w: 1, v: function(d, b) { return "/*PTHR*/(function() { " + directivePrologue()
-    + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()";
-  } },
-  { w: 1, v: function(d, b) { return "/*PTHR*/(function*() { " + directivePrologue()
-    + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()";
-  } },
+  { w: 1, v: function(d, b) { return "/*PTHR*/(function() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
+  { w: 1, v: function(d, b) { return "/*PTHR*/(function*() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
 
   // An async function that awaits once
-  { w: 1, v: function(d, b) { return "(async function() { " + directivePrologue()
-    + "await " + makeExpr(d - 1, b) + "; } })()";
-  } },
+  { w: 1, v: function(d, b) { return "(async function() { " + directivePrologue() + "await " + makeExpr(d - 1, b) + "; } })()"; } },
 
   // A pass-through async generator
-  { w: 1, v: function(d, b) { return "/*PTHR*/(async function*() { " + directivePrologue()
-    + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()";
-  } },
-  { w: 1, v: function(d, b) { return "/*PTHR*/(async function*() { " + directivePrologue()
-    + "for await (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()";
-  } },
+  { w: 1, v: function(d, b) { return "/*PTHR*/(async function*() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
+  { w: 1, v: function(d, b) { return "/*PTHR*/(async function*() { " + directivePrologue() + "for await (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
 
   { w: 1, v: makeFunction },
   { w: 1, v: makeExpr },
@@ -2367,6 +2127,5 @@ function makeAsmJSFunction(d, b)
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior(["ff"]);
-  return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })(this, {ff: "
-    + makeFunction(d - 2, b) + "}, new " + arrayBufferType() + "(4096))";
+  return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })(this, {ff: " + makeFunction(d - 2, b) + "}, new " + arrayBufferType() + "(4096))";
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -22,7 +22,7 @@ function makeScript (d, ignoredB) { // eslint-disable-line require-jsdoc
 }
 
 function makeScriptBody (d, ignoredB) { // eslint-disable-line require-jsdoc
-  if (rnd(3) == 0) {
+  if (rnd(3) === 0) {
     return makeMathyFunAndTest(d, ["x"]);
   }
   return makeStatement(d, ["x"]);
@@ -41,7 +41,7 @@ function makeScriptForEval (d, b) { // eslint-disable-line require-jsdoc
 
 // Statement or block of statements
 function makeStatement (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (rnd(2)) { return makeBuilderStatement(d, b); }
 
@@ -271,7 +271,7 @@ var statementMakers = Random.weighted([
   // Long script -- can confuse Spidermonkey's short vs long jmp or something like that.
   // Spidermonkey's regexp engine is so slow for long strings that we have to bypass whatToTest :(
   // { w: 1, v: function(d, b) { return strTimes("try{}catch(e){}", rnd(10000)); } },
-  { w: 1, v: function (d, b) { if (rnd(200) == 0) return "/*DUPTRY" + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";"; } },
+  { w: 1, v: function (d, b) { if (rnd(200) === 0) return "/*DUPTRY" + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";"; } },
 
   { w: 1, v: function (d, b) { return makeShapeyConstructorLoop(d, b); } },
 
@@ -302,7 +302,7 @@ var statementMakers = Random.weighted([
   // { w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" + makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
 ]);
 
-if (typeof oomTest === "function" && engine != ENGINE_JAVASCRIPTCORE) {
+if (typeof oomTest === "function" && engine !== ENGINE_JAVASCRIPTCORE) {
   statementMakers = statementMakers.concat([
     function (d, b) { return "oomTest(" + makeFunction(d - 1, b) + ")"; },
     function (d, b) { return "oomTest(" + makeFunction(d - 1, b) + ", { keepFailing: true })"; }
@@ -310,7 +310,7 @@ if (typeof oomTest === "function" && engine != ENGINE_JAVASCRIPTCORE) {
 }
 
 function makeUseRegressionTest (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (typeof regressionTestList !== "object") {
     return "/* no regression tests found */";
@@ -321,7 +321,7 @@ function makeUseRegressionTest (d, b) { // eslint-disable-line require-jsdoc
 
   var s = "";
 
-  if (rnd(5) == 0) {
+  if (rnd(5) === 0) {
     // Many tests call assertEq, intending to throw if something unexpected happens.
     // Sometimes, override it with a function that compares but does not throw.
     s += "assertEq = function(x, y) { if (x != y) { print(0); } }; ";
@@ -350,11 +350,11 @@ function makeUseRegressionTest (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function regressionTestIsEvil (contents) { // eslint-disable-line require-jsdoc
-  if (contents.indexOf("SIMD") != -1) {
+  if (contents.indexOf("SIMD") !== -1) {
     // Disable SIMD testing until it's more stable (and we can get better stacks?)
     return true;
   }
-  if (contents.indexOf("print = ") != -1) {
+  if (contents.indexOf("print = ") !== -1) {
     // A testcase that clobbers the |print| function would confuse js_interesting
     return true;
   }
@@ -381,7 +381,7 @@ function inlineTest (filename) { // eslint-disable-line require-jsdoc
   ];
 
   for (var f of noDiffTestingFunctions) {
-    if (s.indexOf(f) != -1) {
+    if (s.indexOf(f) !== -1) {
       return "/*NODIFF*/ " + s;
     }
   }
@@ -395,21 +395,21 @@ function regressionTestDependencies (maintest) { // eslint-disable-line require-
   if (rnd(3)) {
     // Include the chain of 'shell.js' files in their containing directories (starting from regressionTestsRoot)
     for (var i = regressionTestsRoot.length; i < maintest.length; ++i) {
-      if (maintest.charAt(i) == "/" || maintest.charAt(i) == "\\") {
+      if (maintest.charAt(i) === "/" || maintest.charAt(i) === "\\") {
         var shelljs = maintest.substr(0, i + 1) + "shell.js";
-        if (regressionTestList.indexOf(shelljs) != -1) {
+        if (regressionTestList.indexOf(shelljs) !== -1) {
           files.push(shelljs);
         }
       }
     }
 
     // Include prologue.js for jit-tests
-    if (maintest.indexOf("jit-test") != -1) {
+    if (maintest.indexOf("jit-test") !== -1) {
       files.push(libdir + "prologue.js");
     }
 
     // Include web-platform-test-shims.js and testharness.js for streams tests
-    if (maintest.indexOf("web-platform") != -1) {
+    if (maintest.indexOf("web-platform") !== -1) {
       files.push(js_src_tests_dir + "web-platform-test-shims.js"); // eslint-disable-line camelcase
       files.push(w_pltfrm_res_dir + "testharness.js"); // eslint-disable-line camelcase
     }
@@ -428,7 +428,7 @@ function makeNamedFunctionAndUse (d, b) { // eslint-disable-line require-jsdoc
   // Use a unique function name to make it less likely that we'll accidentally make a recursive call
   var funcName = uniqueVarName();
   var formalArgList = makeFormalArgList(d, b);
-  var bv = formalArgList.length == 1 ? b.concat(formalArgList) : b;
+  var bv = formalArgList.length === 1 ? b.concat(formalArgList) : b;
   var declStatement = cat(["/*hhh*/function ", funcName, "(", formalArgList, ")", "{", makeStatement(d - 1, bv), "}"]);
   var useStatement;
   if (rnd(2)) {
@@ -461,7 +461,7 @@ function uniqueVarName () { // eslint-disable-line require-jsdoc
 }
 
 function makeSwitchBody (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var haveSomething = false;
   var haveDefault = false;
@@ -496,7 +496,7 @@ function makeSwitchBody (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeLittleStatement (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   d = d - 1;
 
@@ -549,7 +549,7 @@ var littleStatementMakers =
 // makeStatementOrBlock exists because often, things have different behaviors depending on where there are braces.
 // for example, if braces are added or removed, the meaning of "let" can change.
 function makeStatementOrBlock (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   return (Random.index(statementBlockMakers))(d - 1, b);
 }
@@ -564,7 +564,7 @@ var statementBlockMakers = [
 // Extra-hard testing for try/catch/finally and related things.
 
 function makeExceptionyStatement (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   d = d - 1;
   if (d < 1) { return makeLittleStatement(d, b); }
@@ -623,7 +623,7 @@ var exceptionyStatementMakers = [
 ];
 
 function makeTryBlock (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   // Catches: 1/6 chance of having none
   // Catches: maybe 2 + 1/2
@@ -652,7 +652,7 @@ function makeTryBlock (d, b) { // eslint-disable-line require-jsdoc
     s += cat(["catch", "(", catchId, ")", " { ", catchBlock, " } "]);
   }
 
-  if (numCatches == 0 || rnd(2) === 1) {
+  if (numCatches === 0 || rnd(2) === 1) {
     // Add a finally.
     s += cat(["finally", " { ", makeExceptionyStatement(d, b), " } "]);
   }
@@ -662,7 +662,7 @@ function makeTryBlock (d, b) { // eslint-disable-line require-jsdoc
 
 // Creates a string that sorta makes sense as an expression
 function makeExpr (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (d <= 0 || (rnd(7) === 1)) { return makeTerm(d - 1, b); }
 
@@ -940,7 +940,7 @@ var fuzzTestingFunctions = fuzzTestingFunctionsCtor(!jsshell, fuzzTestingFunctio
 function fuzzTestingFunctionArg (d, b) { return "this"; } // eslint-disable-line require-jsdoc
 
 function makeTestingFunctionCall (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var callStatement = Random.index(fuzzTestingFunctions.testingFunctions)(d, b);
 
@@ -987,7 +987,7 @@ if (typeof XPCNativeWrapper === "function") {
 }
 
 function makeNewGlobalArg (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   // Make an options object to pass to the |newGlobal| shell builtin.
   var propStrs = [];
@@ -1001,7 +1001,7 @@ function makeNewGlobalArg (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeGlobal (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (rnd(10)) { return "this"; }
 
@@ -1032,7 +1032,7 @@ if (xpcshell) {
 }
 
 function makeShapeyConstructor (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
   var argName = uniqueVarName();
   var t = rnd(4) ? "this" : argName;
   var funText = "function shapeyConstructor(" + argName + "){" + directivePrologue();
@@ -1081,7 +1081,7 @@ var propertyNameMakers = Random.weighted([
 function maybeNeg () { return rnd(5) ? "" : "-"; } // eslint-disable-line require-jsdoc
 
 function makePropertyName (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   return (Random.index(propertyNameMakers))(d, b);
 }
@@ -1102,7 +1102,7 @@ function makeShapeyConstructorLoop (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makePropertyDescriptor (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var s = "({";
 
@@ -1131,7 +1131,7 @@ function makePropertyDescriptor (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeBoolean (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */
     case 0:   return "true";
@@ -1143,7 +1143,7 @@ function makeBoolean (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeObjLiteralPart (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   switch (rnd(8)) {
   // Literal getter/setter
@@ -1159,7 +1159,7 @@ function makeObjLiteralPart (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeToXFunction (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */
@@ -1172,7 +1172,7 @@ function makeToXFunction (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeObjLiteralName (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   switch (rnd(6)) {
     /* eslint-disable no-multi-spaces */
@@ -1186,7 +1186,7 @@ function makeObjLiteralName (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeFunction (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   d = d - 1;
 
@@ -1209,7 +1209,7 @@ function directivePrologue () { // eslint-disable-line require-jsdoc
 }
 
 function makeFunctionBody (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   switch (rnd(6)) {
     /* eslint-disable no-multi-spaces */
@@ -1224,9 +1224,9 @@ function makeFunctionBody (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function functionPrefix () { // eslint-disable-line require-jsdoc
-  return (rnd(2) == 0 ? "" : "async ")
+  return (rnd(2) === 0 ? "" : "async ")
     + "function"
-    + (rnd(2) == 0 ? "" : "*");
+    + (rnd(2) === 0 ? "" : "*");
 }
 
 var functionMakers = [
@@ -1320,7 +1320,7 @@ if (typeof XPCNativeWrapper === "function") {
   ]);
 }
 
-if (typeof oomTest === "function" && engine != ENGINE_JAVASCRIPTCORE) {
+if (typeof oomTest === "function" && engine !== ENGINE_JAVASCRIPTCORE) {
   functionMakers = functionMakers.concat([
     function (d, b) { return "oomTest"; }
   ]);
@@ -1339,7 +1339,7 @@ var typedArrayConstructors = [
 ];
 
 function makeTypedArrayStatements (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (d < 0) return "";
 
@@ -1367,7 +1367,7 @@ function makeTypedArrayStatements (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeNumber (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var signStr = rnd(2) ? "-" : "";
 
@@ -1405,7 +1405,7 @@ function makeNumber (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeLetHead (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var items = (d > 0 || rnd(2) === 0) ? rnd(10) + 1 : 1;
   var result = "";
@@ -1419,7 +1419,7 @@ function makeLetHead (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeLetHeadItem (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   d = d - 1;
 
@@ -1427,11 +1427,11 @@ function makeLetHeadItem (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeActualArgList (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var nArgs = rnd(3);
 
-  if (nArgs == 0) { return ""; }
+  if (nArgs === 0) { return ""; }
 
   var argList = makeExpr(d, b);
 
@@ -1441,7 +1441,7 @@ function makeActualArgList (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeFormalArgList (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var argList = [];
 
@@ -1459,7 +1459,7 @@ function makeFormalArgList (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeFormalArg (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (rnd(8) === 1) { return makeDestructuringLValue(d, b); }
 
@@ -1467,13 +1467,13 @@ function makeFormalArg (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeNewId (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   return Random.index(["a", "b", "c", "d", "e", "w", "x", "y", "z"]);
 }
 
 function makeId (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (rnd(3) === 1 && b.length) { return Random.index(b); }
 
@@ -1515,7 +1515,7 @@ function makeId (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeComprehension (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (d < 0) { return ""; }
 
@@ -1535,12 +1535,12 @@ function makeComprehension (d, b) { // eslint-disable-line require-jsdoc
 
 // for..in LHS can be a single variable OR it can be a destructuring array of exactly two elements.
 function makeForInLHS (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
   return makeLValue(d, b);
 }
 
 function makeLValue (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (d <= 0 || (rnd(2) === 1)) { return makeId(d - 1, b); }
 
@@ -1586,7 +1586,7 @@ var lvalueMakers = [
 ];
 
 function makeDestructuringLValue (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   d = d - 1;
 
@@ -1601,7 +1601,7 @@ var destructuringLValueMakers = [
   // destructuring assignment: arrays
   function (d, b) {
     var len = rnd(d, b);
-    if (len == 0) { return "[]"; }
+    if (len === 0) { return "[]"; }
 
     var Ti = [];
     Ti.push("[");
@@ -1619,7 +1619,7 @@ var destructuringLValueMakers = [
   // destructuring assignment: objects
   function (d, b) {
     var len = rnd(d, b);
-    if (len == 0) { return "{}"; }
+    if (len === 0) { return "{}"; }
     var Ti = [];
     Ti.push("{");
     for (var i = 0; i < len; ++i) {
@@ -1644,7 +1644,7 @@ function maybeMakeDestructuringLValue (d, b) { // eslint-disable-line require-js
 }
 
 function makeTerm (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   return (Random.index(termMakers))(d, b);
 }
@@ -1750,7 +1750,7 @@ function makeCrazyToken () { // eslint-disable-line require-jsdoc
 }
 
 function makeShapeyValue (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (rnd(10) === 0) { return makeExpr(d, b); }
 
@@ -1839,7 +1839,7 @@ function mixedTypeArrayElem (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeMixedTypeArray (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   // Pick two to five values to use as array entries.
   var q = rnd(4) + 2;
@@ -1866,7 +1866,7 @@ function makeMixedTypeArray (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeArrayLiteral (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (rnd(2) === 0) { return makeMixedTypeArray(d, b); }
 
@@ -1876,7 +1876,7 @@ function makeArrayLiteral (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeArrayLiteralElem (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   switch (rnd(5)) {
     /* eslint-disable no-multi-spaces */
@@ -1888,7 +1888,7 @@ function makeArrayLiteralElem (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeIterable (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (d < 1) { return "[]"; }
 
@@ -1922,8 +1922,8 @@ var iterableExprMakers = Random.weighted([
 ]);
 
 function strTimes (s, n) { // eslint-disable-line require-jsdoc
-  if (n == 0) return "";
-  if (n == 1) return s;
+  if (n === 0) return "";
+  if (n === 1) return s;
   var s2 = s + s;
   var r = n % 2;
   var d = (n - r) / 2;
@@ -1932,14 +1932,14 @@ function strTimes (s, n) { // eslint-disable-line require-jsdoc
 }
 
 function makeAsmJSModule (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior([]);
   return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })";
 }
 
 function makeAsmJSFunction (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior(["ff"]);
   return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })(this, {ff: " + makeFunction(d - 2, b) + "}, new " + arrayBufferType() + "(4096))";

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -47,8 +47,9 @@ function makeStatement (d, b) { // eslint-disable-line require-jsdoc
 
   if (d < 6 && rnd(3) === 0) { return makePrintStatement(d, b); }
 
-  if (d < rnd(8)) // frequently for small depth, infrequently for large depth
-  { return makeLittleStatement(d, b); }
+  if (d < rnd(8)) { // frequently for small depth, infrequently for large depth
+    return makeLittleStatement(d, b);
+  }
 
   d = rnd(d); // !
 
@@ -88,9 +89,10 @@ function forLoopHead (d, b, v, reps) { // eslint-disable-line require-jsdoc
 
   while (rnd(10) === 0) { sInit += ", " + makeLetHeadItem(d - 2, b); }
   while (rnd(10) === 0) { sInit += ", " + makeExpr(d - 2, b); } // NB: only makes sense if our varBinder is ""
-  while (rnd(1000) === 0)
+  while (rnd(1000) === 0) {
   // never causes the loop to be run, but stuff like register allocation may be happening in the background
-  { sInit = Random.index(varBinderFor) + v; }
+    sInit = Random.index(varBinderFor) + v;
+  }
   while (rnd(10000) === 0) { sInit = ""; } // mostly throws ReferenceError, so make this rare
 
   while (rnd(20) === 0) { sCond = sCond + " && (" + makeExpr(d - 2, b) + ")"; }

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -12,9 +12,9 @@
 /* global stripSemicolon, TOTALLY_RANDOM, totallyRandom, unaryMathFunctions, uneval, UNTERMINATED_COMMENT */
 /* global w_pltfrm_res_dir, XPCNativeWrapper, xpcshell */
 
-/****************************
+/* ************************ *
  * GRAMMAR-BASED GENERATION *
- ****************************/
+ * ************************ */
 
 
 function makeScript(d, ignoredB)
@@ -233,9 +233,9 @@ var statementMakers = Random.weighted([
   { w: 1, v: function(d, b) { var v = makeNewId(d, b), w = makeNewId(d, b); return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), "[", v, ", ", w, "]", " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v, w]))]); } },
 
   // do..while
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "while((", makeExpr(d, b), ") && 0)" /*don't split this, it's needed to avoid marking as infloop*/, makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(), "while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, makeStatementOrBlock(d, b)]); } },
   { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(), "while", "(", makeExpr(d, b), ")", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while((", makeExpr(d, b), ") && 0)" /*don't split this, it's needed to avoid marking as infloop*/, ";"]); } },
+  { w: 1, v: function(d, b) { return cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, ";"]); } },
   { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while", "(", makeExpr(d, b), ");"]); } },
 
   // Switch statement
@@ -277,7 +277,7 @@ var statementMakers = Random.weighted([
 
   // Long script -- can confuse Spidermonkey's short vs long jmp or something like that.
   // Spidermonkey's regexp engine is so slow for long strings that we have to bypass whatToTest :(
-  //{ w: 1, v: function(d, b) { return strTimes("try{}catch(e){}", rnd(10000)); } },
+  // { w: 1, v: function(d, b) { return strTimes("try{}catch(e){}", rnd(10000)); } },
   { w: 1, v: function(d, b) { if (rnd(200)==0) return "/*DUPTRY" + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";"; } },
 
   { w: 1, v: function(d, b) { return makeShapeyConstructorLoop(d, b); } },
@@ -305,8 +305,8 @@ var statementMakers = Random.weighted([
   { w: 20, v: makeUseRegressionTest },
 
   // Discover properties to add to the allPropertyNames list
-  //{ w: 3, v: function(d, b) { return "for (var p in " + makeId(d, b) + ") { addPropertyName(p); }"; } },
-  //{ w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" + makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
+  // { w: 3, v: function(d, b) { return "for (var p in " + makeId(d, b) + ") { addPropertyName(p); }"; } },
+  // { w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" + makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
 ]);
 
 if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
@@ -1155,7 +1155,7 @@ function makeShapeyConstructorLoop(d, b)
     "/*tLoopC*/for (let " + v + " of " + a + ") { " +
      "try{" +
        "let " + v2 + " = " + Random.index(["new ", ""]) + "shapeyConstructor(" + v + "); print('EETT'); " +
-       //"print(uneval(" + v2 + "));" +
+       // "print(uneval(" + v2 + "));" +
        makeStatement(d - 2, bvv) +
      "}catch(e){print('TTEE ' + e); }" +
   " }";

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -1118,7 +1118,7 @@ function makeShapeyConstructor(d, b)
       case 3:  funText += tprop + " = " + makeExpr(d, bp)        + ";"; break;
       case 4:  funText += tprop + " = " + makeFunction(d, bp)    + ";"; break;
       case 5:  funText += "for (var ytq" + uniqueVarName() + " in " + t + ") { }"; break;
-      case 6:  funText += "Object." + Random.index(["preventExtensions","seal","freeze"]) + "(" + t + ");"; break;
+      case 6:  funText += "Object." + Random.index(["preventExtensions", "seal", "freeze"]) + "(" + t + ");"; break;
       default: funText += tprop + " = " + makeShapeyValue(d, bp) + ";"; break;
     }
   }

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -981,11 +981,11 @@ if (typeof evalcx === "function") {
 
 // SpiderMonkey shell has an "evalInWorker" function.
 // This tests evaluating scripts in a separate thread with its own runtime.
-if (typeof evalInWorker == "function") {
+if (typeof evalInWorker === "function") {
   exprMakers = exprMakers.concat([
-    function(d, b) { return makeGlobal(d, b); },
-    function(d, b) { return "evalInWorker(" + uneval(makeScriptForEval(d, b)) + ")"; },
-    function(d, b) { return "evalInWorker(" + uneval(makeScriptForEval(d, b)) + ")"; },
+    function (d, b) { return makeGlobal(d, b); },
+    function (d, b) { return "evalInWorker(" + uneval(makeScriptForEval(d, b)) + ")"; },
+    function (d, b) { return "evalInWorker(" + uneval(makeScriptForEval(d, b)) + ")"; }
   ]);
 }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -24,9 +24,9 @@ function makeScript(d, ignoredB)
 
 function makeScriptBody(d, ignoredB)
 {
-  if (rnd(3) == 0) 
+  if (rnd(3) == 0) {
     return makeMathyFunAndTest(d, ["x"]);
-  
+  }
   return makeStatement(d, ["x"]);
 }
 
@@ -78,20 +78,20 @@ function forLoopHead(d, b, v, reps)
     case 0: // Generates constructs like `for (var x = 3; x > 0; x--) { ... }`
       sInit = Random.index(varBinderFor) + v + " = " + reps;
       sCond = v + " > 0";
-      if (rnd(2)) 
+      if (rnd(2)) {
         sNext = "--" + v;
-      else 
+      } else {
         sNext = v + "--";
-      
+      }
       break;
     default: // Generates constructs like `for (var x = 0; x < 3; x++) { ... }`
       sInit = Random.index(varBinderFor) + v + " = 0";
       sCond = v + " < " + reps;
-      if (rnd(2)) 
+      if (rnd(2)) {
         sNext = "++" + v;
-      else 
+      } else {
         sNext = v + "++";
-      
+      }
   }
 
   while (rnd(10) === 0)
@@ -420,39 +420,39 @@ var statementMakers = Random.weighted([
   // makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
 ]);
 
-if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) 
+if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
   statementMakers = statementMakers.concat([
     function(d, b) { return "oomTest(" + makeFunction(d - 1, b) + ")"; },
     function(d, b) { return "oomTest(" + makeFunction(d - 1, b) + ", { keepFailing: true })"; },
   ]);
-
+}
 
 
 function makeUseRegressionTest(d, b)
 {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (typeof regressionTestList != "object") 
+  if (typeof regressionTestList != "object") {
     return "/* no regression tests found */";
-  
+  }
 
   var maintest = regressionTestsRoot + Random.index(regressionTestList);
   var files = regressionTestDependencies(maintest);
 
   var s = "";
 
-  if (rnd(5) == 0) 
+  if (rnd(5) == 0) {
     // Many tests call assertEq, intending to throw if something unexpected happens.
     // Sometimes, override it with a function that compares but does not throw.
     s += "assertEq = function(x, y) { if (x != y) { print(0); } }; ";
-  
+  }
 
   for (var i = 0; i < files.length; ++i) {
     var file = files[i];
 
-    if (regressionTestIsEvil(read(file))) 
+    if (regressionTestIsEvil(read(file))) {
       continue;
-    
+    }
 
     switch (rnd(2)) {
       case 0:
@@ -472,14 +472,14 @@ function makeUseRegressionTest(d, b)
 
 function regressionTestIsEvil(contents)
 {
-  if (contents.indexOf("SIMD") != -1) 
+  if (contents.indexOf("SIMD") != -1) {
     // Disable SIMD testing until it's more stable (and we can get better stacks?)
     return true;
-  
-  if (contents.indexOf("print = ") != -1) 
+  }
+  if (contents.indexOf("print = ") != -1) {
     // A testcase that clobbers the |print| function would confuse js_interesting
     return true;
-  
+  }
   return false;
 }
 
@@ -505,11 +505,11 @@ function inlineTest(filename)
     "PerfMeasurement",
   ];
 
-  for (var f of noDiffTestingFunctions) 
-    if (s.indexOf(f) != -1) 
+  for (var f of noDiffTestingFunctions) {
+    if (s.indexOf(f) != -1) {
       return "/*NODIFF*/ " + s;
-    
-  
+    }
+  }
 
   return s;
 }
@@ -521,19 +521,19 @@ function regressionTestDependencies(maintest)
 
   if (rnd(3)) {
     // Include the chain of 'shell.js' files in their containing directories (starting from regressionTestsRoot)
-    for (var i = regressionTestsRoot.length; i < maintest.length; ++i) 
+    for (var i = regressionTestsRoot.length; i < maintest.length; ++i) {
       if (maintest.charAt(i) == "/" || maintest.charAt(i) == "\\") {
         var shelljs = maintest.substr(0, i + 1) + "shell.js";
-        if (regressionTestList.indexOf(shelljs) != -1) 
+        if (regressionTestList.indexOf(shelljs) != -1) {
           files.push(shelljs);
-        
+        }
       }
-    
+    }
 
     // Include prologue.js for jit-tests
-    if (maintest.indexOf("jit-test") != -1) 
+    if (maintest.indexOf("jit-test") != -1) {
       files.push(libdir + "prologue.js");
-    
+    }
 
     // Include web-platform-test-shims.js and testharness.js for streams tests
     if (maintest.indexOf("web-platform") != -1) {
@@ -561,18 +561,18 @@ function makeNamedFunctionAndUse(d, b) {
   var bv = formalArgList.length == 1 ? b.concat(formalArgList) : b;
   var declStatement = cat(["/*hhh*/function ", funcName, "(", formalArgList, ")", "{", makeStatement(d - 1, bv), "}"]);
   var useStatement;
-  if (rnd(2)) 
+  if (rnd(2)) {
     // Direct call
     useStatement = cat([funcName, "(", makeActualArgList(d, b), ")", ";"]);
-  else 
+  } else {
     // Any statement, allowed to use the name of the function
     useStatement = "/*iii*/" + makeStatement(d - 1, b.concat([funcName]));
-  
-  if (rnd(2)) 
+  }
+  if (rnd(2)) {
     return declStatement + useStatement;
-  else 
+  } else {
     return useStatement + declStatement;
-  
+  }
 }
 
 function makePrintStatement(d, b)
@@ -833,10 +833,10 @@ function makeTryBlock(d, b)
     s +=   cat(["catch", "(", catchId, ")", " { ", catchBlock, " } "]);
   }
 
-  if (numCatches == 0 || rnd(2) === 1) 
+  if (numCatches == 0 || rnd(2) === 1) {
     // Add a finally.
     s += cat(["finally", " { ", makeExceptionyStatement(d, b), " } "]);
-  
+  }
 
   return s;
 }
@@ -1221,21 +1221,21 @@ function makeTestingFunctionCall(d, b)
 
 // SpiderMonkey shell (but not xpcshell) has an "evalcx" function and a "newGlobal" function.
 // This tests sandboxes and cross-compartment wrappers.
-if (typeof evalcx == "function") 
+if (typeof evalcx == "function") {
   exprMakers = exprMakers.concat([
     function(d, b) { return makeGlobal(d, b); },
     function(d, b) { return "evalcx(" + uneval(makeScriptForEval(d, b)) + ", " + makeExpr(d, b) + ")"; },
     function(d, b) { return "evalcx(" + uneval(makeScriptForEval(d, b)) + ", " + makeGlobal(d, b) + ")"; },
   ]);
-
+}
 
 // xpcshell (but not SpiderMonkey shell) has some XPC wrappers available.
-if (typeof XPCNativeWrapper == "function") 
+if (typeof XPCNativeWrapper == "function") {
   exprMakers = exprMakers.extend([
     function(d, b) { return "new XPCNativeWrapper(" + makeExpr(d, b) + ")"; },
     function(d, b) { return "new XPCSafeJSObjectWrapper(" + makeExpr(d, b) + ")"; },
   ]);
-
+}
 
 function makeNewGlobalArg(d, b)
 {
@@ -1280,7 +1280,7 @@ function makeGlobal(d, b)
   return gs;
 }
 
-if (xpcshell) 
+if (xpcshell) {
   exprMakers = exprMakers.concat([
     function(d, b) { var n = rnd(4); return "newGeckoSandbox(" + n + ")"; },
     function(d, b) { var n = rnd(4); return "s" + n + " = newGeckoSandbox(" + n + ")"; },
@@ -1292,7 +1292,7 @@ if (xpcshell)
     function(d, b) { return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", " + makeExpr(d, b) + ")"; },
     function(d, b) { return "(Components.classes ? quit() : gc()); }"; },
   ]);
-
+}
 
 
 function makeShapeyConstructor(d, b)
@@ -1305,17 +1305,17 @@ function makeShapeyConstructor(d, b)
 
   var nPropNames = rnd(6) + 1;
   var propNames = [];
-  for (var i = 0; i < nPropNames; ++i) 
+  for (var i = 0; i < nPropNames; ++i) {
     propNames[i] = makePropertyName(d, b);
-  
+  }
 
   var nStatements = rnd(11);
   for (var i = 0; i < nStatements; ++i) {
     var propName = Random.index(propNames);
     var tprop = t + "[" + propName + "]";
-    if (rnd(5) === 0) 
+    if (rnd(5) === 0) {
       funText += "if (" + (rnd(2) ? argName : makeExpr(d, bp)) + ") ";
-    
+    }
     switch (rnd(8)) {
       /* eslint-disable no-multi-spaces */
       case 0:  funText += "delete " + tprop + ";"; break;
@@ -1642,18 +1642,18 @@ var functionMakers = [
   function(d, b) { return Random.index(constructors); },
 ];
 
-if (typeof XPCNativeWrapper == "function") 
+if (typeof XPCNativeWrapper == "function") {
   functionMakers = functionMakers.concat([
     function(d, b) { return "XPCNativeWrapper"; },
     function(d, b) { return "XPCSafeJSObjectWrapper"; },
   ]);
+}
 
-
-if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) 
+if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
   functionMakers = functionMakers.concat([
     function(d, b) { return "oomTest"; },
   ]);
-
+}
 
 
 
@@ -1694,9 +1694,9 @@ function makeTypedArrayStatements(d, b)
       statements += viewZero + " = " + makeNumber(d - 2, b) + "; ";
     bv.push(view + "[" + rnd(11) + "]");
   }
-  for (var j = 0; j < numExtraStatements; ++j) 
+  for (var j = 0; j < numExtraStatements; ++j) {
     statements += makeStatement(d - numExtraStatements, bv);
-  
+  }
   return statements;
 }
 
@@ -1795,14 +1795,14 @@ function makeFormalArgList(d, b)
   var argList = [];
 
   var nArgs = rnd(5) ? rnd(3) : rnd(100);
-  for (var i = 0; i < nArgs; ++i) 
+  for (var i = 0; i < nArgs; ++i) {
     argList.push(makeFormalArg(d - i, b));
-  
+  }
 
-  if (rnd(5) === 0) 
+  if (rnd(5) === 0) {
     // https://developer.mozilla.org/en-US/docs/JavaScript/Reference/rest_parameters
     argList.push("..." + makeId(d, b));
-  
+  }
 
   return argList.join(", ");
 }
@@ -2071,9 +2071,9 @@ var termMakers = [
 function randomUnitStringLiteral()
 {
   var s = "\"\\u";
-  for (var i = 0; i < 4; ++i) 
+  for (var i = 0; i < 4; ++i) {
     s += "0123456789ABCDEF".charAt(rnd(16));
-  
+  }
   s += "\"";
   return s;
 }
@@ -2090,12 +2090,12 @@ function maybeMakeTerm(d, b)
 
 function makeCrazyToken()
 {
-  if (rnd(3) === 0) 
+  if (rnd(3) === 0) {
     return String.fromCharCode(32 + rnd(128 - 32));
-  
-  if (rnd(6) === 0) 
+  }
+  if (rnd(6) === 0) {
     return String.fromCharCode(rnd(65536));
-  
+  }
 
   return Random.index([
 
@@ -2245,9 +2245,9 @@ function makeMixedTypeArray(d, b)
   // Pick two to five values to use as array entries.
   var q = rnd(4) + 2;
   var picks = [];
-  for (var j = 0; j < q; ++j) 
+  for (var j = 0; j < q; ++j) {
     picks.push(mixedTypeArrayElem(d, b));
-  
+  }
 
   // Create a large array literal by randomly repeating the values.
   var c = [];
@@ -2258,9 +2258,9 @@ function makeMixedTypeArray(d, b)
     // (This is needed for shape warmup, but not for JIT warmup)
     var repeat = count === 0 ? rnd(4)===0 : rnd(50)===0;
     var repeats = repeat ? rnd(30) : 1;
-    for (var k = 0; k < repeats; ++k) 
+    for (var k = 0; k < repeats; ++k) {
       c.push(elem);
-    
+    }
   }
 
   return "/*MARR*/" + "[" + c.join(", ") + "]";

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -17,18 +17,18 @@
  * GRAMMAR-BASED GENERATION *
  * ************************ */
 
-function makeScript (d, ignoredB) {
+function makeScript (d, ignoredB) { // eslint-disable-line require-jsdoc
   return directivePrologue() + makeScriptBody(d, ignoredB);
 }
 
-function makeScriptBody (d, ignoredB) {
+function makeScriptBody (d, ignoredB) { // eslint-disable-line require-jsdoc
   if (rnd(3) == 0) {
     return makeMathyFunAndTest(d, ["x"]);
   }
   return makeStatement(d, ["x"]);
 }
 
-function makeScriptForEval (d, b) {
+function makeScriptForEval (d, b) { // eslint-disable-line require-jsdoc
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */
     case 0:  return makeExpr(d - 1, b);
@@ -40,7 +40,7 @@ function makeScriptForEval (d, b) {
 }
 
 // Statement or block of statements
-function makeStatement (d, b) {
+function makeStatement (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(2)) { return makeBuilderStatement(d, b); }
@@ -61,7 +61,7 @@ var varBinderFor = ["var ", "let ", ""]; // const is a syntax error in for loops
 // The reason there are several types of loops here is to create different
 // types of scripts without introducing infinite loops.
 
-function forLoopHead (d, b, v, reps) {
+function forLoopHead (d, b, v, reps) { // eslint-disable-line require-jsdoc
   var sInit = "";
   var sCond = "";
   var sNext = "";
@@ -102,7 +102,7 @@ function forLoopHead (d, b, v, reps) {
   return "for (" + sInit + "; " + sCond + "; " + sNext + ")";
 }
 
-function makeOpaqueIdiomaticLoop (d, b) {
+function makeOpaqueIdiomaticLoop (d, b) { // eslint-disable-line require-jsdoc
   var reps = loopCount();
   var vHidden = uniqueVarName();
   return "/*oLoop*/" + forLoopHead(d, b, vHidden, reps) + " { " +
@@ -110,7 +110,7 @@ function makeOpaqueIdiomaticLoop (d, b) {
       " } ";
 }
 
-function makeTransparentIdiomaticLoop (d, b) {
+function makeTransparentIdiomaticLoop (d, b) { // eslint-disable-line require-jsdoc
   var reps = loopCount();
   var vHidden = uniqueVarName();
   var vVisible = makeNewId(d, b);
@@ -121,7 +121,7 @@ function makeTransparentIdiomaticLoop (d, b) {
     " } ";
 }
 
-function makeBranchUnstableLoop (d, b) {
+function makeBranchUnstableLoop (d, b) { // eslint-disable-line require-jsdoc
   var reps = loopCount();
   var v = uniqueVarName();
   var mod = loopModulo();
@@ -132,14 +132,14 @@ function makeBranchUnstableLoop (d, b) {
     " } ";
 }
 
-function makeTypeUnstableLoop (d, b) {
+function makeTypeUnstableLoop (d, b) { // eslint-disable-line require-jsdoc
   var a = makeMixedTypeArray(d, b);
   var v = makeNewId(d, b);
   var bv = b.concat([v]);
   return "/*tLoop*/for (let " + v + " of " + a + ") { " + makeStatement(d - 2, bv) + " }";
 }
 
-function makeFunOnCallChain (d, b) {
+function makeFunOnCallChain (d, b) { // eslint-disable-line require-jsdoc
   var s = "arguments.callee";
   while (rnd(2)) { s += ".caller"; }
   return s;
@@ -307,7 +307,7 @@ if (typeof oomTest === "function" && engine != ENGINE_JAVASCRIPTCORE) {
   ]);
 }
 
-function makeUseRegressionTest (d, b) {
+function makeUseRegressionTest (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (typeof regressionTestList !== "object") {
@@ -347,7 +347,7 @@ function makeUseRegressionTest (d, b) {
   return s;
 }
 
-function regressionTestIsEvil (contents) {
+function regressionTestIsEvil (contents) { // eslint-disable-line require-jsdoc
   if (contents.indexOf("SIMD") != -1) {
     // Disable SIMD testing until it's more stable (and we can get better stacks?)
     return true;
@@ -359,7 +359,7 @@ function regressionTestIsEvil (contents) {
   return false;
 }
 
-function inlineTest (filename) {
+function inlineTest (filename) { // eslint-disable-line require-jsdoc
   // Inline a regression test, adding NODIFF (to disable differential testing) if it calls a testing function that might throw.
 
   const s = "/* " + filename + " */ " + read(filename) + "\n";
@@ -387,7 +387,7 @@ function inlineTest (filename) {
   return s;
 }
 
-function regressionTestDependencies (maintest) {
+function regressionTestDependencies (maintest) { // eslint-disable-line require-jsdoc
   var files = [];
 
   if (rnd(3)) {
@@ -417,12 +417,12 @@ function regressionTestDependencies (maintest) {
   return files;
 }
 
-function linkedList (x, n) {
+function linkedList (x, n) { // eslint-disable-line require-jsdoc
   for (var i = 0; i < n; ++i) { x = { a: x }; }
   return x;
 }
 
-function makeNamedFunctionAndUse (d, b) {
+function makeNamedFunctionAndUse (d, b) { // eslint-disable-line require-jsdoc
   // Use a unique function name to make it less likely that we'll accidentally make a recursive call
   var funcName = uniqueVarName();
   var formalArgList = makeFormalArgList(d, b);
@@ -443,22 +443,22 @@ function makeNamedFunctionAndUse (d, b) {
   }
 }
 
-function makePrintStatement (d, b) {
+function makePrintStatement (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(2) && b.length) { return "print(" + Random.index(b) + ");"; } else { return "print(" + makeExpr(d, b) + ");"; }
 }
 
-function maybeLabel () {
+function maybeLabel () { // eslint-disable-line require-jsdoc
   if (rnd(4) === 1) { return cat([Random.index(["L", "M"]), ":"]); } else { return ""; }
 }
 
-function uniqueVarName () {
+function uniqueVarName () { // eslint-disable-line require-jsdoc
   // Make a random variable name.
   var s = "";
   for (var i = 0; i < 6; ++i) { s += String.fromCharCode(97 + rnd(26)); } // a lowercase english letter
   return s;
 }
 
-function makeSwitchBody (d, b) {
+function makeSwitchBody (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var haveSomething = false;
@@ -493,7 +493,7 @@ function makeSwitchBody (d, b) {
   return output;
 }
 
-function makeLittleStatement (d, b) {
+function makeLittleStatement (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
@@ -546,7 +546,7 @@ var littleStatementMakers =
 
 // makeStatementOrBlock exists because often, things have different behaviors depending on where there are braces.
 // for example, if braces are added or removed, the meaning of "let" can change.
-function makeStatementOrBlock (d, b) {
+function makeStatementOrBlock (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return (Random.index(statementBlockMakers))(d - 1, b);
@@ -561,7 +561,7 @@ var statementBlockMakers = [
 
 // Extra-hard testing for try/catch/finally and related things.
 
-function makeExceptionyStatement (d, b) {
+function makeExceptionyStatement (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
@@ -620,7 +620,7 @@ var exceptionyStatementMakers = [
 */
 ];
 
-function makeTryBlock (d, b) {
+function makeTryBlock (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // Catches: 1/6 chance of having none
@@ -659,7 +659,7 @@ function makeTryBlock (d, b) {
 }
 
 // Creates a string that sorta makes sense as an expression
-function makeExpr (d, b) {
+function makeExpr (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d <= 0 || (rnd(7) === 1)) { return makeTerm(d - 1, b); }
@@ -935,9 +935,9 @@ var fuzzTestingFunctions = fuzzTestingFunctionsCtor(!jsshell, fuzzTestingFunctio
 // Ensure that even if makeExpr returns "" or "1, 2", we only pass one argument to functions like schedulegc
 // (null || (" + makeExpr(d - 2, b) + "))
 // Darn, only |this| and local variables are safe: an expression with side effects breaks the statement-level compare_jit hack
-function fuzzTestingFunctionArg (d, b) { return "this"; }
+function fuzzTestingFunctionArg (d, b) { return "this"; } // eslint-disable-line require-jsdoc
 
-function makeTestingFunctionCall (d, b) {
+function makeTestingFunctionCall (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var callStatement = Random.index(fuzzTestingFunctions.testingFunctions)(d, b);
@@ -984,7 +984,7 @@ if (typeof XPCNativeWrapper === "function") {
   ]);
 }
 
-function makeNewGlobalArg (d, b) {
+function makeNewGlobalArg (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // Make an options object to pass to the |newGlobal| shell builtin.
@@ -998,7 +998,7 @@ function makeNewGlobalArg (d, b) {
   return "{ " + propStrs.join(", ") + " }";
 }
 
-function makeGlobal (d, b) {
+function makeGlobal (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(10)) { return "this"; }
@@ -1029,7 +1029,7 @@ if (xpcshell) {
   ]);
 }
 
-function makeShapeyConstructor (d, b) {
+function makeShapeyConstructor (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
   var argName = uniqueVarName();
   var t = rnd(4) ? "this" : argName;
@@ -1076,15 +1076,15 @@ var propertyNameMakers = Random.weighted([
   { w: 5, v: function (d, b) { return simpleSource(Random.index(allMethodNames)); } }
 ]);
 
-function maybeNeg () { return rnd(5) ? "" : "-"; }
+function maybeNeg () { return rnd(5) ? "" : "-"; } // eslint-disable-line require-jsdoc
 
-function makePropertyName (d, b) {
+function makePropertyName (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return (Random.index(propertyNameMakers))(d, b);
 }
 
-function makeShapeyConstructorLoop (d, b) {
+function makeShapeyConstructorLoop (d, b) { // eslint-disable-line require-jsdoc
   var a = makeIterable(d, b);
   var v = makeNewId(d, b);
   var v2 = uniqueVarName(d, b);
@@ -1099,7 +1099,7 @@ function makeShapeyConstructorLoop (d, b) {
   " }";
 }
 
-function makePropertyDescriptor (d, b) {
+function makePropertyDescriptor (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var s = "({";
@@ -1128,7 +1128,7 @@ function makePropertyDescriptor (d, b) {
   return s;
 }
 
-function makeBoolean (d, b) {
+function makeBoolean (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */
@@ -1140,7 +1140,7 @@ function makeBoolean (d, b) {
   }
 }
 
-function makeObjLiteralPart (d, b) {
+function makeObjLiteralPart (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(8)) {
@@ -1156,7 +1156,7 @@ function makeObjLiteralPart (d, b) {
   }
 }
 
-function makeToXFunction (d, b) {
+function makeToXFunction (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(4)) {
@@ -1169,7 +1169,7 @@ function makeToXFunction (d, b) {
   }
 }
 
-function makeObjLiteralName (d, b) {
+function makeObjLiteralName (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(6)) {
@@ -1183,7 +1183,7 @@ function makeObjLiteralName (d, b) {
   }
 }
 
-function makeFunction (d, b) {
+function makeFunction (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
@@ -1195,18 +1195,18 @@ function makeFunction (d, b) {
   return (Random.index(functionMakers))(d, b);
 }
 
-function maybeName (d, b) {
+function maybeName (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(2) === 0) { return " " + makeId(d, b) + " "; } else { return ""; }
 }
 
-function directivePrologue () {
+function directivePrologue () { // eslint-disable-line require-jsdoc
   var s = "";
   if (rnd(3) === 0) { s += '"use strict"; '; }
   if (rnd(30) === 0) { s += '"use asm"; '; }
   return s;
 }
 
-function makeFunctionBody (d, b) {
+function makeFunctionBody (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(6)) {
@@ -1221,7 +1221,7 @@ function makeFunctionBody (d, b) {
   }
 }
 
-function functionPrefix () {
+function functionPrefix () { // eslint-disable-line require-jsdoc
   return (rnd(2) == 0 ? "" : "async ")
     + "function"
     + (rnd(2) == 0 ? "" : "*");
@@ -1336,7 +1336,7 @@ var typedArrayConstructors = [
   "Uint8ClampedArray"
 ];
 
-function makeTypedArrayStatements (d, b) {
+function makeTypedArrayStatements (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d < 0) return "";
@@ -1364,7 +1364,7 @@ function makeTypedArrayStatements (d, b) {
   return statements;
 }
 
-function makeNumber (d, b) {
+function makeNumber (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var signStr = rnd(2) ? "-" : "";
@@ -1402,7 +1402,7 @@ function makeNumber (d, b) {
   }
 }
 
-function makeLetHead (d, b) {
+function makeLetHead (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var items = (d > 0 || rnd(2) === 0) ? rnd(10) + 1 : 1;
@@ -1416,7 +1416,7 @@ function makeLetHead (d, b) {
   return result;
 }
 
-function makeLetHeadItem (d, b) {
+function makeLetHeadItem (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
@@ -1424,7 +1424,7 @@ function makeLetHeadItem (d, b) {
   if (d < 0 || rnd(2) === 0) { return rnd(2) ? uniqueVarName() : makeId(d, b); } else if (rnd(5) === 0) { return makeDestructuringLValue(d, b) + " = " + makeExpr(d, b); } else { return makeId(d, b) + " = " + makeExpr(d, b); }
 }
 
-function makeActualArgList (d, b) {
+function makeActualArgList (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var nArgs = rnd(3);
@@ -1438,7 +1438,7 @@ function makeActualArgList (d, b) {
   return argList;
 }
 
-function makeFormalArgList (d, b) {
+function makeFormalArgList (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var argList = [];
@@ -1456,7 +1456,7 @@ function makeFormalArgList (d, b) {
   return argList.join(", ");
 }
 
-function makeFormalArg (d, b) {
+function makeFormalArg (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(8) === 1) { return makeDestructuringLValue(d, b); }
@@ -1464,13 +1464,13 @@ function makeFormalArg (d, b) {
   return makeId(d, b) + (rnd(5) ? "" : " = " + makeExpr(d, b));
 }
 
-function makeNewId (d, b) {
+function makeNewId (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return Random.index(["a", "b", "c", "d", "e", "w", "x", "y", "z"]);
 }
 
-function makeId (d, b) {
+function makeId (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(3) === 1 && b.length) { return Random.index(b); }
@@ -1512,7 +1512,7 @@ function makeId (d, b) {
   // but bad things happen if you have "eval setter". so let's not put eval in this list.
 }
 
-function makeComprehension (d, b) {
+function makeComprehension (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d < 0) { return ""; }
@@ -1532,12 +1532,12 @@ function makeComprehension (d, b) {
 }
 
 // for..in LHS can be a single variable OR it can be a destructuring array of exactly two elements.
-function makeForInLHS (d, b) {
+function makeForInLHS (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
   return makeLValue(d, b);
 }
 
-function makeLValue (d, b) {
+function makeLValue (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d <= 0 || (rnd(2) === 1)) { return makeId(d - 1, b); }
@@ -1583,7 +1583,7 @@ var lvalueMakers = [
   function (d, b) { return makeExpr(d, b); }
 ];
 
-function makeDestructuringLValue (d, b) {
+function makeDestructuringLValue (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
@@ -1635,13 +1635,13 @@ var destructuringLValueMakers = [
 ];
 
 // Allow "holes".
-function maybeMakeDestructuringLValue (d, b) {
+function maybeMakeDestructuringLValue (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(2) === 0) { return ""; }
 
   return makeDestructuringLValue(d, b);
 }
 
-function makeTerm (d, b) {
+function makeTerm (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return (Random.index(termMakers))(d, b);
@@ -1683,7 +1683,7 @@ var termMakers = [
   makeRegex
 ];
 
-function randomUnitStringLiteral () {
+function randomUnitStringLiteral () { // eslint-disable-line require-jsdoc
   var s = "\"\\u";
   for (var i = 0; i < 4; ++i) {
     s += "0123456789ABCDEF".charAt(rnd(16));
@@ -1692,11 +1692,11 @@ function randomUnitStringLiteral () {
   return s;
 }
 
-function maybeMakeTerm (d, b) {
+function maybeMakeTerm (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(2)) { return makeTerm(d - 1, b); } else { return ""; }
 }
 
-function makeCrazyToken () {
+function makeCrazyToken () { // eslint-disable-line require-jsdoc
   if (rnd(3) === 0) {
     return String.fromCharCode(32 + rnd(128 - 32));
   }
@@ -1747,7 +1747,7 @@ function makeCrazyToken () {
   ]);
 }
 
-function makeShapeyValue (d, b) {
+function makeShapeyValue (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(10) === 0) { return makeExpr(d, b); }
@@ -1829,14 +1829,14 @@ function makeShapeyValue (d, b) {
   return Random.index(Random.index(a));
 }
 
-function mixedTypeArrayElem (d, b) {
+function mixedTypeArrayElem (d, b) { // eslint-disable-line require-jsdoc
   while (true) {
     var s = makeShapeyValue(d - 3, b);
     if (s.length < 60) { return s; }
   }
 }
 
-function makeMixedTypeArray (d, b) {
+function makeMixedTypeArray (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // Pick two to five values to use as array entries.
@@ -1863,7 +1863,7 @@ function makeMixedTypeArray (d, b) {
   return "/*MARR*/" + "[" + c.join(", ") + "]";
 }
 
-function makeArrayLiteral (d, b) {
+function makeArrayLiteral (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(2) === 0) { return makeMixedTypeArray(d, b); }
@@ -1873,7 +1873,7 @@ function makeArrayLiteral (d, b) {
   return "/*FARR*/" + "[" + elems.join(", ") + "]";
 }
 
-function makeArrayLiteralElem (d, b) {
+function makeArrayLiteralElem (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(5)) {
@@ -1885,7 +1885,7 @@ function makeArrayLiteralElem (d, b) {
   }
 }
 
-function makeIterable (d, b) {
+function makeIterable (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d < 1) { return "[]"; }
@@ -1919,7 +1919,7 @@ var iterableExprMakers = Random.weighted([
   { w: 1, v: makeExpr }
 ]);
 
-function strTimes (s, n) {
+function strTimes (s, n) { // eslint-disable-line require-jsdoc
   if (n == 0) return "";
   if (n == 1) return s;
   var s2 = s + s;
@@ -1929,14 +1929,14 @@ function strTimes (s, n) {
   return r ? m + s : m;
 }
 
-function makeAsmJSModule (d, b) {
+function makeAsmJSModule (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior([]);
   return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })";
 }
 
-function makeAsmJSFunction (d, b) {
+function makeAsmJSFunction (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior(["ff"]);

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -22,7 +22,7 @@ function makeScript (d, ignoredB) { // eslint-disable-line require-jsdoc
 }
 
 function makeScriptBody (d, ignoredB) { // eslint-disable-line require-jsdoc
-  if (rnd(3) === 0) {
+  if (rnd(3) == 0) {
     return makeMathyFunAndTest(d, ["x"]);
   }
   return makeStatement(d, ["x"]);
@@ -41,7 +41,7 @@ function makeScriptForEval (d, b) { // eslint-disable-line require-jsdoc
 
 // Statement or block of statements
 function makeStatement (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(2)) { return makeBuilderStatement(d, b); }
 
@@ -271,7 +271,7 @@ var statementMakers = Random.weighted([
   // Long script -- can confuse Spidermonkey's short vs long jmp or something like that.
   // Spidermonkey's regexp engine is so slow for long strings that we have to bypass whatToTest :(
   // { w: 1, v: function(d, b) { return strTimes("try{}catch(e){}", rnd(10000)); } },
-  { w: 1, v: function (d, b) { if (rnd(200) === 0) return "/*DUPTRY" + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";"; } },
+  { w: 1, v: function (d, b) { if (rnd(200) == 0) return "/*DUPTRY" + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";"; } },
 
   { w: 1, v: function (d, b) { return makeShapeyConstructorLoop(d, b); } },
 
@@ -302,7 +302,7 @@ var statementMakers = Random.weighted([
   // { w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" + makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
 ]);
 
-if (typeof oomTest === "function" && engine !== ENGINE_JAVASCRIPTCORE) {
+if (typeof oomTest === "function" && engine != ENGINE_JAVASCRIPTCORE) {
   statementMakers = statementMakers.concat([
     function (d, b) { return "oomTest(" + makeFunction(d - 1, b) + ")"; },
     function (d, b) { return "oomTest(" + makeFunction(d - 1, b) + ", { keepFailing: true })"; }
@@ -310,7 +310,7 @@ if (typeof oomTest === "function" && engine !== ENGINE_JAVASCRIPTCORE) {
 }
 
 function makeUseRegressionTest (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (typeof regressionTestList !== "object") {
     return "/* no regression tests found */";
@@ -321,7 +321,7 @@ function makeUseRegressionTest (d, b) { // eslint-disable-line require-jsdoc
 
   var s = "";
 
-  if (rnd(5) === 0) {
+  if (rnd(5) == 0) {
     // Many tests call assertEq, intending to throw if something unexpected happens.
     // Sometimes, override it with a function that compares but does not throw.
     s += "assertEq = function(x, y) { if (x != y) { print(0); } }; ";
@@ -350,11 +350,11 @@ function makeUseRegressionTest (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function regressionTestIsEvil (contents) { // eslint-disable-line require-jsdoc
-  if (contents.indexOf("SIMD") !== -1) {
+  if (contents.indexOf("SIMD") != -1) {
     // Disable SIMD testing until it's more stable (and we can get better stacks?)
     return true;
   }
-  if (contents.indexOf("print = ") !== -1) {
+  if (contents.indexOf("print = ") != -1) {
     // A testcase that clobbers the |print| function would confuse js_interesting
     return true;
   }
@@ -381,7 +381,7 @@ function inlineTest (filename) { // eslint-disable-line require-jsdoc
   ];
 
   for (var f of noDiffTestingFunctions) {
-    if (s.indexOf(f) !== -1) {
+    if (s.indexOf(f) != -1) {
       return "/*NODIFF*/ " + s;
     }
   }
@@ -395,21 +395,21 @@ function regressionTestDependencies (maintest) { // eslint-disable-line require-
   if (rnd(3)) {
     // Include the chain of 'shell.js' files in their containing directories (starting from regressionTestsRoot)
     for (var i = regressionTestsRoot.length; i < maintest.length; ++i) {
-      if (maintest.charAt(i) === "/" || maintest.charAt(i) === "\\") {
+      if (maintest.charAt(i) == "/" || maintest.charAt(i) == "\\") {
         var shelljs = maintest.substr(0, i + 1) + "shell.js";
-        if (regressionTestList.indexOf(shelljs) !== -1) {
+        if (regressionTestList.indexOf(shelljs) != -1) {
           files.push(shelljs);
         }
       }
     }
 
     // Include prologue.js for jit-tests
-    if (maintest.indexOf("jit-test") !== -1) {
+    if (maintest.indexOf("jit-test") != -1) {
       files.push(libdir + "prologue.js");
     }
 
     // Include web-platform-test-shims.js and testharness.js for streams tests
-    if (maintest.indexOf("web-platform") !== -1) {
+    if (maintest.indexOf("web-platform") != -1) {
       files.push(js_src_tests_dir + "web-platform-test-shims.js"); // eslint-disable-line camelcase
       files.push(w_pltfrm_res_dir + "testharness.js"); // eslint-disable-line camelcase
     }
@@ -428,7 +428,7 @@ function makeNamedFunctionAndUse (d, b) { // eslint-disable-line require-jsdoc
   // Use a unique function name to make it less likely that we'll accidentally make a recursive call
   var funcName = uniqueVarName();
   var formalArgList = makeFormalArgList(d, b);
-  var bv = formalArgList.length === 1 ? b.concat(formalArgList) : b;
+  var bv = formalArgList.length == 1 ? b.concat(formalArgList) : b;
   var declStatement = cat(["/*hhh*/function ", funcName, "(", formalArgList, ")", "{", makeStatement(d - 1, bv), "}"]);
   var useStatement;
   if (rnd(2)) {
@@ -461,7 +461,7 @@ function uniqueVarName () { // eslint-disable-line require-jsdoc
 }
 
 function makeSwitchBody (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var haveSomething = false;
   var haveDefault = false;
@@ -496,7 +496,7 @@ function makeSwitchBody (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeLittleStatement (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
 
@@ -549,7 +549,7 @@ var littleStatementMakers =
 // makeStatementOrBlock exists because often, things have different behaviors depending on where there are braces.
 // for example, if braces are added or removed, the meaning of "let" can change.
 function makeStatementOrBlock (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return (Random.index(statementBlockMakers))(d - 1, b);
 }
@@ -564,7 +564,7 @@ var statementBlockMakers = [
 // Extra-hard testing for try/catch/finally and related things.
 
 function makeExceptionyStatement (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
   if (d < 1) { return makeLittleStatement(d, b); }
@@ -623,7 +623,7 @@ var exceptionyStatementMakers = [
 ];
 
 function makeTryBlock (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // Catches: 1/6 chance of having none
   // Catches: maybe 2 + 1/2
@@ -652,7 +652,7 @@ function makeTryBlock (d, b) { // eslint-disable-line require-jsdoc
     s += cat(["catch", "(", catchId, ")", " { ", catchBlock, " } "]);
   }
 
-  if (numCatches === 0 || rnd(2) === 1) {
+  if (numCatches == 0 || rnd(2) === 1) {
     // Add a finally.
     s += cat(["finally", " { ", makeExceptionyStatement(d, b), " } "]);
   }
@@ -662,7 +662,7 @@ function makeTryBlock (d, b) { // eslint-disable-line require-jsdoc
 
 // Creates a string that sorta makes sense as an expression
 function makeExpr (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d <= 0 || (rnd(7) === 1)) { return makeTerm(d - 1, b); }
 
@@ -940,7 +940,7 @@ var fuzzTestingFunctions = fuzzTestingFunctionsCtor(!jsshell, fuzzTestingFunctio
 function fuzzTestingFunctionArg (d, b) { return "this"; } // eslint-disable-line require-jsdoc
 
 function makeTestingFunctionCall (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var callStatement = Random.index(fuzzTestingFunctions.testingFunctions)(d, b);
 
@@ -987,7 +987,7 @@ if (typeof XPCNativeWrapper === "function") {
 }
 
 function makeNewGlobalArg (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // Make an options object to pass to the |newGlobal| shell builtin.
   var propStrs = [];
@@ -1001,7 +1001,7 @@ function makeNewGlobalArg (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeGlobal (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(10)) { return "this"; }
 
@@ -1032,7 +1032,7 @@ if (xpcshell) {
 }
 
 function makeShapeyConstructor (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
   var argName = uniqueVarName();
   var t = rnd(4) ? "this" : argName;
   var funText = "function shapeyConstructor(" + argName + "){" + directivePrologue();
@@ -1081,7 +1081,7 @@ var propertyNameMakers = Random.weighted([
 function maybeNeg () { return rnd(5) ? "" : "-"; } // eslint-disable-line require-jsdoc
 
 function makePropertyName (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return (Random.index(propertyNameMakers))(d, b);
 }
@@ -1102,7 +1102,7 @@ function makeShapeyConstructorLoop (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makePropertyDescriptor (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var s = "({";
 
@@ -1131,7 +1131,7 @@ function makePropertyDescriptor (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeBoolean (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */
     case 0:   return "true";
@@ -1143,7 +1143,7 @@ function makeBoolean (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeObjLiteralPart (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(8)) {
   // Literal getter/setter
@@ -1159,7 +1159,7 @@ function makeObjLiteralPart (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeToXFunction (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */
@@ -1172,7 +1172,7 @@ function makeToXFunction (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeObjLiteralName (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(6)) {
     /* eslint-disable no-multi-spaces */
@@ -1186,7 +1186,7 @@ function makeObjLiteralName (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeFunction (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
 
@@ -1209,7 +1209,7 @@ function directivePrologue () { // eslint-disable-line require-jsdoc
 }
 
 function makeFunctionBody (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(6)) {
     /* eslint-disable no-multi-spaces */
@@ -1224,9 +1224,9 @@ function makeFunctionBody (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function functionPrefix () { // eslint-disable-line require-jsdoc
-  return (rnd(2) === 0 ? "" : "async ")
+  return (rnd(2) == 0 ? "" : "async ")
     + "function"
-    + (rnd(2) === 0 ? "" : "*");
+    + (rnd(2) == 0 ? "" : "*");
 }
 
 var functionMakers = [
@@ -1320,7 +1320,7 @@ if (typeof XPCNativeWrapper === "function") {
   ]);
 }
 
-if (typeof oomTest === "function" && engine !== ENGINE_JAVASCRIPTCORE) {
+if (typeof oomTest === "function" && engine != ENGINE_JAVASCRIPTCORE) {
   functionMakers = functionMakers.concat([
     function (d, b) { return "oomTest"; }
   ]);
@@ -1339,7 +1339,7 @@ var typedArrayConstructors = [
 ];
 
 function makeTypedArrayStatements (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d < 0) return "";
 
@@ -1367,7 +1367,7 @@ function makeTypedArrayStatements (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeNumber (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var signStr = rnd(2) ? "-" : "";
 
@@ -1405,7 +1405,7 @@ function makeNumber (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeLetHead (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var items = (d > 0 || rnd(2) === 0) ? rnd(10) + 1 : 1;
   var result = "";
@@ -1419,7 +1419,7 @@ function makeLetHead (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeLetHeadItem (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
 
@@ -1427,11 +1427,11 @@ function makeLetHeadItem (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeActualArgList (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var nArgs = rnd(3);
 
-  if (nArgs === 0) { return ""; }
+  if (nArgs == 0) { return ""; }
 
   var argList = makeExpr(d, b);
 
@@ -1441,7 +1441,7 @@ function makeActualArgList (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeFormalArgList (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var argList = [];
 
@@ -1459,7 +1459,7 @@ function makeFormalArgList (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeFormalArg (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(8) === 1) { return makeDestructuringLValue(d, b); }
 
@@ -1467,13 +1467,13 @@ function makeFormalArg (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeNewId (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return Random.index(["a", "b", "c", "d", "e", "w", "x", "y", "z"]);
 }
 
 function makeId (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(3) === 1 && b.length) { return Random.index(b); }
 
@@ -1515,7 +1515,7 @@ function makeId (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeComprehension (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d < 0) { return ""; }
 
@@ -1535,12 +1535,12 @@ function makeComprehension (d, b) { // eslint-disable-line require-jsdoc
 
 // for..in LHS can be a single variable OR it can be a destructuring array of exactly two elements.
 function makeForInLHS (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
   return makeLValue(d, b);
 }
 
 function makeLValue (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d <= 0 || (rnd(2) === 1)) { return makeId(d - 1, b); }
 
@@ -1586,7 +1586,7 @@ var lvalueMakers = [
 ];
 
 function makeDestructuringLValue (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
 
@@ -1601,7 +1601,7 @@ var destructuringLValueMakers = [
   // destructuring assignment: arrays
   function (d, b) {
     var len = rnd(d, b);
-    if (len === 0) { return "[]"; }
+    if (len == 0) { return "[]"; }
 
     var Ti = [];
     Ti.push("[");
@@ -1619,7 +1619,7 @@ var destructuringLValueMakers = [
   // destructuring assignment: objects
   function (d, b) {
     var len = rnd(d, b);
-    if (len === 0) { return "{}"; }
+    if (len == 0) { return "{}"; }
     var Ti = [];
     Ti.push("{");
     for (var i = 0; i < len; ++i) {
@@ -1644,7 +1644,7 @@ function maybeMakeDestructuringLValue (d, b) { // eslint-disable-line require-js
 }
 
 function makeTerm (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return (Random.index(termMakers))(d, b);
 }
@@ -1750,7 +1750,7 @@ function makeCrazyToken () { // eslint-disable-line require-jsdoc
 }
 
 function makeShapeyValue (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(10) === 0) { return makeExpr(d, b); }
 
@@ -1839,7 +1839,7 @@ function mixedTypeArrayElem (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeMixedTypeArray (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // Pick two to five values to use as array entries.
   var q = rnd(4) + 2;
@@ -1866,7 +1866,7 @@ function makeMixedTypeArray (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeArrayLiteral (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (rnd(2) === 0) { return makeMixedTypeArray(d, b); }
 
@@ -1876,7 +1876,7 @@ function makeArrayLiteral (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeArrayLiteralElem (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(5)) {
     /* eslint-disable no-multi-spaces */
@@ -1888,7 +1888,7 @@ function makeArrayLiteralElem (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeIterable (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d < 1) { return "[]"; }
 
@@ -1922,8 +1922,8 @@ var iterableExprMakers = Random.weighted([
 ]);
 
 function strTimes (s, n) { // eslint-disable-line require-jsdoc
-  if (n === 0) return "";
-  if (n === 1) return s;
+  if (n == 0) return "";
+  if (n == 1) return s;
   var s2 = s + s;
   var r = n % 2;
   var d = (n - r) / 2;
@@ -1932,14 +1932,14 @@ function strTimes (s, n) { // eslint-disable-line require-jsdoc
 }
 
 function makeAsmJSModule (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior([]);
   return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })";
 }
 
 function makeAsmJSFunction (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior(["ff"]);
   return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })(this, {ff: " + makeFunction(d - 2, b) + "}, new " + arrayBufferType() + "(4096))";

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -222,7 +222,7 @@ var statementMakers = Random.weighted([
 
   // Modify something during a loop -- perhaps the thing being looped over
   // Since we use "let" to bind the for-variables, and only do wacky stuff once, I *think* this is unlikely to hang.
-//  function(d, b) { return "let forCount = 0; for (let " + makeId(d, b) + " in " + makeExpr(d, b) + ") { if (forCount++ == " + rnd(3) + ") { " + makeStatement(d - 1, b) + " } }"; },
+  //  function(d, b) { return "let forCount = 0; for (let " + makeId(d, b) + " in " + makeExpr(d, b) + ") { if (forCount++ == " + rnd(3) + ") { " + makeStatement(d - 1, b) + " } }"; },
 
   // Hoisty "for..in" loops.  I don't know why this construct exists, but it does, and it hoists the initial-value expression above the loop.
   // With "var" or "const", the entire thing is hoisted.
@@ -345,11 +345,11 @@ function makeUseRegressionTest(d, b)
 
     switch (rnd(2)) {
       case 0:
-        // simply inline the script -- this is the only one that will work in newGlobal()
+      // simply inline the script -- this is the only one that will work in newGlobal()
         s += "/* regression-test-inline */ " + inlineTest(file);
         break;
       default:
-        // run it using load()
+      // run it using load()
         s += "/* regression-test-load */ " + "load(" + simpleSource(file) + ");";
         break;
       // NB: these scripts will also be run through eval(), evalcx(), evaluate() thanks to other parts of the fuzzer using makeScriptForEval or makeStatement
@@ -1170,17 +1170,17 @@ function makePropertyDescriptor(d, b)
   var s = "({";
 
   switch(rnd(3)) {
-  case 0:
+    case 0:
     // Data descriptor. Can have 'value' and 'writable'.
-    if (rnd(2)) s += "value: " + makeExpr(d, b) + ", ";
-    if (rnd(2)) s += "writable: " + makeBoolean(d, b) + ", ";
-    break;
-  case 1:
+      if (rnd(2)) s += "value: " + makeExpr(d, b) + ", ";
+      if (rnd(2)) s += "writable: " + makeBoolean(d, b) + ", ";
+      break;
+    case 1:
     // Accessor descriptor. Can have 'get' and 'set'.
-    if (rnd(2)) s += "get: " + makeFunction(d, b) + ", ";
-    if (rnd(2)) s += "set: " + makeFunction(d, b) + ", ";
-    break;
-  default:
+      if (rnd(2)) s += "get: " + makeFunction(d, b) + ", ";
+      if (rnd(2)) s += "set: " + makeFunction(d, b) + ", ";
+      break;
+    default:
   }
 
   if (rnd(2)) s += "configurable: " + makeBoolean(d, b) + ", ";
@@ -1212,9 +1212,9 @@ function makeObjLiteralPart(d, b)
 
   switch(rnd(8))
   {
-    // Literal getter/setter
-    // Surprisingly, string literals, integer literals, and float literals are also good!
-    // (See https://bugzilla.mozilla.org/show_bug.cgi?id=520696.)
+  // Literal getter/setter
+  // Surprisingly, string literals, integer literals, and float literals are also good!
+  // (See https://bugzilla.mozilla.org/show_bug.cgi?id=520696.)
     case 2: return cat([" get ", makeObjLiteralName(d, b), maybeName(d, b), "(", makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)]);
     case 3: return cat([" set ", makeObjLiteralName(d, b), maybeName(d, b), "(", makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)]);
 
@@ -1574,34 +1574,35 @@ function makeId(d, b)
 
   switch(rnd(200))
   {
-  case 0:
-    return makeTerm(d, b);
-  case 1:
-    return makeExpr(d, b);
-  case 2: case 3: case 4: case 5:
-    return makeLValue(d, b);
-  case 6: case 7:
-    return makeDestructuringLValue(d, b);
-  case 8: case 9: case 10:
+    case 0:
+      return makeTerm(d, b);
+    case 1:
+      return makeExpr(d, b);
+    case 2: case 3: case 4: case 5:
+      return makeLValue(d, b);
+    case 6: case 7:
+      return makeDestructuringLValue(d, b);
+    case 8: case 9: case 10:
     // some keywords that can be used as identifiers in some contexts (e.g. variables, function names, argument names)
     // but that's annoying, and some of these cause lots of syntax errors.
-    return Random.index(["get", "set", "getter", "setter", "delete", "let", "yield", "await", "of"]);
-  case 11: case 12: case 13:
-    return "this." + makeId(d, b);
-  case 14: case 15: case 16:
-    return makeObjLiteralName(d - 1, b);
-  case 17: case 18:
-    return makeId(d - 1, b);
-  case 19:
-    return " "; // [k, v] becomes [, v] -- test how holes are handled in unexpected destructuring
-  case 20:
-    return "this";
+      return Random.index(["get", "set", "getter", "setter", "delete", "let", "yield", "await", "of"]);
+    case 11: case 12: case 13:
+      return "this." + makeId(d, b);
+    case 14: case 15: case 16:
+      return makeObjLiteralName(d - 1, b);
+    case 17: case 18:
+      return makeId(d - 1, b);
+    case 19:
+      return " "; // [k, v] becomes [, v] -- test how holes are handled in unexpected destructuring
+    case 20:
+      return "this";
   }
 
-  return Random.index(["a", "b", "c", "d", "e", "w", "x", "y", "z",
-                 "window", "eval", "\u3056", "NaN",
-//                 "valueOf", "toString", // e.g. valueOf getter :P // bug 381242, etc
-                  ]);
+  return Random.index([
+    "a", "b", "c", "d", "e", "w", "x", "y", "z",
+    "window", "eval", "\u3056", "NaN",
+    // "valueOf", "toString", // e.g. valueOf getter :P // bug 381242, etc
+  ]);
 
   // window is a const (in the browser), so some attempts to redeclare it will cause errors
 
@@ -1618,16 +1619,16 @@ function makeComprehension(d, b)
     return "";
 
   switch(rnd(7)) {
-  case 0:
-    return "";
-  case 1:
-    return cat([" for ",          "(", makeForInLHS(d, b), " in ", makeExpr(d - 2, b),     ")"]) + makeComprehension(d - 1, b);
-  case 2:
-    return cat([" for ",          "(", makeId(d, b),       " of ", makeExpr(d - 2, b),     ")"]) + makeComprehension(d - 1, b);
-  case 3:
-    return cat([" for ",          "(", makeId(d, b),       " of ", makeIterable(d - 2, b), ")"]) + makeComprehension(d - 1, b);
-  default:
-    return cat([" if ", "(", makeExpr(d - 2, b), ")"]); // this is always last (and must be preceded by a "for", oh well)
+    case 0:
+      return "";
+    case 1:
+      return cat([" for ",          "(", makeForInLHS(d, b), " in ", makeExpr(d - 2, b),     ")"]) + makeComprehension(d - 1, b);
+    case 2:
+      return cat([" for ",          "(", makeId(d, b),       " of ", makeExpr(d - 2, b),     ")"]) + makeComprehension(d - 1, b);
+    case 3:
+      return cat([" for ",          "(", makeId(d, b),       " of ", makeIterable(d - 2, b), ")"]) + makeComprehension(d - 1, b);
+    default:
+      return cat([" if ", "(", makeExpr(d - 2, b), ")"]); // this is always last (and must be preceded by a "for", oh well)
   }
 }
 
@@ -1791,7 +1792,7 @@ var termMakers = [
     "length",
 
     '"\u03A0"', // unicode not escaped
-    ]);
+  ]);
   },
   makeNumber,
   function(d, b) { return Random.index([ "true", "false", "undefined", "null"]); },
@@ -1833,44 +1834,44 @@ function makeCrazyToken()
 
   return Random.index([
 
-  // Some of this is from reading jsscan.h.
+    // Some of this is from reading jsscan.h.
 
-  // Comments; comments hiding line breaks.
-  "//", UNTERMINATED_COMMENT, (UNTERMINATED_COMMENT + "\n"), "/*\n*/",
+    // Comments; comments hiding line breaks.
+    "//", UNTERMINATED_COMMENT, (UNTERMINATED_COMMENT + "\n"), "/*\n*/",
 
-  // groupers (which will usually be unmatched if they come from here ;)
-  "[", "]",
-  "{", "}",
-  "(", ")",
+    // groupers (which will usually be unmatched if they come from here ;)
+    "[", "]",
+    "{", "}",
+    "(", ")",
 
-  // a few operators
-  "!", "@", "%", "^", "*", "**", "|", ":", "?", "'", "\"", ",", ".", "/",
-  "~", "_", "+", "=", "-", "++", "--", "+=", "%=", "|=", "-=",
-  "...", "=>",
+    // a few operators
+    "!", "@", "%", "^", "*", "**", "|", ":", "?", "'", "\"", ",", ".", "/",
+    "~", "_", "+", "=", "-", "++", "--", "+=", "%=", "|=", "-=",
+    "...", "=>",
 
-  // most real keywords plus a few reserved keywords
-  " in ", " instanceof ", " let ", " new ", " get ", " for ", " if ", " else ", " else if ", " try ", " catch ", " finally ", " export ", " import ", " void ", " with ",
-  " default ", " goto ", " case ", " switch ", " do ", " /*infloop*/while ", " return ", " yield ", " await ", " break ", " continue ", " typeof ", " var ", " const ",
+    // most real keywords plus a few reserved keywords
+    " in ", " instanceof ", " let ", " new ", " get ", " for ", " if ", " else ", " else if ", " try ", " catch ", " finally ", " export ", " import ", " void ", " with ",
+    " default ", " goto ", " case ", " switch ", " do ", " /*infloop*/while ", " return ", " yield ", " await ", " break ", " continue ", " typeof ", " var ", " const ",
 
-  // reserved when found in strict mode code
-  " package ",
+    // reserved when found in strict mode code
+    " package ",
 
-  // several keywords can be used as identifiers. these are just a few of them.
-  " enum ", // JS_HAS_RESERVED_ECMA_KEYWORDS
-  " debugger ", // JS_HAS_DEBUGGER_KEYWORD
-  " super ", // TOK_PRIMARY!
+    // several keywords can be used as identifiers. these are just a few of them.
+    " enum ", // JS_HAS_RESERVED_ECMA_KEYWORDS
+    " debugger ", // JS_HAS_DEBUGGER_KEYWORD
+    " super ", // TOK_PRIMARY!
 
-  " this ", // TOK_PRIMARY!
-  " null ", // TOK_PRIMARY!
-  " undefined ", // not a keyword, but a default part of the global object
-  "\n", // trigger semicolon insertion, also acts as whitespace where it might not be expected
-  "\r",
-  "\u2028", // LINE_SEPARATOR?
-  "\u2029", // PARA_SEPARATOR?
-  "<" + "!" + "--", // beginning of HTML-style to-end-of-line comment (!)
-  "--" + ">", // end of HTML-style comment
-  "",
-  "\0", // confuse anything that tries to guess where a string ends. but note: "illegal character"!
+    " this ", // TOK_PRIMARY!
+    " null ", // TOK_PRIMARY!
+    " undefined ", // not a keyword, but a default part of the global object
+    "\n", // trigger semicolon insertion, also acts as whitespace where it might not be expected
+    "\r",
+    "\u2028", // LINE_SEPARATOR?
+    "\u2029", // PARA_SEPARATOR?
+    "<" + "!" + "--", // beginning of HTML-style to-end-of-line comment (!)
+    "--" + ">", // end of HTML-style comment
+    "",
+    "\0", // confuse anything that tries to guess where a string ends. but note: "illegal character"!
   ]);
 }
 
@@ -1885,36 +1886,36 @@ function makeShapeyValue(d, b)
   var a = [
     // Numbers and number-like things
     [
-    "0", "1", "2", "3", "0.1", ".2", "1.3", "4.", "5.0000000000000000000000",
-    "1.2e3", "1e81", "1e+81", "1e-81", "1e4", "-0", "(-0)",
-    "-1", "(-1)", "0x99", "033", "3/0", "-3/0", "0/0",
-    "Math.PI",
-    "0x2D413CCC", "0x5a827999", "0xB504F332", "-0x2D413CCC", "-0x5a827999", "-0xB504F332", "0x50505050", "(0x50505050 >> 1)",
+      "0", "1", "2", "3", "0.1", ".2", "1.3", "4.", "5.0000000000000000000000",
+      "1.2e3", "1e81", "1e+81", "1e-81", "1e4", "-0", "(-0)",
+      "-1", "(-1)", "0x99", "033", "3/0", "-3/0", "0/0",
+      "Math.PI",
+      "0x2D413CCC", "0x5a827999", "0xB504F332", "-0x2D413CCC", "-0x5a827999", "-0xB504F332", "0x50505050", "(0x50505050 >> 1)",
 
-    // various powers of two, with values near JSVAL_INT_MAX especially tested
-    "0x10000000", "0x20000000", "0x3FFFFFFE", "0x3FFFFFFF", "0x40000000", "0x40000001",
+      // various powers of two, with values near JSVAL_INT_MAX especially tested
+      "0x10000000", "0x20000000", "0x3FFFFFFE", "0x3FFFFFFF", "0x40000000", "0x40000001",
     ],
 
     // Boundaries
     [
     // Boundaries of int, signed, unsigned (near +/- 2^31, +/- 2^32)
-    "0x07fffffff",  "0x080000000",  "0x080000001",
-    "-0x07fffffff", "-0x080000000", "-0x080000001",
-    "0x0ffffffff",  "0x100000000",  "0x100000001",
-    "-0x0ffffffff", "-0x100000000",  "-0x100000001",
+      "0x07fffffff",  "0x080000000",  "0x080000001",
+      "-0x07fffffff", "-0x080000000", "-0x080000001",
+      "0x0ffffffff",  "0x100000000",  "0x100000001",
+      "-0x0ffffffff", "-0x100000000",  "-0x100000001",
 
-    // Boundaries of double
-    "Number.MIN_VALUE", "-Number.MIN_VALUE",
-    "Number.MAX_VALUE", "-Number.MAX_VALUE",
+      // Boundaries of double
+      "Number.MIN_VALUE", "-Number.MIN_VALUE",
+      "Number.MAX_VALUE", "-Number.MAX_VALUE",
 
-    // Boundaries of maximum safe integer
-    "Number.MIN_SAFE_INTEGER", "-Number.MIN_SAFE_INTEGER",
-    "-(2**53-2)", "-(2**53)", "-(2**53+2)",
-    "Number.MAX_SAFE_INTEGER", "-Number.MAX_SAFE_INTEGER",
-    "(2**53)-2", "(2**53)", "(2**53)+2",
+      // Boundaries of maximum safe integer
+      "Number.MIN_SAFE_INTEGER", "-Number.MIN_SAFE_INTEGER",
+      "-(2**53-2)", "-(2**53)", "-(2**53+2)",
+      "Number.MAX_SAFE_INTEGER", "-Number.MAX_SAFE_INTEGER",
+      "(2**53)-2", "(2**53)", "(2**53)+2",
 
-    // See bug 1350097 - 1.79...e308 is the largest (by module) finite number
-    "0.000000000000001", "1.7976931348623157e308",
+      // See bug 1350097 - 1.79...e308 is the largest (by module) finite number
+      "0.000000000000001", "1.7976931348623157e308",
     ],
 
     // Special numbers

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -17,22 +17,18 @@
  * GRAMMAR-BASED GENERATION *
  * ************************ */
 
-
-function makeScript(d, ignoredB)
-{
+function makeScript (d, ignoredB) {
   return directivePrologue() + makeScriptBody(d, ignoredB);
 }
 
-function makeScriptBody(d, ignoredB)
-{
+function makeScriptBody (d, ignoredB) {
   if (rnd(3) == 0) {
     return makeMathyFunAndTest(d, ["x"]);
   }
   return makeStatement(d, ["x"]);
 }
 
-function makeScriptForEval(d, b)
-{
+function makeScriptForEval (d, b) {
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */
     case 0:  return makeExpr(d - 1, b);
@@ -43,20 +39,16 @@ function makeScriptForEval(d, b)
   }
 }
 
-
 // Statement or block of statements
-function makeStatement(d, b)
-{
+function makeStatement (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (rnd(2))
-    return makeBuilderStatement(d, b);
+  if (rnd(2)) { return makeBuilderStatement(d, b); }
 
-  if (d < 6 && rnd(3) === 0)
-    return makePrintStatement(d, b);
+  if (d < 6 && rnd(3) === 0) { return makePrintStatement(d, b); }
 
   if (d < rnd(8)) // frequently for small depth, infrequently for large depth
-    return makeLittleStatement(d, b);
+  { return makeLittleStatement(d, b); }
 
   d = rnd(d); // !
 
@@ -69,8 +61,7 @@ var varBinderFor = ["var ", "let ", ""]; // const is a syntax error in for loops
 // The reason there are several types of loops here is to create different
 // types of scripts without introducing infinite loops.
 
-function forLoopHead(d, b, v, reps)
-{
+function forLoopHead (d, b, v, reps) {
   var sInit = "";
   var sCond = "";
   var sNext = "";
@@ -95,31 +86,23 @@ function forLoopHead(d, b, v, reps)
       }
   }
 
-  while (rnd(10) === 0)
-    sInit += ", " + makeLetHeadItem(d - 2, b);
-  while (rnd(10) === 0)
-    sInit += ", " + makeExpr(d - 2, b); // NB: only makes sense if our varBinder is ""
+  while (rnd(10) === 0) { sInit += ", " + makeLetHeadItem(d - 2, b); }
+  while (rnd(10) === 0) { sInit += ", " + makeExpr(d - 2, b); } // NB: only makes sense if our varBinder is ""
   while (rnd(1000) === 0)
-    // never causes the loop to be run, but stuff like register allocation may be happening in the background
-    sInit = Random.index(varBinderFor) + v;
-  while (rnd(10000) === 0)
-    sInit = ""; // mostly throws ReferenceError, so make this rare
+  // never causes the loop to be run, but stuff like register allocation may be happening in the background
+  { sInit = Random.index(varBinderFor) + v; }
+  while (rnd(10000) === 0) { sInit = ""; } // mostly throws ReferenceError, so make this rare
 
-  while (rnd(20) === 0)
-    sCond = sCond + " && (" + makeExpr(d - 2, b) + ")";
-  while (rnd(20) === 0)
-    sCond = "(" + makeExpr(d - 2, b) + ") && " + sCond;
+  while (rnd(20) === 0) { sCond = sCond + " && (" + makeExpr(d - 2, b) + ")"; }
+  while (rnd(20) === 0) { sCond = "(" + makeExpr(d - 2, b) + ") && " + sCond; }
 
-  while (rnd(20) === 0)
-    sNext = sNext + ", " + makeExpr(d - 2, b);
-  while (rnd(20) === 0)
-    sNext = makeExpr(d - 2, b) + ", " + sNext;
+  while (rnd(20) === 0) { sNext = sNext + ", " + makeExpr(d - 2, b); }
+  while (rnd(20) === 0) { sNext = makeExpr(d - 2, b) + ", " + sNext; }
 
   return "for (" + sInit + "; " + sCond + "; " + sNext + ")";
 }
 
-function makeOpaqueIdiomaticLoop(d, b)
-{
+function makeOpaqueIdiomaticLoop (d, b) {
   var reps = loopCount();
   var vHidden = uniqueVarName();
   return "/*oLoop*/" + forLoopHead(d, b, vHidden, reps) + " { " +
@@ -127,8 +110,7 @@ function makeOpaqueIdiomaticLoop(d, b)
       " } ";
 }
 
-function makeTransparentIdiomaticLoop(d, b)
-{
+function makeTransparentIdiomaticLoop (d, b) {
   var reps = loopCount();
   var vHidden = uniqueVarName();
   var vVisible = makeNewId(d, b);
@@ -139,8 +121,7 @@ function makeTransparentIdiomaticLoop(d, b)
     " } ";
 }
 
-function makeBranchUnstableLoop(d, b)
-{
+function makeBranchUnstableLoop (d, b) {
   var reps = loopCount();
   var v = uniqueVarName();
   var mod = loopModulo();
@@ -151,58 +132,55 @@ function makeBranchUnstableLoop(d, b)
     " } ";
 }
 
-function makeTypeUnstableLoop(d, b) {
+function makeTypeUnstableLoop (d, b) {
   var a = makeMixedTypeArray(d, b);
   var v = makeNewId(d, b);
   var bv = b.concat([v]);
   return "/*tLoop*/for (let " + v + " of " + a + ") { " + makeStatement(d - 2, bv) + " }";
 }
 
-
-function makeFunOnCallChain(d, b) {
+function makeFunOnCallChain (d, b) {
   var s = "arguments.callee";
-  while (rnd(2))
-    s += ".caller";
+  while (rnd(2)) { s += ".caller"; }
   return s;
 }
-
 
 var statementMakers = Random.weighted([
 
   // Any two statements in sequence
-  { w: 15, v: function(d, b) { return cat([makeStatement(d - 1, b),       makeStatement(d - 1, b)      ]); } },
-  { w: 15, v: function(d, b) { return cat([makeStatement(d - 1, b), "\n", makeStatement(d - 1, b), "\n"]); } },
+  { w: 15, v: function (d, b) { return cat([makeStatement(d - 1, b), makeStatement(d - 1, b) ]); } },
+  { w: 15, v: function (d, b) { return cat([makeStatement(d - 1, b), "\n", makeStatement(d - 1, b), "\n"]); } },
 
   // Stripping semilcolons.  What happens if semicolons are missing?  Especially with line breaks used in place of semicolons (semicolon insertion).
-  { w: 1, v: function(d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n", makeStatement(d, b)]); } },
-  { w: 1, v: function(d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n"                   ]); } },
-  { w: 1, v: function(d, b) { return stripSemicolon(makeStatement(d, b)); } }, // usually invalid, but can be ok e.g. at the end of a block with curly braces
+  { w: 1, v: function (d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n", makeStatement(d, b)]); } },
+  { w: 1, v: function (d, b) { return cat([stripSemicolon(makeStatement(d, b)), "\n" ]); } },
+  { w: 1, v: function (d, b) { return stripSemicolon(makeStatement(d, b)); } }, // usually invalid, but can be ok e.g. at the end of a block with curly braces
 
   // Simple variable declarations, followed (or preceded) by statements using those variables
-  { w: 4, v: function(d, b) { var v = makeNewId(d, b); return cat([Random.index(varBinder), v, " = ", makeExpr(d, b), ";", makeStatement(d - 1, b.concat([v]))]); } },
-  { w: 4, v: function(d, b) { var v = makeNewId(d, b); return cat([makeStatement(d - 1, b.concat([v])), Random.index(varBinder), v, " = ", makeExpr(d, b), ";"]); } },
+  { w: 4, v: function (d, b) { var v = makeNewId(d, b); return cat([Random.index(varBinder), v, " = ", makeExpr(d, b), ";", makeStatement(d - 1, b.concat([v]))]); } },
+  { w: 4, v: function (d, b) { var v = makeNewId(d, b); return cat([makeStatement(d - 1, b.concat([v])), Random.index(varBinder), v, " = ", makeExpr(d, b), ";"]); } },
 
   // Complex variable declarations, e.g. "const [a,b] = [3,4];" or "var a,b,c,d=4,e;"
-  { w: 10, v: function(d, b) { return cat([Random.index(varBinder), makeLetHead(d, b), ";", makeStatement(d - 1, b)]); } },
+  { w: 10, v: function (d, b) { return cat([Random.index(varBinder), makeLetHead(d, b), ";", makeStatement(d - 1, b)]); } },
 
   // Blocks
-  { w: 2, v: function(d, b) { return cat(["{", makeStatement(d, b), " }"]); } },
-  { w: 2, v: function(d, b) { return cat(["{", makeStatement(d - 1, b), makeStatement(d - 1, b), " }"]); } },
+  { w: 2, v: function (d, b) { return cat(["{", makeStatement(d, b), " }"]); } },
+  { w: 2, v: function (d, b) { return cat(["{", makeStatement(d - 1, b), makeStatement(d - 1, b), " }"]); } },
 
   /* eslint-disable no-multi-spaces */
   // "with" blocks
-  { w: 2, v: function(d, b) {                          return cat([maybeLabel(), "with", "(", makeExpr(d, b), ")",                    makeStatementOrBlock(d, b)]);             } },
-  { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat([maybeLabel(), "with", "(", "{", v, ": ", makeExpr(d, b), "}", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 2, v: function (d, b) {                          return cat([maybeLabel(), "with", "(", makeExpr(d, b), ")",                    makeStatementOrBlock(d, b)]);             } },
+  { w: 2, v: function (d, b) { var v = makeNewId(d, b); return cat([maybeLabel(), "with", "(", "{", v, ": ", makeExpr(d, b), "}", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // C-style "for" loops
   // Two kinds of "for" loops: one with an expression as the first part, one with a var or let binding 'statement' as the first part.
   // I'm not sure if arbitrary statements are allowed there; I think not.
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                                                    "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v, " = ", makeExpr(d, b),                             "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeDestructuringLValue(d, b), " = ", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                                                    "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v, " = ", makeExpr(d, b),                             "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeDestructuringLValue(d, b), " = ", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
   /* eslint-enable no-multi-spaces */
 
   // Various types of "for" loops, specially set up to test tracing, carefully avoiding infinite loops
@@ -215,20 +193,20 @@ var statementMakers = Random.weighted([
   // "for..in" loops
   // arbitrary-LHS marked as infloop because
   // -- for (key in obj)
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   // -- for (key in generator())
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
   // -- for (element of arraylike)
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // -- for-await-of
-  { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   /* eslint-enable no-multi-spaces */
 
   // Modify something during a loop -- perhaps the thing being looped over
@@ -240,50 +218,50 @@ var statementMakers = Random.weighted([
   // With "var" or "const", the entire thing is hoisted.
   // With "let", only the value is hoisted, and it can be elim'ed as a useless statement.
   // The last form is specific to JavaScript 1.7 (only).
-  { w: 1, v: function(d, b) {                                                   return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeId(d, b),         " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b);                          return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                    " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b); var w = makeNewId(d, b); return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), "[", v, ", ", w, "]", " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v, w]))]); } },
+  { w: 1, v: function (d, b) {                                                   return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeId(d, b),         " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b);                          return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                    " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); var w = makeNewId(d, b); return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), "[", v, ", ", w, "]", " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v, w]))]); } },
   /* eslint-enable no-multi-spaces */
 
   // do..while
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(), "while", "(", makeExpr(d, b), ")", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, ";"]); } },
-  { w: 1, v: function(d, b) { return "/*infloop*/" + cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while", "(", makeExpr(d, b), ");"]); } },
+  { w: 1, v: function (d, b) { return cat([maybeLabel(), "while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { return "/*infloop*/" + cat([maybeLabel(), "while", "(", makeExpr(d, b), ")", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { return cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, ";"]); } },
+  { w: 1, v: function (d, b) { return "/*infloop*/" + cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while", "(", makeExpr(d, b), ");"]); } },
 
   // Switch statement
-  { w: 3, v: function(d, b) { return cat([maybeLabel(), "switch", "(", makeExpr(d, b), ")", " { ", makeSwitchBody(d, b), " }"]); } },
+  { w: 3, v: function (d, b) { return cat([maybeLabel(), "switch", "(", makeExpr(d, b), ")", " { ", makeSwitchBody(d, b), " }"]); } },
 
   // "let" blocks, with bound variable used inside the block
-  { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v, ")", " { ", makeStatement(d, b.concat([v])), " }"]); } },
+  { w: 2, v: function (d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v, ")", " { ", makeStatement(d, b.concat([v])), " }"]); } },
 
   // "let" blocks, with and without multiple bindings, with and without initial values
-  { w: 2, v: function(d, b) { return cat(["let ", "(", makeLetHead(d, b), ")", " { ", makeStatement(d, b), " }"]); } },
+  { w: 2, v: function (d, b) { return cat(["let ", "(", makeLetHead(d, b), ")", " { ", makeStatement(d, b), " }"]); } },
 
   // Conditionals, perhaps with 'else if' / 'else'
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b)]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b)]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b)]); } },
+  { w: 1, v: function (d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b)]); } },
+  { w: 1, v: function (d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b)]); } },
+  { w: 1, v: function (d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b)]); } },
 
   // A tricky pair of if/else cases.
   // In the SECOND case, braces must be preserved to keep the final "else" associated with the first "if".
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b), "}"]); } },
-  { w: 1, v: function(d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), "}", " else ", makeStatementOrBlock(d - 1, b)]); } },
+  { w: 1, v: function (d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), " else ", makeStatementOrBlock(d - 1, b), "}"]); } },
+  { w: 1, v: function (d, b) { return cat([maybeLabel(), "if(", makeBoolean(d, b), ") ", "{", " if ", "(", makeExpr(d, b), ") ", makeStatementOrBlock(d - 1, b), "}", " else ", makeStatementOrBlock(d - 1, b)]); } },
 
   // Expression statements
-  { w: 5, v: function(d, b) { return cat([makeExpr(d, b), ";"]); } },
-  { w: 5, v: function(d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); } },
+  { w: 5, v: function (d, b) { return cat([makeExpr(d, b), ";"]); } },
+  { w: 5, v: function (d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); } },
 
   // Exception-related statements :)
-  { w: 6, v: function(d, b) { return makeExceptionyStatement(d - 1, b) + makeExceptionyStatement(d - 1, b); } },
-  { w: 7, v: function(d, b) { return makeExceptionyStatement(d, b); } },
+  { w: 6, v: function (d, b) { return makeExceptionyStatement(d - 1, b) + makeExceptionyStatement(d - 1, b); } },
+  { w: 7, v: function (d, b) { return makeExceptionyStatement(d, b); } },
 
   // Labels. (JavaScript does not have goto, but it does have break-to-label and continue-to-label).
-  { w: 1, v: function(d, b) { return cat(["L", ": ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { return cat(["L", ": ", makeStatementOrBlock(d, b)]); } },
 
   // Function-declaration-statements with shared names
-  { w: 10, v: function(d, b) { return cat([makeStatement(d-2, b), "function ", makeId(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d - 1, b), makeStatement(d-2, b)]); } },
+  { w: 10, v: function (d, b) { return cat([makeStatement(d - 2, b), "function ", makeId(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d - 1, b), makeStatement(d - 2, b)]); } },
 
   // Function-declaration-statements with unique names, along with calls to those functions
   { w: 8, v: makeNamedFunctionAndUse },
@@ -291,19 +269,19 @@ var statementMakers = Random.weighted([
   // Long script -- can confuse Spidermonkey's short vs long jmp or something like that.
   // Spidermonkey's regexp engine is so slow for long strings that we have to bypass whatToTest :(
   // { w: 1, v: function(d, b) { return strTimes("try{}catch(e){}", rnd(10000)); } },
-  { w: 1, v: function(d, b) { if (rnd(200)==0) return "/*DUPTRY" + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";"; } },
+  { w: 1, v: function (d, b) { if (rnd(200) == 0) return "/*DUPTRY" + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";"; } },
 
-  { w: 1, v: function(d, b) { return makeShapeyConstructorLoop(d, b); } },
+  { w: 1, v: function (d, b) { return makeShapeyConstructorLoop(d, b); } },
 
   // Replace a variable with a long linked list pointing to it.  (Forces SpiderMonkey's GC marker into a stackless mode.)
-  { w: 1, v: function(d, b) { var x = makeId(d, b); return x + " = linkedList(" + x + ", " + (rnd(100) * rnd(100)) + ");"; } },
+  { w: 1, v: function (d, b) { var x = makeId(d, b); return x + " = linkedList(" + x + ", " + (rnd(100) * rnd(100)) + ");"; } },
 
   // Oddly placed "use strict" or "use asm"
-  { w: 1, v: function(d, b) { return directivePrologue() + makeStatement(d - 1, b); } },
+  { w: 1, v: function (d, b) { return directivePrologue() + makeStatement(d - 1, b); } },
 
   // Spidermonkey GC and JIT controls
-  { w: 3, v: function(d, b) { return makeTestingFunctionCall(d, b); } },
-  { w: 3, v: function(d, b) { return makeTestingFunctionCall(d - 1, b) + " " + makeStatement(d - 1, b); } },
+  { w: 3, v: function (d, b) { return makeTestingFunctionCall(d, b); } },
+  { w: 3, v: function (d, b) { return makeTestingFunctionCall(d - 1, b) + " " + makeStatement(d - 1, b); } },
 
   // Blocks of statements related to typed arrays
   { w: 8, v: makeTypedArrayStatements },
@@ -315,26 +293,24 @@ var statementMakers = Random.weighted([
 
   { w: 1, v: makeRegisterStompBody },
 
-  { w: 20, v: makeUseRegressionTest },
+  { w: 20, v: makeUseRegressionTest }
 
   // Discover properties to add to the allPropertyNames list
   // { w: 3, v: function(d, b) { return "for (var p in " + makeId(d, b) + ") { addPropertyName(p); }"; } },
   // { w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" + makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
 ]);
 
-if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
+if (typeof oomTest === "function" && engine != ENGINE_JAVASCRIPTCORE) {
   statementMakers = statementMakers.concat([
-    function(d, b) { return "oomTest(" + makeFunction(d - 1, b) + ")"; },
-    function(d, b) { return "oomTest(" + makeFunction(d - 1, b) + ", { keepFailing: true })"; },
+    function (d, b) { return "oomTest(" + makeFunction(d - 1, b) + ")"; },
+    function (d, b) { return "oomTest(" + makeFunction(d - 1, b) + ", { keepFailing: true })"; }
   ]);
 }
 
-
-function makeUseRegressionTest(d, b)
-{
+function makeUseRegressionTest (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (typeof regressionTestList != "object") {
+  if (typeof regressionTestList !== "object") {
     return "/* no regression tests found */";
   }
 
@@ -371,8 +347,7 @@ function makeUseRegressionTest(d, b)
   return s;
 }
 
-function regressionTestIsEvil(contents)
-{
+function regressionTestIsEvil (contents) {
   if (contents.indexOf("SIMD") != -1) {
     // Disable SIMD testing until it's more stable (and we can get better stacks?)
     return true;
@@ -384,8 +359,7 @@ function regressionTestIsEvil(contents)
   return false;
 }
 
-function inlineTest(filename)
-{
+function inlineTest (filename) {
   // Inline a regression test, adding NODIFF (to disable differential testing) if it calls a testing function that might throw.
 
   const s = "/* " + filename + " */ " + read(filename) + "\n";
@@ -401,7 +375,7 @@ function inlineTest(filename)
     "isAsmJSCompilationAvailable",
     "isSimdAvailable", // in 32-bit x86 builds, it depends on whether --no-fpu is passed in, because --no-fpu also disables SSE
     "hasChild",
-    "PerfMeasurement",
+    "PerfMeasurement"
   ];
 
   for (var f of noDiffTestingFunctions) {
@@ -413,9 +387,7 @@ function inlineTest(filename)
   return s;
 }
 
-
-function regressionTestDependencies(maintest)
-{
+function regressionTestDependencies (maintest) {
   var files = [];
 
   if (rnd(3)) {
@@ -445,15 +417,12 @@ function regressionTestDependencies(maintest)
   return files;
 }
 
-
-function linkedList(x, n)
-{
-  for (var i = 0; i < n; ++i)
-    x = {a: x};
+function linkedList (x, n) {
+  for (var i = 0; i < n; ++i) { x = { a: x }; }
   return x;
 }
 
-function makeNamedFunctionAndUse(d, b) {
+function makeNamedFunctionAndUse (d, b) {
   // Use a unique function name to make it less likely that we'll accidentally make a recursive call
   var funcName = uniqueVarName();
   var formalArgList = makeFormalArgList(d, b);
@@ -474,37 +443,22 @@ function makeNamedFunctionAndUse(d, b) {
   }
 }
 
-function makePrintStatement(d, b)
-{
-  if (rnd(2) && b.length)
-    return "print(" + Random.index(b) + ");";
-  else
-    return "print(" + makeExpr(d, b) + ");";
+function makePrintStatement (d, b) {
+  if (rnd(2) && b.length) { return "print(" + Random.index(b) + ");"; } else { return "print(" + makeExpr(d, b) + ");"; }
 }
 
-
-function maybeLabel()
-{
-  if (rnd(4) === 1)
-    return cat([Random.index(["L", "M"]), ":"]);
-  else
-    return "";
+function maybeLabel () {
+  if (rnd(4) === 1) { return cat([Random.index(["L", "M"]), ":"]); } else { return ""; }
 }
 
-
-function uniqueVarName()
-{
+function uniqueVarName () {
   // Make a random variable name.
   var s = "";
-  for (var i = 0; i < 6; ++i)
-    s += String.fromCharCode(97 + rnd(26)); // a lowercase english letter
+  for (var i = 0; i < 6; ++i) { s += String.fromCharCode(97 + rnd(26)); } // a lowercase english letter
   return s;
 }
 
-
-
-function makeSwitchBody(d, b)
-{
+function makeSwitchBody (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var haveSomething = false;
@@ -512,15 +466,13 @@ function makeSwitchBody(d, b)
   var output = "";
 
   do {
-
     if (!haveSomething || rnd(2)) {
       // Want a case/default (or, if this is the beginning, "need").
 
       if (!haveDefault && rnd(2)) {
         output += "default: ";
         haveDefault = true;
-      }
-      else {
+      } else {
         // cases with numbers (integers?) have special optimizations,
         // so be sure to test those well in addition to testing complicated expressions.
         output += "case " + (rnd(2) ? rnd(10) : makeExpr(d, b)) + ": ";
@@ -530,29 +482,23 @@ function makeSwitchBody(d, b)
     }
 
     // Might want a statement.
-    if (rnd(2))
-      output += makeStatement(d, b);
+    if (rnd(2)) { output += makeStatement(d, b); }
 
     // Might want to break, or might want to fall through.
-    if (rnd(2))
-      output += "break; ";
+    if (rnd(2)) { output += "break; "; }
 
-    if (rnd(2))
-      --d;
-
+    if (rnd(2)) { --d; }
   } while (d && rnd(5));
 
   return output;
 }
 
-function makeLittleStatement(d, b)
-{
+function makeLittleStatement (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
 
-  if (rnd(4) === 1)
-    return makeStatement(d, b);
+  if (rnd(4) === 1) { return makeStatement(d, b); }
 
   return (Random.index(littleStatementMakers))(d, b);
 }
@@ -560,71 +506,66 @@ function makeLittleStatement(d, b)
 var littleStatementMakers =
 [
   // Tiny
-  function(d, b) { return cat([";"]); }, // e.g. empty "if" block
-  function(d, b) { return cat(["{", "}"]); }, // e.g. empty "if" block
-  function(d, b) { return cat([""]); },
+  function (d, b) { return cat([";"]); }, // e.g. empty "if" block
+  function (d, b) { return cat(["{", "}"]); }, // e.g. empty "if" block
+  function (d, b) { return cat([""]); },
 
   // Throw stuff.
-  function(d, b) { return cat(["throw ", makeExpr(d, b), ";"]); },
+  function (d, b) { return cat(["throw ", makeExpr(d, b), ";"]); },
 
   // Break/continue [to label].
-  function(d, b) { return cat([Random.index(["continue", "break"]), " ", Random.index(["L", "M", "", ""]), ";"]); },
+  function (d, b) { return cat([Random.index(["continue", "break"]), " ", Random.index(["L", "M", "", ""]), ";"]); },
 
   // Named and unnamed functions (which have different behaviors in different places: both can be expressions,
   // but unnamed functions "want" to be expressions and named functions "want" to be special statements)
-  function(d, b) { return makeFunction(d, b); },
+  function (d, b) { return makeFunction(d, b); },
 
   // Return, yield, await
-  function(d, b) { return cat(["return ", makeExpr(d, b), ";"]); },
-  function(d, b) { return "return;"; }, // return without a value is allowed in generators; return with a value is not.
-  function(d, b) { return cat(["yield ", makeExpr(d, b), ";"]); }, // note: yield can also be a left-unary operator, or something like that
-  function(d, b) { return "yield;"; },
-  function(d, b) { return cat(["await ", makeExpr(d, b), ";"]); },
+  function (d, b) { return cat(["return ", makeExpr(d, b), ";"]); },
+  function (d, b) { return "return;"; }, // return without a value is allowed in generators; return with a value is not.
+  function (d, b) { return cat(["yield ", makeExpr(d, b), ";"]); }, // note: yield can also be a left-unary operator, or something like that
+  function (d, b) { return "yield;"; },
+  function (d, b) { return cat(["await ", makeExpr(d, b), ";"]); },
 
   // Expression statements
-  function(d, b) { return cat([makeExpr(d, b), ";"]); },
-  function(d, b) { return cat([makeExpr(d, b), ";"]); },
-  function(d, b) { return cat([makeExpr(d, b), ";"]); },
-  function(d, b) { return cat([makeExpr(d, b), ";"]); },
-  function(d, b) { return cat([makeExpr(d, b), ";"]); },
-  function(d, b) { return cat([makeExpr(d, b), ";"]); },
-  function(d, b) { return cat([makeExpr(d, b), ";"]); },
-  function(d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
-  function(d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
-  function(d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
-  function(d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
-  function(d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
-  function(d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
-  function(d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
+  function (d, b) { return cat([makeExpr(d, b), ";"]); },
+  function (d, b) { return cat([makeExpr(d, b), ";"]); },
+  function (d, b) { return cat([makeExpr(d, b), ";"]); },
+  function (d, b) { return cat([makeExpr(d, b), ";"]); },
+  function (d, b) { return cat([makeExpr(d, b), ";"]); },
+  function (d, b) { return cat([makeExpr(d, b), ";"]); },
+  function (d, b) { return cat([makeExpr(d, b), ";"]); },
+  function (d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
+  function (d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
+  function (d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
+  function (d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
+  function (d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
+  function (d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); },
+  function (d, b) { return cat(["(", makeExpr(d, b), ")", ";"]); }
 ];
-
 
 // makeStatementOrBlock exists because often, things have different behaviors depending on where there are braces.
 // for example, if braces are added or removed, the meaning of "let" can change.
-function makeStatementOrBlock(d, b)
-{
+function makeStatementOrBlock (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return (Random.index(statementBlockMakers))(d - 1, b);
 }
 
 var statementBlockMakers = [
-  function(d, b) { return makeStatement(d, b); },
-  function(d, b) { return makeStatement(d, b); },
-  function(d, b) { return cat(["{", makeStatement(d, b), " }"]); },
-  function(d, b) { return cat(["{", makeStatement(d - 1, b), makeStatement(d - 1, b), " }"]); },
+  function (d, b) { return makeStatement(d, b); },
+  function (d, b) { return makeStatement(d, b); },
+  function (d, b) { return cat(["{", makeStatement(d, b), " }"]); },
+  function (d, b) { return cat(["{", makeStatement(d - 1, b), makeStatement(d - 1, b), " }"]); }
 ];
-
 
 // Extra-hard testing for try/catch/finally and related things.
 
-function makeExceptionyStatement(d, b)
-{
+function makeExceptionyStatement (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
-  if (d < 1)
-    return makeLittleStatement(d, b);
+  if (d < 1) { return makeLittleStatement(d, b); }
 
   return (Random.index(exceptionyStatementMakers))(d, b);
 }
@@ -632,37 +573,37 @@ function makeExceptionyStatement(d, b)
 var exceptionProperties = ["constructor", "message", "name", "fileName", "lineNumber", "stack"];
 
 var exceptionyStatementMakers = [
-  function(d, b) { return makeTryBlock(d, b); },
+  function (d, b) { return makeTryBlock(d, b); },
 
-  function(d, b) { return makeStatement(d, b); },
-  function(d, b) { return makeLittleStatement(d, b); },
+  function (d, b) { return makeStatement(d, b); },
+  function (d, b) { return makeLittleStatement(d, b); },
 
-  function(d, b) { return "return;"; }, // return without a value can be mixed with yield
-  function(d, b) { return cat(["return ", makeExpr(d, b), ";"]); },
-  function(d, b) { return cat(["yield ", makeExpr(d, b), ";"]); },
-  function(d, b) { return cat(["await ", makeExpr(d, b), ";"]); },
-  function(d, b) { return cat(["throw ", makeId(d, b), ";"]); },
-  function(d, b) { return "this.zzz.zzz;"; }, // throws; also tests js_DecompileValueGenerator in various locations
-  function(d, b) { return b[b.length - 1] + "." + Random.index(exceptionProperties) + ";"; },
-  function(d, b) { return makeId(d, b) + "." + Random.index(exceptionProperties) + ";"; },
-  function(d, b) { return cat([makeId(d, b), " = ", makeId(d, b), ";"]); },
-  function(d, b) { return cat([makeLValue(d, b), " = ", makeId(d, b), ";"]); },
+  function (d, b) { return "return;"; }, // return without a value can be mixed with yield
+  function (d, b) { return cat(["return ", makeExpr(d, b), ";"]); },
+  function (d, b) { return cat(["yield ", makeExpr(d, b), ";"]); },
+  function (d, b) { return cat(["await ", makeExpr(d, b), ";"]); },
+  function (d, b) { return cat(["throw ", makeId(d, b), ";"]); },
+  function (d, b) { return "this.zzz.zzz;"; }, // throws; also tests js_DecompileValueGenerator in various locations
+  function (d, b) { return b[b.length - 1] + "." + Random.index(exceptionProperties) + ";"; },
+  function (d, b) { return makeId(d, b) + "." + Random.index(exceptionProperties) + ";"; },
+  function (d, b) { return cat([makeId(d, b), " = ", makeId(d, b), ";"]); },
+  function (d, b) { return cat([makeLValue(d, b), " = ", makeId(d, b), ";"]); },
 
   // Iteration is also useful to test because it asserts that there is no pending exception.
-  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " in []);"; },
-  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " in " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
-  function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
-  function(d, b) { var v = makeNewId(d, b); return "for await(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
+  function (d, b) { var v = makeNewId(d, b); return "for(let " + v + " in []);"; },
+  function (d, b) { var v = makeNewId(d, b); return "for(let " + v + " in " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
+  function (d, b) { var v = makeNewId(d, b); return "for(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
+  function (d, b) { var v = makeNewId(d, b); return "for await(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
 
   /* eslint-disable no-multi-spaces */
   // Brendan says these are scary places to throw: with, let block, lambda called immediately in let expr.
   // And I think he was right.
-  function(d, b) { return "with({}) "   + makeExceptionyStatement(d, b);         },
-  function(d, b) { return "with({}) { " + makeExceptionyStatement(d, b) + " } "; },
-  function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") { " + makeExceptionyStatement(d, b.concat([v])) + "}"; },
-  function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") ((function(){" + makeExceptionyStatement(d, b.concat([v])) + "})());"; },
-  function(d, b) { return "let(" + makeLetHead(d, b) + ") { " + makeExceptionyStatement(d, b) + "}"; },
-  function(d, b) { return "let(" + makeLetHead(d, b) + ") ((function(){" + makeExceptionyStatement(d, b) + "})());"; },
+  function (d, b) { return "with({}) "   + makeExceptionyStatement(d, b);         },
+  function (d, b) { return "with({}) { " + makeExceptionyStatement(d, b) + " } "; },
+  function (d, b) { var v = makeNewId(d, b); return "let(" + v + ") { " + makeExceptionyStatement(d, b.concat([v])) + "}"; },
+  function (d, b) { var v = makeNewId(d, b); return "let(" + v + ") ((function(){" + makeExceptionyStatement(d, b.concat([v])) + "})());"; },
+  function (d, b) { return "let(" + makeLetHead(d, b) + ") { " + makeExceptionyStatement(d, b) + "}"; },
+  function (d, b) { return "let(" + makeLetHead(d, b) + ") ((function(){" + makeExceptionyStatement(d, b) + "})());"; }
   /* eslint-enable no-multi-spaces */
 
   // Commented out due to causing too much noise on stderr and causing a nonzero exit code :/
@@ -679,8 +620,7 @@ var exceptionyStatementMakers = [
 */
 ];
 
-function makeTryBlock(d, b)
-{
+function makeTryBlock (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // Catches: 1/6 chance of having none
@@ -689,7 +629,6 @@ function makeTryBlock(d, b)
   // Therefore we want to keep the chance of recursing too much down.
 
   d = d - rnd(3);
-
 
   var s = cat(["try", " { ", makeExceptionyStatement(d, b), " } "]);
 
@@ -700,10 +639,7 @@ function makeTryBlock(d, b)
     ++numCatches;
     var catchId = makeId(d, b);
     var catchBlock = makeExceptionyStatement(d, b.concat([catchId]));
-    if (rnd(2))
-      s += cat(["catch", "(", catchId, " if ",                 makeExpr(d, b),                    ")", " { ", catchBlock, " } "]);
-    else
-      s += cat(["catch", "(", catchId, " if ", "(function(){", makeExceptionyStatement(d, b), "})())", " { ", catchBlock, " } "]);
+    if (rnd(2)) { s += cat(["catch", "(", catchId, " if ", makeExpr(d, b), ")", " { ", catchBlock, " } "]); } else { s += cat(["catch", "(", catchId, " if ", "(function(){", makeExceptionyStatement(d, b), "})())", " { ", catchBlock, " } "]); }
   }
 
   if (rnd(2)) {
@@ -711,7 +647,7 @@ function makeTryBlock(d, b)
     ++numCatches;
     var catchId = makeId(d, b);
     var catchBlock = makeExceptionyStatement(d, b.concat([catchId]));
-    s +=   cat(["catch", "(", catchId,                                                          ")", " { ", catchBlock, " } "]);
+    s += cat(["catch", "(", catchId, ")", " { ", catchBlock, " } "]);
   }
 
   if (numCatches == 0 || rnd(2) === 1) {
@@ -722,37 +658,28 @@ function makeTryBlock(d, b)
   return s;
 }
 
-
-
 // Creates a string that sorta makes sense as an expression
-function makeExpr(d, b)
-{
+function makeExpr (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (d <= 0 || (rnd(7) === 1))
-    return makeTerm(d - 1, b);
+  if (d <= 0 || (rnd(7) === 1)) { return makeTerm(d - 1, b); }
 
-  if (rnd(6) === 1 && b.length)
-    return Random.index(b);
+  if (rnd(6) === 1 && b.length) { return Random.index(b); }
 
-  if (rnd(10) === 1)
-    return makeImmediateRecursiveCall(d, b);
+  if (rnd(10) === 1) { return makeImmediateRecursiveCall(d, b); }
 
   d = rnd(d); // !
 
   var expr = (Random.index(exprMakers))(d, b);
 
-  if (rnd(4) === 1)
-    return "(" + expr + ")";
-  else
-    return expr;
+  if (rnd(4) === 1) { return "(" + expr + ")"; } else { return expr; }
 }
 
 var binaryOps = [
   // Long-standing JavaScript operators, roughly in order from http://www.codehouse.com/javascript/precedence/
   " * ", " / ", " % ", " + ", " - ", " << ", " >> ", " >>> ", " < ", " > ", " <= ", " >= ", " instanceof ",
   " in ", " == ", " != ", " === ", " !== ", " & ", " | ", " ^ ", " && ", " || ", " = ", " *= ", " /= ",
-  " %= ", " += ", " -= ", " <<= ", " >>= ", " >>>= ", " &= ", " ^= ", " |= ", " , ", " ** ", " **= ",
+  " %= ", " += ", " -= ", " <<= ", " >>= ", " >>>= ", " &= ", " ^= ", " |= ", " , ", " ** ", " **= "
 ];
 
 var leftUnaryOps = [
@@ -760,13 +687,12 @@ var leftUnaryOps = [
   "void ", "typeof ", "delete ",
   "new ", // but note that "new" can also be a very strange left-binary operator
   "yield ", // see http://www.python.org/dev/peps/pep-0342/ .  Often needs to be parenthesized, so there's also a special exprMaker for it.
-  "await ",
+  "await "
 ];
 
 var incDecOps = [
-  "++", "--",
+  "++", "--"
 ];
-
 
 var specialProperties = [
   "__proto__", "constructor", "prototype",
@@ -775,7 +701,7 @@ var specialProperties = [
   "toString", "valueOf",
   "call", "apply", // ({apply:...}).apply() hits a special case (speculation failure with funapply / funcall bytecode)
   "length",
-  "0", "1",
+  "0", "1"
 ];
 
 // This makes it easier for fuzz-generated code to mess with the fuzzer. Will I regret it?
@@ -797,223 +723,221 @@ function addPropertyName(p)
 var exprMakers =
 [
   // Increment and decrement
-  function(d, b) { return cat([makeLValue(d, b), Random.index(incDecOps)]); },
-  function(d, b) { return cat([Random.index(incDecOps), makeLValue(d, b)]); },
+  function (d, b) { return cat([makeLValue(d, b), Random.index(incDecOps)]); },
+  function (d, b) { return cat([Random.index(incDecOps), makeLValue(d, b)]); },
 
   // Other left-unary operators
-  function(d, b) { return cat([Random.index(leftUnaryOps), makeExpr(d, b)]); },
+  function (d, b) { return cat([Random.index(leftUnaryOps), makeExpr(d, b)]); },
 
   // Methods
-  function(d, b) { var id = makeId(d, b); return cat(["/*UUV1*/", "(", id, ".", Random.index(allMethodNames), " = ", makeFunction(d, b), ")"]); },
-  function(d, b) { var id = makeId(d, b); return cat(["/*UUV2*/", "(", id, ".", Random.index(allMethodNames), " = ", id, ".", Random.index(allMethodNames), ")"]); },
-  function(d, b) { return cat([makeExpr(d, b), ".", Random.index(allMethodNames), "(", makeActualArgList(d, b), ")"]); },
-  function(d, b) { return cat([makeExpr(d, b), ".", "valueOf", "(", uneval("number"), ")"]); },
+  function (d, b) { var id = makeId(d, b); return cat(["/*UUV1*/", "(", id, ".", Random.index(allMethodNames), " = ", makeFunction(d, b), ")"]); },
+  function (d, b) { var id = makeId(d, b); return cat(["/*UUV2*/", "(", id, ".", Random.index(allMethodNames), " = ", id, ".", Random.index(allMethodNames), ")"]); },
+  function (d, b) { return cat([makeExpr(d, b), ".", Random.index(allMethodNames), "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat([makeExpr(d, b), ".", "valueOf", "(", uneval("number"), ")"]); },
 
   // Binary operators
-  function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
-  function(d, b) { let expr = makeExpr(d, b); return cat(["/*infloop*/", expr, Random.index(binaryOps), expr]); },
-  function(d, b) { return cat([makeId(d, b),   Random.index(binaryOps), makeId(d, b)]); },
-  function(d, b) { return cat([makeId(d, b),   Random.index(binaryOps), makeId(d, b)]); },
-  function(d, b) { return cat([makeId(d, b),   Random.index(binaryOps), makeId(d, b)]); },
-  function(d, b) { let id = makeId(d, b); return cat(["/*infloop*/", id, Random.index(binaryOps), id]); },
+  function (d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), Random.index(binaryOps), makeExpr(d, b)]); },
+  function (d, b) { let expr = makeExpr(d, b); return cat(["/*infloop*/", expr, Random.index(binaryOps), expr]); },
+  function (d, b) { return cat([makeId(d, b), Random.index(binaryOps), makeId(d, b)]); },
+  function (d, b) { return cat([makeId(d, b), Random.index(binaryOps), makeId(d, b)]); },
+  function (d, b) { return cat([makeId(d, b), Random.index(binaryOps), makeId(d, b)]); },
+  function (d, b) { let id = makeId(d, b); return cat(["/*infloop*/", id, Random.index(binaryOps), id]); },
 
   // Ternary operator
-  function(d, b) { return cat([makeExpr(d, b), " ? ", makeExpr(d, b), " : ", makeExpr(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b), " ? ", makeExpr(d, b), " : ", makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), " ? ", makeExpr(d, b), " : ", makeExpr(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), " ? ", makeExpr(d, b), " : ", makeExpr(d, b)]); },
 
   // In most contexts, yield expressions must be parenthesized, so including explicitly parenthesized yields makes actually-compiling yields appear more often.
-  function(d, b) { return cat(["yield ", makeExpr(d, b)]); },
-  function(d, b) { return cat(["(", "yield ", makeExpr(d, b), ")"]); },
+  function (d, b) { return cat(["yield ", makeExpr(d, b)]); },
+  function (d, b) { return cat(["(", "yield ", makeExpr(d, b), ")"]); },
 
-  function(d, b) { return cat(["await ", makeExpr(d, b)]); },
+  function (d, b) { return cat(["await ", makeExpr(d, b)]); },
 
   // Test mark bits of objects
   // addMarkObservers may need a better input than makeArrayLiteral, to focus more on valid objects
-  function(d, b) { return cat(["addMarkObservers", "(", makeArrayLiteral(d, b), ")"]); },
-  function(d, b) { return cat(["clearMarkObservers", "()"]); },
-  function(d, b) { return cat(["getMarks", "()"]); },
+  function (d, b) { return cat(["addMarkObservers", "(", makeArrayLiteral(d, b), ")"]); },
+  function (d, b) { return cat(["clearMarkObservers", "()"]); },
+  function (d, b) { return cat(["getMarks", "()"]); },
 
   // Print the scope chain of objects
-  function(d, b) { return cat(["dumpScopeChain", "(", makeFunction(d, b), ")"]); },
+  function (d, b) { return cat(["dumpScopeChain", "(", makeFunction(d, b), ")"]); },
 
   // Array functions (including extras).  The most interesting are map and filter, I think.
   // These are mostly interesting to fuzzers in the sense of "what happens if i do strange things from a filter function?"  e.g. modify the array.. :)
   // This fuzzer isn't the best for attacking this kind of thing, since it's unlikely that the code in the function will attempt to modify the array or make it go away.
   // The second parameter to "map" is used as the "this" for the function.
-  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]) ]); },
-  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ", ", makeExpr(d, b), ")"]); },
-  function(d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ")"]); },
+  function (d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]) ]); },
+  function (d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ", ", makeExpr(d, b), ")"]); },
+  function (d, b) { return cat([makeArrayLiteral(d, b), ".", Random.index(["map", "filter", "some", "sort"]), "(", makeFunction(d, b), ")"]); },
 
   // RegExp replace.  This is interesting for the same reason as array extras.
-  function(d, b) { return cat(["'fafafa'", ".", "replace", "(", "/", "a", "/", "g", ", ", makeFunction(d, b), ")"]); },
+  function (d, b) { return cat(["'fafafa'", ".", "replace", "(", "/", "a", "/", "g", ", ", makeFunction(d, b), ")"]); },
 
   // Containment in an array or object (or, if this happens to end up on the LHS of an assignment, destructuring)
-  function(d, b) { return cat(["[", makeExpr(d, b), "]"]); },
-  function(d, b) { return cat(["(", "{", makeId(d, b), ": ", makeExpr(d, b), "}", ")"]); },
+  function (d, b) { return cat(["[", makeExpr(d, b), "]"]); },
+  function (d, b) { return cat(["(", "{", makeId(d, b), ": ", makeExpr(d, b), "}", ")"]); },
 
   // Functions: called immediately/not
-  function(d, b) { return makeFunction(d, b); },
-  function(d, b) { return makeFunction(d, b) + ".prototype"; },
-  function(d, b) { return cat(["(", makeFunction(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return makeFunction(d, b); },
+  function (d, b) { return makeFunction(d, b) + ".prototype"; },
+  function (d, b) { return cat(["(", makeFunction(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
 
   // Try to call things that may or may not be functions.
-  function(d, b) { return cat([     makeExpr(d, b),          "(", makeActualArgList(d, b), ")"]); },
-  function(d, b) { return cat(["(", makeExpr(d, b),     ")", "(", makeActualArgList(d, b), ")"]); },
-  function(d, b) { return cat([     makeFunction(d, b),      "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat([ makeExpr(d, b), "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat(["(", makeExpr(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat([ makeFunction(d, b), "(", makeActualArgList(d, b), ")"]); },
 
   // Try to test function.call heavily.
-  function(d, b) { return cat(["(", makeFunction(d, b), ")", ".", "call", "(", makeExpr(d, b), ", ", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat(["(", makeFunction(d, b), ")", ".", "call", "(", makeExpr(d, b), ", ", makeActualArgList(d, b), ")"]); },
 
   // Binary "new", with and without clarifying parentheses, with expressions or functions
-  function(d, b) { return cat(["new ",      makeExpr(d, b),          "(", makeActualArgList(d, b), ")"]); },
-  function(d, b) { return cat(["new ", "(", makeExpr(d, b), ")",     "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat(["new ", makeExpr(d, b), "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat(["new ", "(", makeExpr(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
 
-  function(d, b) { return cat(["new ",      makeFunction(d, b),      "(", makeActualArgList(d, b), ")"]); },
-  function(d, b) { return cat(["new ", "(", makeFunction(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat(["new ", makeFunction(d, b), "(", makeActualArgList(d, b), ")"]); },
+  function (d, b) { return cat(["new ", "(", makeFunction(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
 
   // Sometimes we do crazy stuff, like putting a statement where an expression should go.  This frequently causes a syntax error.
-  function(d, b) { return stripSemicolon(makeLittleStatement(d, b)); },
-  function(d, b) { return ""; },
+  function (d, b) { return stripSemicolon(makeLittleStatement(d, b)); },
+  function (d, b) { return ""; },
 
   /* eslint-disable no-multi-spaces */
   // Let expressions -- note the lack of curly braces.
-  function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v,                            ") ", makeExpr(d - 1, b.concat([v]))]); },
-  function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v, " = ", makeExpr(d - 1, b), ") ", makeExpr(d - 1, b.concat([v]))]); },
-  function(d, b) {                          return cat(["let ", "(", makeLetHead(d, b),            ") ", makeExpr(d, b)]); },
+  function (d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v,                            ") ", makeExpr(d - 1, b.concat([v]))]); },
+  function (d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v, " = ", makeExpr(d - 1, b), ") ", makeExpr(d - 1, b.concat([v]))]); },
+  function (d, b) {                          return cat(["let ", "(", makeLetHead(d, b),            ") ", makeExpr(d, b)]); },
   /* eslint-enable no-multi-spaces */
 
   // Comments and whitespace
-  function(d, b) { return cat([" /* Comment */", makeExpr(d, b)]); },
-  function(d, b) { return cat(["\n", makeExpr(d, b)]); }, // perhaps trigger semicolon insertion and stuff
-  function(d, b) { return cat([makeExpr(d, b), "\n"]); },
+  function (d, b) { return cat([" /* Comment */", makeExpr(d, b)]); },
+  function (d, b) { return cat(["\n", makeExpr(d, b)]); }, // perhaps trigger semicolon insertion and stuff
+  function (d, b) { return cat([makeExpr(d, b), "\n"]); },
 
   // LValue as an expression
-  function(d, b) { return cat([makeLValue(d, b)]); },
+  function (d, b) { return cat([makeLValue(d, b)]); },
 
   // Assignment (can be destructuring)
-  function(d, b) { return cat([     makeLValue(d, b),      " = ", makeExpr(d, b)     ]); },
-  function(d, b) { return cat([     makeLValue(d, b),      " = ", makeExpr(d, b)     ]); },
-  function(d, b) { return cat(["(", makeLValue(d, b),      " = ", makeExpr(d, b), ")"]); },
-  function(d, b) { return cat(["(", makeLValue(d, b), ")", " = ", makeExpr(d, b)     ]); },
+  function (d, b) { return cat([ makeLValue(d, b), " = ", makeExpr(d, b) ]); },
+  function (d, b) { return cat([ makeLValue(d, b), " = ", makeExpr(d, b) ]); },
+  function (d, b) { return cat(["(", makeLValue(d, b), " = ", makeExpr(d, b), ")"]); },
+  function (d, b) { return cat(["(", makeLValue(d, b), ")", " = ", makeExpr(d, b) ]); },
 
   // Destructuring assignment
-  function(d, b) { return cat([     makeDestructuringLValue(d, b),      " = ", makeExpr(d, b)     ]); },
-  function(d, b) { return cat([     makeDestructuringLValue(d, b),      " = ", makeExpr(d, b)     ]); },
-  function(d, b) { return cat(["(", makeDestructuringLValue(d, b),      " = ", makeExpr(d, b), ")"]); },
-  function(d, b) { return cat(["(", makeDestructuringLValue(d, b), ")", " = ", makeExpr(d, b)     ]); },
+  function (d, b) { return cat([ makeDestructuringLValue(d, b), " = ", makeExpr(d, b) ]); },
+  function (d, b) { return cat([ makeDestructuringLValue(d, b), " = ", makeExpr(d, b) ]); },
+  function (d, b) { return cat(["(", makeDestructuringLValue(d, b), " = ", makeExpr(d, b), ")"]); },
+  function (d, b) { return cat(["(", makeDestructuringLValue(d, b), ")", " = ", makeExpr(d, b) ]); },
 
   // Destructuring assignment with lots of group assignment
-  function(d, b) { return cat([makeDestructuringLValue(d, b), " = ", makeDestructuringLValue(d, b)]); },
+  function (d, b) { return cat([makeDestructuringLValue(d, b), " = ", makeDestructuringLValue(d, b)]); },
 
   // Modifying assignment, with operators that do various coercions
-  function(d, b) { return cat([makeLValue(d, b), Random.index(["|=", "%=", "+=", "-="]), makeExpr(d, b)]); },
+  function (d, b) { return cat([makeLValue(d, b), Random.index(["|=", "%=", "+=", "-="]), makeExpr(d, b)]); },
 
   // ES5 getter/setter syntax, imperative (added in Gecko 1.9.3?)
-  function(d, b) { return cat(["Object.defineProperty", "(", makeId(d, b), ", ", makePropertyName(d, b), ", ", makePropertyDescriptor(d, b), ")"]); },
+  function (d, b) { return cat(["Object.defineProperty", "(", makeId(d, b), ", ", makePropertyName(d, b), ", ", makePropertyDescriptor(d, b), ")"]); },
 
   // Test the prototype of a particular object
-  function(d, b) { return cat(["Object.getPrototypeOf", "(", makeId(d, b), ")"]); },
-  function(d, b) { return cat(["Object.setPrototypeOf", "(", makeId(d, b), ", ", makeId(d, b), ")"]); },
+  function (d, b) { return cat(["Object.getPrototypeOf", "(", makeId(d, b), ")"]); },
+  function (d, b) { return cat(["Object.setPrototypeOf", "(", makeId(d, b), ", ", makeId(d, b), ")"]); },
 
   // Test retrieving an object's enumerable property values
-  function(d, b) { return cat(["Object.values", "(", makeId(d, b), ")"]); },
+  function (d, b) { return cat(["Object.values", "(", makeId(d, b), ")"]); },
 
   // Old getter/setter syntax, imperative
-  function(d, b) { return cat([makeExpr(d, b), ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
-  function(d, b) { return cat([makeExpr(d, b), ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
-  function(d, b) { return cat(["this", ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
-  function(d, b) { return cat(["this", ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
+  function (d, b) { return cat([makeExpr(d, b), ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
+  function (d, b) { return cat([makeExpr(d, b), ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
+  function (d, b) { return cat(["this", ".", "__defineGetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
+  function (d, b) { return cat(["this", ".", "__defineSetter__", "(", uneval(makeId(d, b)), ", ", makeFunction(d, b), ")"]); },
 
   // Object literal
-  function(d, b) { return cat(["(", "{", makeObjLiteralPart(d, b), " }", ")"]); },
-  function(d, b) { return cat(["(", "{", makeObjLiteralPart(d, b), ", ", makeObjLiteralPart(d, b), " }", ")"]); },
+  function (d, b) { return cat(["(", "{", makeObjLiteralPart(d, b), " }", ")"]); },
+  function (d, b) { return cat(["(", "{", makeObjLiteralPart(d, b), ", ", makeObjLiteralPart(d, b), " }", ")"]); },
 
   // Test js_ReportIsNotFunction heavily.
-  function(d, b) { return "(p={}, (p.z = " + makeExpr(d, b) + ")())"; },
+  function (d, b) { return "(p={}, (p.z = " + makeExpr(d, b) + ")())"; },
 
   // Test js_ReportIsNotFunction heavily.
   // Test decompilation for ".keyword" a bit.
   // Test throwing-into-generator sometimes.
-  function(d, b) { return cat([makeExpr(d, b), ".", "throw", "(", makeExpr(d, b), ")"]); },
-  function(d, b) { return cat([makeExpr(d, b), ".", "yoyo",   "(", makeExpr(d, b), ")"]); },
+  function (d, b) { return cat([makeExpr(d, b), ".", "throw", "(", makeExpr(d, b), ")"]); },
+  function (d, b) { return cat([makeExpr(d, b), ".", "yoyo", "(", makeExpr(d, b), ")"]); },
 
   // Test eval in various contexts. (but avoid clobbering eval)
   // Test the special "obj.eval" and "eval(..., obj)" forms.
-  function(d, b) { return makeExpr(d, b) + ".eval(" + uneval(makeScriptForEval(d, b)) + ")"; },
-  function(d, b) { return "eval(" + uneval(makeScriptForEval(d, b)) + ")"; },
-  function(d, b) { return "eval(" + uneval(makeScriptForEval(d, b)) + ", " + makeExpr(d, b) + ")"; },
+  function (d, b) { return makeExpr(d, b) + ".eval(" + uneval(makeScriptForEval(d, b)) + ")"; },
+  function (d, b) { return "eval(" + uneval(makeScriptForEval(d, b)) + ")"; },
+  function (d, b) { return "eval(" + uneval(makeScriptForEval(d, b)) + ", " + makeExpr(d, b) + ")"; },
 
   // Uneval needs more testing than it will get accidentally.  No cat() because I don't want uneval clobbered (assigned to) accidentally.
-  function(d, b) { return "(uneval(" + makeExpr(d, b) + "))"; },
+  function (d, b) { return "(uneval(" + makeExpr(d, b) + "))"; },
 
   /* eslint-disable no-multi-spaces */
   // Constructors.  No cat() because I don't want to screw with the constructors themselves, just call them.
-  function(d, b) { return "new " + Random.index(constructors) + "(" + makeActualArgList(d, b) + ")"; },
-  function(d, b) { return          Random.index(constructors) + "(" + makeActualArgList(d, b) + ")"; },
+  function (d, b) { return "new " + Random.index(constructors) + "(" + makeActualArgList(d, b) + ")"; },
+  function (d, b) { return          Random.index(constructors) + "(" + makeActualArgList(d, b) + ")"; },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // Unary Math functions
-  function(d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeExpr(d, b)   + ")"; },
-  function(d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeNumber(d, b) + ")"; },
+  function (d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeExpr(d, b)   + ")"; },
+  function (d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeNumber(d, b) + ")"; },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // Binary Math functions
-  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeExpr(d, b)   + ")"; },
-  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeNumber(d, b) + ")"; },
-  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeExpr(d, b)   + ")"; },
-  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeNumber(d, b) + ")"; },
+  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeExpr(d, b)   + ")"; },
+  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeNumber(d, b) + ")"; },
+  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeExpr(d, b)   + ")"; },
+  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeNumber(d, b) + ")"; },
   /* eslint-enable no-multi-spaces */
 
   // Harmony proxy creation: object, function without constructTrap, function with constructTrap
-  function(d, b) { return makeId(d, b) + " = " + "Proxy.create(" + makeProxyHandler(d, b) + ", " + makeExpr(d, b) + ")"; },
-  function(d, b) { return makeId(d, b) + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ")"; },
-  function(d, b) { return makeId(d, b) + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ", " + makeFunction(d, b) + ")"; },
+  function (d, b) { return makeId(d, b) + " = " + "Proxy.create(" + makeProxyHandler(d, b) + ", " + makeExpr(d, b) + ")"; },
+  function (d, b) { return makeId(d, b) + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ")"; },
+  function (d, b) { return makeId(d, b) + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ", " + makeFunction(d, b) + ")"; },
 
-  function(d, b) { return cat(["delete", " ", makeId(d, b), ".", makeId(d, b)]); },
+  function (d, b) { return cat(["delete", " ", makeId(d, b), ".", makeId(d, b)]); },
 
   // Spidermonkey: global ES5 strict mode
-  function(d, b) { return "(void options('strict_mode'))"; },
+  function (d, b) { return "(void options('strict_mode'))"; },
 
   // Spidermonkey: additional "strict" warnings, distinct from ES5 strict mode
-  function(d, b) { return "(void options('strict'))"; },
+  function (d, b) { return "(void options('strict'))"; },
 
   // More special Spidermonkey shell functions
   // (Note: functions without returned objects or visible side effects go in testing-functions.js, in order to allow presence/absence differential testing.)
   //  function(d, b) { return "dumpObject(" + makeExpr(d, b) + ")" } }, // crashes easily, bug 836603
-  function(d, b) { return "(void shapeOf(" + makeExpr(d, b) + "))"; },
-  function(d, b) { return "intern(" + makeExpr(d, b) + ")"; },
-  function(d, b) { return "allocationMarker()"; },
-  function(d, b) { return "timeout(1800)"; }, // see https://bugzilla.mozilla.org/show_bug.cgi?id=840284#c12 -- replace when bug 831046 is fixed
-  function(d, b) { return "(makeFinalizeObserver('tenured'))"; },
-  function(d, b) { return "(makeFinalizeObserver('nursery'))"; },
+  function (d, b) { return "(void shapeOf(" + makeExpr(d, b) + "))"; },
+  function (d, b) { return "intern(" + makeExpr(d, b) + ")"; },
+  function (d, b) { return "allocationMarker()"; },
+  function (d, b) { return "timeout(1800)"; }, // see https://bugzilla.mozilla.org/show_bug.cgi?id=840284#c12 -- replace when bug 831046 is fixed
+  function (d, b) { return "(makeFinalizeObserver('tenured'))"; },
+  function (d, b) { return "(makeFinalizeObserver('nursery'))"; },
 
   makeRegexUseExpr,
   makeShapeyValue,
   makeIterable,
-  function(d, b) { return makeMathExpr(d + rnd(3), b); },
+  function (d, b) { return makeMathExpr(d + rnd(3), b); }
 ];
-
 
 var fuzzTestingFunctions = fuzzTestingFunctionsCtor(!jsshell, fuzzTestingFunctionArg, fuzzTestingFunctionArg);
 
 // Ensure that even if makeExpr returns "" or "1, 2", we only pass one argument to functions like schedulegc
 // (null || (" + makeExpr(d - 2, b) + "))
 // Darn, only |this| and local variables are safe: an expression with side effects breaks the statement-level compare_jit hack
-function fuzzTestingFunctionArg(d, b) { return "this"; }
+function fuzzTestingFunctionArg (d, b) { return "this"; }
 
-function makeTestingFunctionCall(d, b)
-{
+function makeTestingFunctionCall (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var callStatement = Random.index(fuzzTestingFunctions.testingFunctions)(d, b);
@@ -1042,52 +966,42 @@ function makeTestingFunctionCall(d, b)
   return callBlock;
 }
 
-
 // SpiderMonkey shell (but not xpcshell) has an "evalcx" function and a "newGlobal" function.
 // This tests sandboxes and cross-compartment wrappers.
-if (typeof evalcx == "function") {
+if (typeof evalcx === "function") {
   exprMakers = exprMakers.concat([
-    function(d, b) { return makeGlobal(d, b); },
-    function(d, b) { return "evalcx(" + uneval(makeScriptForEval(d, b)) + ", " + makeExpr(d, b) + ")"; },
-    function(d, b) { return "evalcx(" + uneval(makeScriptForEval(d, b)) + ", " + makeGlobal(d, b) + ")"; },
+    function (d, b) { return makeGlobal(d, b); },
+    function (d, b) { return "evalcx(" + uneval(makeScriptForEval(d, b)) + ", " + makeExpr(d, b) + ")"; },
+    function (d, b) { return "evalcx(" + uneval(makeScriptForEval(d, b)) + ", " + makeGlobal(d, b) + ")"; }
   ]);
 }
 
 // xpcshell (but not SpiderMonkey shell) has some XPC wrappers available.
-if (typeof XPCNativeWrapper == "function") {
+if (typeof XPCNativeWrapper === "function") {
   exprMakers = exprMakers.extend([
-    function(d, b) { return "new XPCNativeWrapper(" + makeExpr(d, b) + ")"; },
-    function(d, b) { return "new XPCSafeJSObjectWrapper(" + makeExpr(d, b) + ")"; },
+    function (d, b) { return "new XPCNativeWrapper(" + makeExpr(d, b) + ")"; },
+    function (d, b) { return "new XPCSafeJSObjectWrapper(" + makeExpr(d, b) + ")"; }
   ]);
 }
 
-function makeNewGlobalArg(d, b)
-{
+function makeNewGlobalArg (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // Make an options object to pass to the |newGlobal| shell builtin.
   var propStrs = [];
-  if (rnd(2))
-    propStrs.push("newCompartment: " + makeBoolean(d - 1, b));
-  if (rnd(2))
-    propStrs.push("sameCompartmentAs: " + makeExpr(d - 1, b));
-  if (rnd(2))
-    propStrs.push("sameZoneAs: " + makeExpr(d - 1, b));
-  if (rnd(2))
-    propStrs.push("cloneSingletons: " + makeBoolean(d - 1, b));
-  if (rnd(2))
-    propStrs.push("disableLazyParsing: " + makeBoolean(d - 1, b));
-  if (rnd(2))
-    propStrs.push("invisibleToDebugger: " + makeBoolean(d - 1, b));
+  if (rnd(2)) { propStrs.push("newCompartment: " + makeBoolean(d - 1, b)); }
+  if (rnd(2)) { propStrs.push("sameCompartmentAs: " + makeExpr(d - 1, b)); }
+  if (rnd(2)) { propStrs.push("sameZoneAs: " + makeExpr(d - 1, b)); }
+  if (rnd(2)) { propStrs.push("cloneSingletons: " + makeBoolean(d - 1, b)); }
+  if (rnd(2)) { propStrs.push("disableLazyParsing: " + makeBoolean(d - 1, b)); }
+  if (rnd(2)) { propStrs.push("invisibleToDebugger: " + makeBoolean(d - 1, b)); }
   return "{ " + propStrs.join(", ") + " }";
 }
 
-function makeGlobal(d, b)
-{
+function makeGlobal (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (rnd(10))
-    return "this";
+  if (rnd(10)) { return "this"; }
 
   var gs;
   switch (rnd(4)) {
@@ -1098,27 +1012,24 @@ function makeGlobal(d, b)
     /* eslint-enable no-multi-spaces */
   }
 
-  if (rnd(2))
-    gs = "fillShellSandbox(" + gs + ")";
+  if (rnd(2)) { gs = "fillShellSandbox(" + gs + ")"; }
 
   return gs;
 }
 
 if (xpcshell) {
   exprMakers = exprMakers.concat([
-    function(d, b) { var n = rnd(4); return "newGeckoSandbox(" + n + ")"; },
-    function(d, b) { var n = rnd(4); return "s" + n + " = newGeckoSandbox(" + n + ")"; },
+    function (d, b) { var n = rnd(4); return "newGeckoSandbox(" + n + ")"; },
+    function (d, b) { var n = rnd(4); return "s" + n + " = newGeckoSandbox(" + n + ")"; },
     // FIXME: Doesn't this need to be Components.utils.evalInSandbox?
-    function(d, b) { var n = rnd(4); return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", newGeckoSandbox(" + n + "))"; },
-    function(d, b) { var n = rnd(4); return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", s" + n + ")"; },
-    function(d, b) { return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", " + makeExpr(d, b) + ")"; },
-    function(d, b) { return "(Components.classes ? quit() : gc()); }"; },
+    function (d, b) { var n = rnd(4); return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", newGeckoSandbox(" + n + "))"; },
+    function (d, b) { var n = rnd(4); return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", s" + n + ")"; },
+    function (d, b) { return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", " + makeExpr(d, b) + ")"; },
+    function (d, b) { return "(Components.classes ? quit() : gc()); }"; }
   ]);
 }
 
-
-function makeShapeyConstructor(d, b)
-{
+function makeShapeyConstructor (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
   var argName = uniqueVarName();
   var t = rnd(4) ? "this" : argName;
@@ -1155,28 +1066,25 @@ function makeShapeyConstructor(d, b)
   return funText;
 }
 
-
 var propertyNameMakers = Random.weighted([
-  { w: 1,  v: function(d, b) { return makeExpr(d - 1, b); } },
-  { w: 1,  v: function(d, b) { return maybeNeg() + rnd(20); } },
-  { w: 1,  v: function(d, b) { return '"' + maybeNeg() + rnd(20) + '"'; } },
-  { w: 1,  v: function(d, b) { return "new String(" + '"' + maybeNeg() + rnd(20) + '"' + ")"; } },
-  { w: 5,  v: function(d, b) { return simpleSource(Random.index(specialProperties)); } },
-  { w: 1,  v: function(d, b) { return simpleSource(makeId(d - 1, b)); } },
-  { w: 5,  v: function(d, b) { return simpleSource(Random.index(allMethodNames)); } },
+  { w: 1, v: function (d, b) { return makeExpr(d - 1, b); } },
+  { w: 1, v: function (d, b) { return maybeNeg() + rnd(20); } },
+  { w: 1, v: function (d, b) { return '"' + maybeNeg() + rnd(20) + '"'; } },
+  { w: 1, v: function (d, b) { return "new String(" + '"' + maybeNeg() + rnd(20) + '"' + ")"; } },
+  { w: 5, v: function (d, b) { return simpleSource(Random.index(specialProperties)); } },
+  { w: 1, v: function (d, b) { return simpleSource(makeId(d - 1, b)); } },
+  { w: 5, v: function (d, b) { return simpleSource(Random.index(allMethodNames)); } }
 ]);
 
-function maybeNeg() { return rnd(5) ? "" : "-"; }
+function maybeNeg () { return rnd(5) ? "" : "-"; }
 
-function makePropertyName(d, b)
-{
+function makePropertyName (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return (Random.index(propertyNameMakers))(d, b);
 }
 
-function makeShapeyConstructorLoop(d, b)
-{
+function makeShapeyConstructorLoop (d, b) {
   var a = makeIterable(d, b);
   var v = makeNewId(d, b);
   var v2 = uniqueVarName(d, b);
@@ -1191,9 +1099,7 @@ function makeShapeyConstructorLoop(d, b)
   " }";
 }
 
-
-function makePropertyDescriptor(d, b)
-{
+function makePropertyDescriptor (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var s = "({";
@@ -1216,15 +1122,13 @@ function makePropertyDescriptor(d, b)
   if (rnd(2)) s += "enumerable: " + makeBoolean(d, b) + ", ";
 
   // remove trailing comma
-  if (s.length > 2)
-    s = s.substr(0, s.length - 2);
+  if (s.length > 2) { s = s.substr(0, s.length - 2); }
 
   s += "})";
   return s;
 }
 
-function makeBoolean(d, b)
-{
+function makeBoolean (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */
@@ -1236,13 +1140,10 @@ function makeBoolean(d, b)
   }
 }
 
-
-function makeObjLiteralPart(d, b)
-{
+function makeObjLiteralPart (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  switch (rnd(8))
-  {
+  switch (rnd(8)) {
   // Literal getter/setter
   // Surprisingly, string literals, integer literals, and float literals are also good!
   // (See https://bugzilla.mozilla.org/show_bug.cgi?id=520696.)
@@ -1255,8 +1156,7 @@ function makeObjLiteralPart(d, b)
   }
 }
 
-function makeToXFunction(d, b)
-{
+function makeToXFunction (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(4)) {
@@ -1269,13 +1169,10 @@ function makeToXFunction(d, b)
   }
 }
 
-
-function makeObjLiteralName(d, b)
-{
+function makeObjLiteralName (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  switch (rnd(6))
-  {
+  switch (rnd(6)) {
     /* eslint-disable no-multi-spaces */
     case 0:  return simpleSource(makeNumber(d, b)); // a quoted number
     case 1:  return makeNumber(d, b);
@@ -1286,43 +1183,30 @@ function makeObjLiteralName(d, b)
   }
 }
 
-
-function makeFunction(d, b)
-{
+function makeFunction (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
 
-  if (rnd(5) === 1)
-    return makeExpr(d, b);
+  if (rnd(5) === 1) { return makeExpr(d, b); }
 
-  if (rnd(4) === 1)
-    return Random.index(builtinFunctions);
+  if (rnd(4) === 1) { return Random.index(builtinFunctions); }
 
   return (Random.index(functionMakers))(d, b);
 }
 
-
-function maybeName(d, b)
-{
-  if (rnd(2) === 0)
-    return " " + makeId(d, b) + " ";
-  else
-    return "";
+function maybeName (d, b) {
+  if (rnd(2) === 0) { return " " + makeId(d, b) + " "; } else { return ""; }
 }
 
-function directivePrologue()
-{
+function directivePrologue () {
   var s = "";
-  if (rnd(3) === 0)
-    s += '"use strict"; ';
-  if (rnd(30) === 0)
-    s += '"use asm"; ';
+  if (rnd(3) === 0) { s += '"use strict"; '; }
+  if (rnd(30) === 0) { s += '"use asm"; '; }
   return s;
 }
 
-function makeFunctionBody(d, b)
-{
+function makeFunctionBody (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(6)) {
@@ -1337,7 +1221,7 @@ function makeFunctionBody(d, b)
   }
 }
 
-function functionPrefix() {
+function functionPrefix () {
   return (rnd(2) == 0 ? "" : "async ")
     + "function"
     + (rnd(2) == 0 ? "" : "*");
@@ -1352,95 +1236,93 @@ var functionMakers = [
 
   /* eslint-disable no-multi-spaces */
   // Functions and expression closures
-  function(d, b) { var v = makeNewId(d, b); return cat([functionPrefix(), " ", maybeName(d, b), "(", v,                       ")", makeFunctionBody(d, b.concat([v]))]); },
-  function(d, b) {                          return cat([functionPrefix(), " ", maybeName(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d, b)]); },
+  function (d, b) { var v = makeNewId(d, b); return cat([functionPrefix(), " ", maybeName(d, b), "(", v,                       ")", makeFunctionBody(d, b.concat([v]))]); },
+  function (d, b) {                          return cat([functionPrefix(), " ", maybeName(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d, b)]); },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // Arrow functions with one argument (no parens needed) (no destructuring allowed in this form?)
-  function(d, b) { var v = makeNewId(d, b); return cat([     v,                            " => ", makeFunctionBody(d, b.concat([v]))]); },
+  function (d, b) { var v = makeNewId(d, b); return cat([     v,                            " => ", makeFunctionBody(d, b.concat([v]))]); },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // Arrow functions with multiple arguments
-  function(d, b) {                          return cat(["(", makeFormalArgList(d, b), ")", " => ", makeFunctionBody(d, b)]); },
+  function (d, b) {                          return cat(["(", makeFormalArgList(d, b), ")", " => ", makeFunctionBody(d, b)]); },
   /* eslint-enable no-multi-spaces */
 
   // The identity function
-  function(d, b) { return functionPrefix() + "(q) { " + directivePrologue() + "return q; }"; },
-  function(d, b) { return "q => q"; },
+  function (d, b) { return functionPrefix() + "(q) { " + directivePrologue() + "return q; }"; },
+  function (d, b) { return "q => q"; },
 
   // A function that does something
-  function(d, b) { return functionPrefix() + "(y) { " + directivePrologue() + makeStatement(d, b.concat(["y"])) + " }"; },
+  function (d, b) { return functionPrefix() + "(y) { " + directivePrologue() + makeStatement(d, b.concat(["y"])) + " }"; },
 
   // A function that computes something
-  function(d, b) { return functionPrefix() + "(y) { " + directivePrologue() + "return " + makeExpr(d, b.concat(["y"])) + " }"; },
+  function (d, b) { return functionPrefix() + "(y) { " + directivePrologue() + "return " + makeExpr(d, b.concat(["y"])) + " }"; },
 
   // A generator that does something
-  function(d, b) { return "function(y) { " + directivePrologue() + "yield y; " + makeStatement(d, b.concat(["y"])) + "; yield y; }"; },
-  function(d, b) { return "function*(y) { " + directivePrologue() + "yield y; " + makeStatement(d, b.concat(["y"])) + "; yield y; }"; },
+  function (d, b) { return "function(y) { " + directivePrologue() + "yield y; " + makeStatement(d, b.concat(["y"])) + "; yield y; }"; },
+  function (d, b) { return "function*(y) { " + directivePrologue() + "yield y; " + makeStatement(d, b.concat(["y"])) + "; yield y; }"; },
 
   // An async function that does something
-  function(d, b) { return "async function (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
+  function (d, b) { return "async function (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
 
   // An async generator that does something
-  function(d, b) { return "async function* (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
-  function(d, b) { return "async function* (y) { " + directivePrologue() + "yield y; await y; " + makeStatement(d, b.concat(["y"])) + "; yield y; await y; }"; },
+  function (d, b) { return "async function* (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
+  function (d, b) { return "async function* (y) { " + directivePrologue() + "yield y; await y; " + makeStatement(d, b.concat(["y"])) + "; yield y; await y; }"; },
 
   // A simple wrapping pattern
-  function(d, b) { return "/*wrap1*/(" + functionPrefix() + "(){ " + directivePrologue() + makeStatement(d, b) + "return " + makeFunction(d, b) + "})()"; },
+  function (d, b) { return "/*wrap1*/(" + functionPrefix() + "(){ " + directivePrologue() + makeStatement(d, b) + "return " + makeFunction(d, b) + "})()"; },
 
   // Wrapping with upvar: escaping, may or may not be modified
-  function(d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap2*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; var " + v2 + " = " + makeFunction(d, b.concat([v1])) + "; return " + v2 + ";})()"; },
+  function (d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap2*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; var " + v2 + " = " + makeFunction(d, b.concat([v1])) + "; return " + v2 + ";})()"; },
 
   // Wrapping with upvar: non-escaping
-  function(d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap3*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; (" + makeFunction(d, b.concat([v1])) + ")(); })"; },
+  function (d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap3*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; (" + makeFunction(d, b.concat([v1])) + ")(); })"; },
 
   // Apply, call
-  function(d, b) { return "(" + makeFunction(d-1, b) + ").apply"; },
-  function(d, b) { return "(" + makeFunction(d-1, b) + ").call"; },
+  function (d, b) { return "(" + makeFunction(d - 1, b) + ").apply"; },
+  function (d, b) { return "(" + makeFunction(d - 1, b) + ").call"; },
 
   // Bind
-  function(d, b) { return "(" + makeFunction(d-1, b) + ").bind"; },
-  function(d, b) { return "(" + makeFunction(d-1, b) + ").bind(" + makeActualArgList(d, b) + ")"; },
+  function (d, b) { return "(" + makeFunction(d - 1, b) + ").bind"; },
+  function (d, b) { return "(" + makeFunction(d - 1, b) + ").bind(" + makeActualArgList(d, b) + ")"; },
 
   // Methods with known names
-  function(d, b) { return cat([makeExpr(d, b), ".", Random.index(allMethodNames)]); },
+  function (d, b) { return cat([makeExpr(d, b), ".", Random.index(allMethodNames)]); },
 
   // Special functions that might have interesting results, especially when called "directly" by things like string.replace or array.map.
-  function(d, b) { return "eval"; }, // eval is interesting both for its "no indirect calls" feature and for the way it's implemented in spidermonkey (a special bytecode).
-  function(d, b) { return "(let (e=eval) e)"; },
-  function(d, b) { return "new Function"; }, // this won't be interpreted the same way for each caller of makeFunction, but that's ok
-  function(d, b) { return "(new Function(" + uneval(makeStatement(d, b)) + "))"; },
-  function(d, b) { return "Function"; }, // without "new"
-  function(d, b) { return "decodeURI"; },
-  function(d, b) { return "decodeURIComponent"; },
-  function(d, b) { return "encodeURI"; },
-  function(d, b) { return "encodeURIComponent"; },
-  function(d, b) { return "neuter"; },
-  function(d, b) { return "createIsHTMLDDA"; }, // spidermonkey shell object like the browser's document.all
-  function(d, b) { return "offThreadCompileScript"; },
-  function(d, b) { return "runOffThreadScript"; },
-  function(d, b) { return makeProxyHandlerFactory(d, b); },
-  function(d, b) { return makeShapeyConstructor(d, b); },
-  function(d, b) { return Random.index(typedArrayConstructors); },
-  function(d, b) { return Random.index(constructors); },
+  function (d, b) { return "eval"; }, // eval is interesting both for its "no indirect calls" feature and for the way it's implemented in spidermonkey (a special bytecode).
+  function (d, b) { return "(let (e=eval) e)"; },
+  function (d, b) { return "new Function"; }, // this won't be interpreted the same way for each caller of makeFunction, but that's ok
+  function (d, b) { return "(new Function(" + uneval(makeStatement(d, b)) + "))"; },
+  function (d, b) { return "Function"; }, // without "new"
+  function (d, b) { return "decodeURI"; },
+  function (d, b) { return "decodeURIComponent"; },
+  function (d, b) { return "encodeURI"; },
+  function (d, b) { return "encodeURIComponent"; },
+  function (d, b) { return "neuter"; },
+  function (d, b) { return "createIsHTMLDDA"; }, // spidermonkey shell object like the browser's document.all
+  function (d, b) { return "offThreadCompileScript"; },
+  function (d, b) { return "runOffThreadScript"; },
+  function (d, b) { return makeProxyHandlerFactory(d, b); },
+  function (d, b) { return makeShapeyConstructor(d, b); },
+  function (d, b) { return Random.index(typedArrayConstructors); },
+  function (d, b) { return Random.index(constructors); }
 ];
 
-if (typeof XPCNativeWrapper == "function") {
+if (typeof XPCNativeWrapper === "function") {
   functionMakers = functionMakers.concat([
-    function(d, b) { return "XPCNativeWrapper"; },
-    function(d, b) { return "XPCSafeJSObjectWrapper"; },
+    function (d, b) { return "XPCNativeWrapper"; },
+    function (d, b) { return "XPCSafeJSObjectWrapper"; }
   ]);
 }
 
-if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
+if (typeof oomTest === "function" && engine != ENGINE_JAVASCRIPTCORE) {
   functionMakers = functionMakers.concat([
-    function(d, b) { return "oomTest"; },
+    function (d, b) { return "oomTest"; }
   ]);
 }
-
-
 
 var typedArrayConstructors = [
   "Int8Array",
@@ -1451,11 +1333,10 @@ var typedArrayConstructors = [
   "Uint32Array",
   "Float32Array",
   "Float64Array",
-  "Uint8ClampedArray",
+  "Uint8ClampedArray"
 ];
 
-function makeTypedArrayStatements(d, b)
-{
+function makeTypedArrayStatements (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d < 0) return "";
@@ -1473,10 +1354,8 @@ function makeTypedArrayStatements(d, b)
     bv.push(view);
     var viewZero = view + "[0]";
     bv.push(viewZero);
-    if (rnd(3) === 0)
-      statements += "print(" + viewZero + "); ";
-    if (rnd(3))
-      statements += viewZero + " = " + makeNumber(d - 2, b) + "; ";
+    if (rnd(3) === 0) { statements += "print(" + viewZero + "); "; }
+    if (rnd(3)) { statements += viewZero + " = " + makeNumber(d - 2, b) + "; "; }
     bv.push(view + "[" + rnd(11) + "]");
   }
   for (var j = 0; j < numExtraStatements; ++j) {
@@ -1485,8 +1364,7 @@ function makeTypedArrayStatements(d, b)
   return statements;
 }
 
-function makeNumber(d, b)
-{
+function makeNumber (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var signStr = rnd(2) ? "-" : "";
@@ -1516,7 +1394,7 @@ function makeNumber(d, b)
       "Number.MAX_SAFE_INTEGER", "-Number.MAX_SAFE_INTEGER",
       "(2**53)-2", "(2**53)", "(2**53)+2",
       // See bug 1350097
-      "0.000000000000001", "1.7976931348623157e308",
+      "0.000000000000001", "1.7976931348623157e308"
     ]);
     case 6:  return signStr + (Math.pow(2, rnd(66)) + (rnd(3) - 1));
     default: return signStr + rnd(30);
@@ -1524,57 +1402,43 @@ function makeNumber(d, b)
   }
 }
 
-
-function makeLetHead(d, b)
-{
+function makeLetHead (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var items = (d > 0 || rnd(2) === 0) ? rnd(10) + 1 : 1;
   var result = "";
 
   for (var i = 0; i < items; ++i) {
-    if (i > 0)
-      result += ", ";
+    if (i > 0) { result += ", "; }
     result += makeLetHeadItem(d - i, b);
   }
 
   return result;
 }
 
-function makeLetHeadItem(d, b)
-{
+function makeLetHeadItem (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
 
-  if (d < 0 || rnd(2) === 0)
-    return rnd(2) ? uniqueVarName() : makeId(d, b);
-  else if (rnd(5) === 0)
-    return makeDestructuringLValue(d, b) + " = " + makeExpr(d, b);
-  else
-    return makeId(d, b) + " = " + makeExpr(d, b);
+  if (d < 0 || rnd(2) === 0) { return rnd(2) ? uniqueVarName() : makeId(d, b); } else if (rnd(5) === 0) { return makeDestructuringLValue(d, b) + " = " + makeExpr(d, b); } else { return makeId(d, b) + " = " + makeExpr(d, b); }
 }
 
-
-function makeActualArgList(d, b)
-{
+function makeActualArgList (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var nArgs = rnd(3);
 
-  if (nArgs == 0)
-    return "";
+  if (nArgs == 0) { return ""; }
 
   var argList = makeExpr(d, b);
 
-  for (var i = 1; i < nArgs; ++i)
-    argList += ", " + makeExpr(d - i, b);
+  for (var i = 1; i < nArgs; ++i) { argList += ", " + makeExpr(d - i, b); }
 
   return argList;
 }
 
-function makeFormalArgList(d, b)
-{
+function makeFormalArgList (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var argList = [];
@@ -1592,33 +1456,26 @@ function makeFormalArgList(d, b)
   return argList.join(", ");
 }
 
-function makeFormalArg(d, b)
-{
+function makeFormalArg (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (rnd(8) === 1)
-    return makeDestructuringLValue(d, b);
+  if (rnd(8) === 1) { return makeDestructuringLValue(d, b); }
 
   return makeId(d, b) + (rnd(5) ? "" : " = " + makeExpr(d, b));
 }
 
-
-function makeNewId(d, b)
-{
+function makeNewId (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return Random.index(["a", "b", "c", "d", "e", "w", "x", "y", "z"]);
 }
 
-function makeId(d, b)
-{
+function makeId (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (rnd(3) === 1 && b.length)
-    return Random.index(b);
+  if (rnd(3) === 1 && b.length) { return Random.index(b); }
 
-  switch (rnd(200))
-  {
+  switch (rnd(200)) {
     case 0:
       return makeTerm(d, b);
     case 1:
@@ -1645,7 +1502,7 @@ function makeId(d, b)
 
   return Random.index([
     "a", "b", "c", "d", "e", "w", "x", "y", "z",
-    "window", "eval", "\u3056", "NaN",
+    "window", "eval", "\u3056", "NaN"
     // "valueOf", "toString", // e.g. valueOf getter :P // bug 381242, etc
   ]);
 
@@ -1655,109 +1512,94 @@ function makeId(d, b)
   // but bad things happen if you have "eval setter". so let's not put eval in this list.
 }
 
-
-function makeComprehension(d, b)
-{
+function makeComprehension (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (d < 0)
-    return "";
+  if (d < 0) { return ""; }
 
   switch (rnd(7)) {
     case 0:
       return "";
     case 1:
-      return cat([" for ",          "(", makeForInLHS(d, b), " in ", makeExpr(d - 2, b),     ")"]) + makeComprehension(d - 1, b);
+      return cat([" for ", "(", makeForInLHS(d, b), " in ", makeExpr(d - 2, b), ")"]) + makeComprehension(d - 1, b);
     case 2:
-      return cat([" for ",          "(", makeId(d, b),       " of ", makeExpr(d - 2, b),     ")"]) + makeComprehension(d - 1, b);
+      return cat([" for ", "(", makeId(d, b), " of ", makeExpr(d - 2, b), ")"]) + makeComprehension(d - 1, b);
     case 3:
-      return cat([" for ",          "(", makeId(d, b),       " of ", makeIterable(d - 2, b), ")"]) + makeComprehension(d - 1, b);
+      return cat([" for ", "(", makeId(d, b), " of ", makeIterable(d - 2, b), ")"]) + makeComprehension(d - 1, b);
     default:
       return cat([" if ", "(", makeExpr(d - 2, b), ")"]); // this is always last (and must be preceded by a "for", oh well)
   }
 }
 
-
 // for..in LHS can be a single variable OR it can be a destructuring array of exactly two elements.
-function makeForInLHS(d, b)
-{
+function makeForInLHS (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
   return makeLValue(d, b);
 }
 
-
-function makeLValue(d, b)
-{
+function makeLValue (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (d <= 0 || (rnd(2) === 1))
-    return makeId(d - 1, b);
+  if (d <= 0 || (rnd(2) === 1)) { return makeId(d - 1, b); }
 
   d = rnd(d); // !
 
   return (Random.index(lvalueMakers))(d, b);
 }
 
-
 var lvalueMakers = [
   // Simple variable names :)
-  function(d, b) { return cat([makeId(d, b)]); },
+  function (d, b) { return cat([makeId(d, b)]); },
 
   // Parenthesized lvalues
-  function(d, b) { return cat(["(", makeLValue(d, b), ")"]); },
+  function (d, b) { return cat(["(", makeLValue(d, b), ")"]); },
 
   // Destructuring
-  function(d, b) { return makeDestructuringLValue(d, b); },
-  function(d, b) { return "(" + makeDestructuringLValue(d, b) + ")"; },
+  function (d, b) { return makeDestructuringLValue(d, b); },
+  function (d, b) { return "(" + makeDestructuringLValue(d, b) + ")"; },
 
   // Certain functions can act as lvalues!  See JS_HAS_LVALUE_RETURN in js engine source.
-  function(d, b) { return cat([makeId(d, b), "(", makeExpr(d, b), ")"]); },
-  function(d, b) { return cat(["(", makeExpr(d, b), ")", "(", makeExpr(d, b), ")"]); },
+  function (d, b) { return cat([makeId(d, b), "(", makeExpr(d, b), ")"]); },
+  function (d, b) { return cat(["(", makeExpr(d, b), ")", "(", makeExpr(d, b), ")"]); },
 
   // Builtins
-  function(d, b) { return Random.index(builtinProperties); },
-  function(d, b) { return Random.index(builtinObjectNames); },
+  function (d, b) { return Random.index(builtinProperties); },
+  function (d, b) { return Random.index(builtinObjectNames); },
 
   // Arguments object, which can alias named parameters to the function
-  function(d, b) { return "arguments"; },
-  function(d, b) { return cat(["arguments", "[", makePropertyName(d, b), "]"]); },
-  function(d, b) { return makeFunOnCallChain(d, b) + ".arguments"; }, // read-only arguments object
+  function (d, b) { return "arguments"; },
+  function (d, b) { return cat(["arguments", "[", makePropertyName(d, b), "]"]); },
+  function (d, b) { return makeFunOnCallChain(d, b) + ".arguments"; }, // read-only arguments object
 
   // Property access / index into array
-  function(d, b) { return cat([makeExpr(d, b),  ".", makeId(d, b)]); },
-  function(d, b) { return cat([makeExpr(d, b),  ".", "__proto__"]); },
-  function(d, b) { return cat([makeExpr(d, b), "[", makePropertyName(d, b), "]"]); },
+  function (d, b) { return cat([makeExpr(d, b), ".", makeId(d, b)]); },
+  function (d, b) { return cat([makeExpr(d, b), ".", "__proto__"]); },
+  function (d, b) { return cat([makeExpr(d, b), "[", makePropertyName(d, b), "]"]); },
 
   // Throws, but more importantly, tests js_DecompileValueGenerator in various contexts.
-  function(d, b) { return "this.zzz.zzz"; },
+  function (d, b) { return "this.zzz.zzz"; },
 
   // Intentionally bogus, but not quite garbage.
-  function(d, b) { return makeExpr(d, b); },
+  function (d, b) { return makeExpr(d, b); }
 ];
 
-
-function makeDestructuringLValue(d, b)
-{
+function makeDestructuringLValue (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   d = d - 1;
 
-  if (d < 0 || rnd(4) === 1)
-    return makeId(d, b);
+  if (d < 0 || rnd(4) === 1) { return makeId(d, b); }
 
-  if (rnd(6) === 1)
-    return makeLValue(d, b);
+  if (rnd(6) === 1) { return makeLValue(d, b); }
 
   return (Random.index(destructuringLValueMakers))(d, b);
 }
 
 var destructuringLValueMakers = [
   // destructuring assignment: arrays
-  function(d, b)
-  {
+  function (d, b) {
     var len = rnd(d, b);
-    if (len == 0)
-      return "[]";
+    if (len == 0) { return "[]"; }
 
     var Ti = [];
     Ti.push("[");
@@ -1773,16 +1615,13 @@ var destructuringLValueMakers = [
   },
 
   // destructuring assignment: objects
-  function(d, b)
-  {
+  function (d, b) {
     var len = rnd(d, b);
-    if (len == 0)
-      return "{}";
+    if (len == 0) { return "{}"; }
     var Ti = [];
     Ti.push("{");
     for (var i = 0; i < len; ++i) {
-      if (i > 0)
-        Ti.push(", ");
+      if (i > 0) { Ti.push(", "); }
       Ti.push(makeId(d, b));
       if (rnd(3)) {
         Ti.push(": ");
@@ -1792,22 +1631,17 @@ var destructuringLValueMakers = [
     Ti.push("}");
 
     return cat(Ti);
-  },
+  }
 ];
 
 // Allow "holes".
-function maybeMakeDestructuringLValue(d, b)
-{
-  if (rnd(2) === 0)
-    return "";
+function maybeMakeDestructuringLValue (d, b) {
+  if (rnd(2) === 0) { return ""; }
 
   return makeDestructuringLValue(d, b);
 }
 
-
-
-function makeTerm(d, b)
-{
+function makeTerm (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return (Random.index(termMakers))(d, b);
@@ -1815,41 +1649,41 @@ function makeTerm(d, b)
 
 var termMakers = [
   // Variable names
-  function(d, b) { return makeId(d, b); },
+  function (d, b) { return makeId(d, b); },
 
   // Simple literals (no recursion required to make them)
-  function(d, b) { return Random.index([
+  function (d, b) {
+    return Random.index([
     // Arrays
-    "[]", "[1]", "[[]]", "[[1]]", "[,]", "[,,]", "[1,,]",
-    // Objects
-    "{}", "({})", "({a1:1})",
-    // Possibly-destructuring arrays
-    "[z1]", "[z1,,]", "[,,z1]",
-    // Possibly-destructuring objects
-    "({a2:z2})",
-    "function(id) { return id }",
-    "function ([y]) { }",
-    "(function ([y]) { })()",
+      "[]", "[1]", "[[]]", "[[1]]", "[,]", "[,,]", "[1,,]",
+      // Objects
+      "{}", "({})", "({a1:1})",
+      // Possibly-destructuring arrays
+      "[z1]", "[z1,,]", "[,,z1]",
+      // Possibly-destructuring objects
+      "({a2:z2})",
+      "function(id) { return id }",
+      "function ([y]) { }",
+      "(function ([y]) { })()",
 
-    "arguments",
-    "Math",
-    "this",
-    "length",
+      "arguments",
+      "Math",
+      "this",
+      "length",
 
-    '"\u03A0"', // unicode not escaped
-  ]);
+      '"\u03A0"' // unicode not escaped
+    ]);
   },
   makeNumber,
-  function(d, b) { return Random.index([ "true", "false", "undefined", "null"]); },
-  function(d, b) { return Random.index([ "this", "window" ]); },
-  function(d, b) { return Random.index([" \"\" ", " '' "]); },
+  function (d, b) { return Random.index([ "true", "false", "undefined", "null"]); },
+  function (d, b) { return Random.index([ "this", "window" ]); },
+  function (d, b) { return Random.index([" \"\" ", " '' "]); },
   randomUnitStringLiteral, // unicode escaped
-  function(d, b) { return Random.index([" /x/ ", " /x/g "]); },
-  makeRegex,
+  function (d, b) { return Random.index([" /x/ ", " /x/g "]); },
+  makeRegex
 ];
 
-function randomUnitStringLiteral()
-{
+function randomUnitStringLiteral () {
   var s = "\"\\u";
   for (var i = 0; i < 4; ++i) {
     s += "0123456789ABCDEF".charAt(rnd(16));
@@ -1858,18 +1692,11 @@ function randomUnitStringLiteral()
   return s;
 }
 
-
-function maybeMakeTerm(d, b)
-{
-  if (rnd(2))
-    return makeTerm(d - 1, b);
-  else
-    return "";
+function maybeMakeTerm (d, b) {
+  if (rnd(2)) { return makeTerm(d - 1, b); } else { return ""; }
 }
 
-
-function makeCrazyToken()
-{
+function makeCrazyToken () {
   if (rnd(3) === 0) {
     return String.fromCharCode(32 + rnd(128 - 32));
   }
@@ -1916,17 +1743,14 @@ function makeCrazyToken()
     "<" + "!" + "--", // beginning of HTML-style to-end-of-line comment (!)
     "--" + ">", // end of HTML-style comment
     "",
-    "\0", // confuse anything that tries to guess where a string ends. but note: "illegal character"!
+    "\0" // confuse anything that tries to guess where a string ends. but note: "illegal character"!
   ]);
 }
 
-
-function makeShapeyValue(d, b)
-{
+function makeShapeyValue (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (rnd(10) === 0)
-    return makeExpr(d, b);
+  if (rnd(10) === 0) { return makeExpr(d, b); }
 
   var a = [
     // Numbers and number-like things
@@ -1938,16 +1762,16 @@ function makeShapeyValue(d, b)
       "0x2D413CCC", "0x5a827999", "0xB504F332", "-0x2D413CCC", "-0x5a827999", "-0xB504F332", "0x50505050", "(0x50505050 >> 1)",
 
       // various powers of two, with values near JSVAL_INT_MAX especially tested
-      "0x10000000", "0x20000000", "0x3FFFFFFE", "0x3FFFFFFF", "0x40000000", "0x40000001",
+      "0x10000000", "0x20000000", "0x3FFFFFFE", "0x3FFFFFFF", "0x40000000", "0x40000001"
     ],
 
     // Boundaries
     [
     // Boundaries of int, signed, unsigned (near +/- 2^31, +/- 2^32)
-      "0x07fffffff",  "0x080000000",  "0x080000001",
+      "0x07fffffff", "0x080000000", "0x080000001",
       "-0x07fffffff", "-0x080000000", "-0x080000001",
-      "0x0ffffffff",  "0x100000000",  "0x100000001",
-      "-0x0ffffffff", "-0x100000000",  "-0x100000001",
+      "0x0ffffffff", "0x100000000", "0x100000001",
+      "-0x0ffffffff", "-0x100000000", "-0x100000001",
 
       // Boundaries of double
       "Number.MIN_VALUE", "-Number.MIN_VALUE",
@@ -1960,7 +1784,7 @@ function makeShapeyValue(d, b)
       "(2**53)-2", "(2**53)", "(2**53)+2",
 
       // See bug 1350097 - 1.79...e308 is the largest (by module) finite number
-      "0.000000000000001", "1.7976931348623157e308",
+      "0.000000000000001", "1.7976931348623157e308"
     ],
 
     // Special numbers
@@ -1999,23 +1823,20 @@ function makeShapeyValue(d, b)
     [ "objectEmulatingUndefined()" ],
 
     // Actual variables (slightly dangerous)
-    [ b.length ? Random.index(b) : "x" ],
+    [ b.length ? Random.index(b) : "x" ]
   ];
 
   return Random.index(Random.index(a));
 }
 
-function mixedTypeArrayElem(d, b)
-{
+function mixedTypeArrayElem (d, b) {
   while (true) {
     var s = makeShapeyValue(d - 3, b);
-    if (s.length < 60)
-      return s;
+    if (s.length < 60) { return s; }
   }
 }
 
-function makeMixedTypeArray(d, b)
-{
+function makeMixedTypeArray (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // Pick two to five values to use as array entries.
@@ -2032,7 +1853,7 @@ function makeMixedTypeArray(d, b)
     var elem = Random.index(picks);
     // Sometimes, especially at the beginning of arrays, repeat a single value (or type) many times
     // (This is needed for shape warmup, but not for JIT warmup)
-    var repeat = count === 0 ? rnd(4)===0 : rnd(50)===0;
+    var repeat = count === 0 ? rnd(4) === 0 : rnd(50) === 0;
     var repeats = repeat ? rnd(30) : 1;
     for (var k = 0; k < repeats; ++k) {
       c.push(elem);
@@ -2042,20 +1863,17 @@ function makeMixedTypeArray(d, b)
   return "/*MARR*/" + "[" + c.join(", ") + "]";
 }
 
-function makeArrayLiteral(d, b)
-{
+function makeArrayLiteral (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (rnd(2) === 0)
-    return makeMixedTypeArray(d, b);
+  if (rnd(2) === 0) { return makeMixedTypeArray(d, b); }
 
   var elems = [];
   while (rnd(5)) elems.push(makeArrayLiteralElem(d, b));
   return "/*FARR*/" + "[" + elems.join(", ") + "]";
 }
 
-function makeArrayLiteralElem(d, b)
-{
+function makeArrayLiteralElem (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(5)) {
@@ -2067,44 +1885,41 @@ function makeArrayLiteralElem(d, b)
   }
 }
 
-function makeIterable(d, b)
-{
+function makeIterable (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (d < 1)
-    return "[]";
+  if (d < 1) { return "[]"; }
 
   return (Random.index(iterableExprMakers))(d, b);
 }
 
 var iterableExprMakers = Random.weighted([
   // Arrays
-  { w: 1, v: function(d, b) { return "new Array(" + makeNumber(d, b) + ")"; } },
+  { w: 1, v: function (d, b) { return "new Array(" + makeNumber(d, b) + ")"; } },
   { w: 8, v: makeArrayLiteral },
 
   // Array comprehensions (JavaScript 1.7)
-  { w: 1, v: function(d, b) { return cat(["[", makeExpr(d, b), makeComprehension(d, b), "]"]); } },
+  { w: 1, v: function (d, b) { return cat(["[", makeExpr(d, b), makeComprehension(d, b), "]"]); } },
 
   // A generator that yields once
-  { w: 1, v: function(d, b) { return "(function() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },
-  { w: 1, v: function(d, b) { return "(function*() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },
+  { w: 1, v: function (d, b) { return "(function() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },
+  { w: 1, v: function (d, b) { return "(function*() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },
   // A pass-through generator
-  { w: 1, v: function(d, b) { return "/*PTHR*/(function() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
-  { w: 1, v: function(d, b) { return "/*PTHR*/(function*() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
+  { w: 1, v: function (d, b) { return "/*PTHR*/(function() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
+  { w: 1, v: function (d, b) { return "/*PTHR*/(function*() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
 
   // An async function that awaits once
-  { w: 1, v: function(d, b) { return "(async function() { " + directivePrologue() + "await " + makeExpr(d - 1, b) + "; } })()"; } },
+  { w: 1, v: function (d, b) { return "(async function() { " + directivePrologue() + "await " + makeExpr(d - 1, b) + "; } })()"; } },
 
   // A pass-through async generator
-  { w: 1, v: function(d, b) { return "/*PTHR*/(async function*() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
-  { w: 1, v: function(d, b) { return "/*PTHR*/(async function*() { " + directivePrologue() + "for await (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
+  { w: 1, v: function (d, b) { return "/*PTHR*/(async function*() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
+  { w: 1, v: function (d, b) { return "/*PTHR*/(async function*() { " + directivePrologue() + "for await (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
 
   { w: 1, v: makeFunction },
-  { w: 1, v: makeExpr },
+  { w: 1, v: makeExpr }
 ]);
 
-function strTimes(s, n)
-{
+function strTimes (s, n) {
   if (n == 0) return "";
   if (n == 1) return s;
   var s2 = s + s;
@@ -2114,17 +1929,14 @@ function strTimes(s, n)
   return r ? m + s : m;
 }
 
-
-function makeAsmJSModule(d, b)
-{
+function makeAsmJSModule (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior([]);
   return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })";
 }
 
-function makeAsmJSFunction(d, b)
-{
+function makeAsmJSFunction (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior(["ff"]);

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -933,14 +933,14 @@ var exprMakers =
   function(d, b) { return          Random.index(constructors) + "(" + makeActualArgList(d, b) + ")"; },
 
   // Unary Math functions
-  function (d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeExpr(d, b)   + ")"; },
-  function (d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeNumber(d, b) + ")"; },
+  function(d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeExpr(d, b)   + ")"; },
+  function(d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeNumber(d, b) + ")"; },
 
   // Binary Math functions
-  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeExpr(d, b)   + ")"; },
-  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeNumber(d, b) + ")"; },
-  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeExpr(d, b)   + ")"; },
-  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeNumber(d, b) + ")"; },
+  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeExpr(d, b)   + ")"; },
+  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeNumber(d, b) + ")"; },
+  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeExpr(d, b)   + ")"; },
+  function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeNumber(d, b) + ")"; },
 
   // Harmony proxy creation: object, function without constructTrap, function with constructTrap
   function(d, b) { return makeId(d, b) + " = " + "Proxy.create(" + makeProxyHandler(d, b) + ", " + makeExpr(d, b) + ")"; },

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -33,10 +33,12 @@ function makeScriptBody(d, ignoredB)
 function makeScriptForEval(d, b)
 {
   switch (rnd(4)) {
+    /* eslint-disable no-multi-spaces */
     case 0:  return makeExpr(d - 1, b);
     case 1:  return makeStatement(d - 1, b);
     case 2:  return makeUseRegressionTest(d, b);
     default: return makeScript(d - 3, b);
+    /* eslint-enable no-multi-spaces */
   }
 }
 
@@ -186,10 +188,13 @@ var statementMakers = Random.weighted([
   { w: 2, v: function(d, b) { return cat(["{", makeStatement(d, b), " }"]); } },
   { w: 2, v: function(d, b) { return cat(["{", makeStatement(d - 1, b), makeStatement(d - 1, b), " }"]); } },
 
+  /* eslint-disable no-multi-spaces */
   // "with" blocks
   { w: 2, v: function(d, b) {                          return cat([maybeLabel(), "with", "(", makeExpr(d, b), ")",                    makeStatementOrBlock(d, b)]);             } },
   { w: 2, v: function(d, b) { var v = makeNewId(d, b); return cat([maybeLabel(), "with", "(", "{", v, ": ", makeExpr(d, b), "}", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
+  /* eslint-enable no-multi-spaces */
 
+  /* eslint-disable no-multi-spaces */
   // C-style "for" loops
   // Two kinds of "for" loops: one with an expression as the first part, one with a var or let binding 'statement' as the first part.
   // I'm not sure if arbitrary statements are allowed there; I think not.
@@ -197,6 +202,7 @@ var statementMakers = Random.weighted([
   { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                                                    "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   { w: 1, v: function(d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v, " = ", makeExpr(d, b),                             "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeDestructuringLValue(d, b), " = ", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
+  /* eslint-enable no-multi-spaces */
 
   // Various types of "for" loops, specially set up to test tracing, carefully avoiding infinite loops
   { w: 6, v: makeTransparentIdiomaticLoop },
@@ -204,6 +210,7 @@ var statementMakers = Random.weighted([
   { w: 6, v: makeBranchUnstableLoop },
   { w: 8, v: makeTypeUnstableLoop },
 
+  /* eslint-disable no-multi-spaces */
   // "for..in" loops
   // arbitrary-LHS marked as infloop because
   // -- for (key in obj)
@@ -215,15 +222,19 @@ var statementMakers = Random.weighted([
   // -- for (element of arraylike)
   { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
   { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  /* eslint-enable no-multi-spaces */
 
+  /* eslint-disable no-multi-spaces */
   // -- for-await-of
   { w: 1, v: function(d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
   { w: 1, v: function(d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  /* eslint-enable no-multi-spaces */
 
   // Modify something during a loop -- perhaps the thing being looped over
   // Since we use "let" to bind the for-variables, and only do wacky stuff once, I *think* this is unlikely to hang.
   //  function(d, b) { return "let forCount = 0; for (let " + makeId(d, b) + " in " + makeExpr(d, b) + ") { if (forCount++ == " + rnd(3) + ") { " + makeStatement(d - 1, b) + " } }"; },
 
+  /* eslint-disable no-multi-spaces */
   // Hoisty "for..in" loops.  I don't know why this construct exists, but it does, and it hoists the initial-value expression above the loop.
   // With "var" or "const", the entire thing is hoisted.
   // With "let", only the value is hoisted, and it can be elim'ed as a useless statement.
@@ -231,6 +242,7 @@ var statementMakers = Random.weighted([
   { w: 1, v: function(d, b) {                                               return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeId(d, b),         " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
   { w: 1, v: function(d, b) { var v = makeNewId(d, b);                      return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                    " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   { w: 1, v: function(d, b) { var v = makeNewId(d, b), w = makeNewId(d, b); return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), "[", v, ", ", w, "]", " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v, w]))]); } },
+  /* eslint-enable no-multi-spaces */
 
   // do..while
   { w: 1, v: function(d, b) { return cat([maybeLabel(), "while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, makeStatementOrBlock(d, b)]); } },
@@ -283,7 +295,7 @@ var statementMakers = Random.weighted([
   { w: 1, v: function(d, b) { return makeShapeyConstructorLoop(d, b); } },
 
   // Replace a variable with a long linked list pointing to it.  (Forces SpiderMonkey's GC marker into a stackless mode.)
-  { w: 1, v: function(d, b) { var x = makeId(d, b); return x + " = linkedList(" + x + ", " + (rnd(100) * rnd(100)) + ");";  } },
+  { w: 1, v: function(d, b) { var x = makeId(d, b); return x + " = linkedList(" + x + ", " + (rnd(100) * rnd(100)) + ");"; } },
 
   // Oddly placed "use strict" or "use asm"
   { w: 1, v: function(d, b) { return directivePrologue() + makeStatement(d - 1, b); } },
@@ -641,6 +653,7 @@ var exceptionyStatementMakers = [
   function(d, b) { var v = makeNewId(d, b); return "for(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
   function(d, b) { var v = makeNewId(d, b); return "for await(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
 
+  /* eslint-disable no-multi-spaces */
   // Brendan says these are scary places to throw: with, let block, lambda called immediately in let expr.
   // And I think he was right.
   function(d, b) { return "with({}) "   + makeExceptionyStatement(d, b);         },
@@ -649,6 +662,7 @@ var exceptionyStatementMakers = [
   function(d, b) { var v = makeNewId(d, b); return "let(" + v + ") ((function(){" + makeExceptionyStatement(d, b.concat([v])) + "})());"; },
   function(d, b) { return "let(" + makeLetHead(d, b) + ") { " + makeExceptionyStatement(d, b) + "}"; },
   function(d, b) { return "let(" + makeLetHead(d, b) + ") ((function(){" + makeExceptionyStatement(d, b) + "})());"; },
+  /* eslint-enable no-multi-spaces */
 
   // Commented out due to causing too much noise on stderr and causing a nonzero exit code :/
 /*
@@ -869,10 +883,12 @@ var exprMakers =
   function(d, b) { return stripSemicolon(makeLittleStatement(d, b)); },
   function(d, b) { return ""; },
 
+  /* eslint-disable no-multi-spaces */
   // Let expressions -- note the lack of curly braces.
   function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v,                            ") ", makeExpr(d - 1, b.concat([v]))]); },
   function(d, b) { var v = makeNewId(d, b); return cat(["let ", "(", v, " = ", makeExpr(d - 1, b), ") ", makeExpr(d - 1, b.concat([v]))]); },
   function(d, b) {                          return cat(["let ", "(", makeLetHead(d, b),            ") ", makeExpr(d, b)]); },
+  /* eslint-enable no-multi-spaces */
 
   // Comments and whitespace
   function(d, b) { return cat([" /* Comment */", makeExpr(d, b)]); },
@@ -938,19 +954,25 @@ var exprMakers =
   // Uneval needs more testing than it will get accidentally.  No cat() because I don't want uneval clobbered (assigned to) accidentally.
   function(d, b) { return "(uneval(" + makeExpr(d, b) + "))"; },
 
+  /* eslint-disable no-multi-spaces */
   // Constructors.  No cat() because I don't want to screw with the constructors themselves, just call them.
   function(d, b) { return "new " + Random.index(constructors) + "(" + makeActualArgList(d, b) + ")"; },
   function(d, b) { return          Random.index(constructors) + "(" + makeActualArgList(d, b) + ")"; },
+  /* eslint-enable no-multi-spaces */
 
+  /* eslint-disable no-multi-spaces */
   // Unary Math functions
   function(d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeExpr(d, b)   + ")"; },
   function(d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeNumber(d, b) + ")"; },
+  /* eslint-enable no-multi-spaces */
 
+  /* eslint-disable no-multi-spaces */
   // Binary Math functions
   function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeExpr(d, b)   + ")"; },
   function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeNumber(d, b) + ")"; },
   function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeExpr(d, b)   + ")"; },
   function(d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeNumber(d, b) + ")"; },
+  /* eslint-enable no-multi-spaces */
 
   // Harmony proxy creation: object, function without constructTrap, function with constructTrap
   function(d, b) { return makeId(d, b) + " = " + "Proxy.create(" + makeProxyHandler(d, b) + ", " + makeExpr(d, b) + ")"; },
@@ -1066,9 +1088,11 @@ function makeGlobal(d, b)
 
   var gs;
   switch (rnd(4)) {
+    /* eslint-disable no-multi-spaces */
     case 0:  gs = "evalcx('')"; break;
     case 1:  gs = "evalcx('lazy')"; break;
     default: gs = "newGlobal(" + makeNewGlobalArg(d - 1, b) + ")"; break;
+    /* eslint-enable no-multi-spaces */
   }
 
   if (rnd(2))
@@ -1112,6 +1136,7 @@ function makeShapeyConstructor(d, b)
       funText += "if (" + (rnd(2) ? argName : makeExpr(d, bp)) + ") ";
     }
     switch (rnd(8)) {
+      /* eslint-disable no-multi-spaces */
       case 0:  funText += "delete " + tprop + ";"; break;
       case 1:  funText += "Object.defineProperty(" + t + ", " + (rnd(2) ? propName : makePropertyName(d, b)) + ", " + makePropertyDescriptor(d, bp) + ");"; break;
       case 2:  funText += "{ " + makeStatement(d, bp) + " } "; break;
@@ -1120,6 +1145,7 @@ function makeShapeyConstructor(d, b)
       case 5:  funText += "for (var ytq" + uniqueVarName() + " in " + t + ") { }"; break;
       case 6:  funText += "Object." + Random.index(["preventExtensions", "seal", "freeze"]) + "(" + t + ");"; break;
       default: funText += tprop + " = " + makeShapeyValue(d, bp) + ";"; break;
+      /* eslint-enable no-multi-spaces */
     }
   }
   funText += "return " + t + "; }";
@@ -1198,10 +1224,12 @@ function makeBoolean(d, b)
 {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
   switch (rnd(4)) {
+    /* eslint-disable no-multi-spaces */
     case 0:   return "true";
     case 1:   return "false";
     case 2:   return makeExpr(d - 2, b);
     default:  var m = loopModulo(); return "(" + Random.index(b) + " % " + m + Random.index([" == ", " != "]) + rnd(m) + ")";
+    /* eslint-enable no-multi-spaces */
   }
 }
 
@@ -1229,10 +1257,12 @@ function makeToXFunction(d, b)
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(4)) {
+    /* eslint-disable no-multi-spaces */
     case 0:  return "function() { return " + makeExpr(d, b) + "; }";
     case 1:  return "function() { return this; }";
     case 2:  return makeEvilCallback(d, b);
     default: return makeFunction(d, b);
+    /* eslint-enable no-multi-spaces */
   }
 }
 
@@ -1243,11 +1273,13 @@ function makeObjLiteralName(d, b)
 
   switch (rnd(6))
   {
+    /* eslint-disable no-multi-spaces */
     case 0:  return simpleSource(makeNumber(d, b)); // a quoted number
     case 1:  return makeNumber(d, b);
     case 2:  return Random.index(allPropertyNames);
     case 3:  return Random.index(specialProperties);
     default: return makeId(d, b);
+    /* eslint-enable no-multi-spaces */
   }
 }
 
@@ -1291,12 +1323,14 @@ function makeFunctionBody(d, b)
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(6)) {
+    /* eslint-disable no-multi-spaces */
     case 0:  return cat([" { ", directivePrologue(), makeStatement(d - 1, b),   " } "]);
     case 1:  return cat([" { ", directivePrologue(), "return ", makeExpr(d, b), " } "]);
     case 2:  return cat([" { ", directivePrologue(), "yield ",  makeExpr(d, b), " } "]);
     case 3:  return cat([" { ", directivePrologue(), "await ",  makeExpr(d, b), " } "]);
     case 4:  return '"use asm"; ' + asmJSInterior([]);
     default: return makeExpr(d, b); // make an "expression closure"
+    /* eslint-enable no-multi-spaces */
   }
 }
 
@@ -1313,15 +1347,21 @@ var functionMakers = [
   makeMathFunction,
   makeMathyFunRef,
 
+  /* eslint-disable no-multi-spaces */
   // Functions and expression closures
   function(d, b) { var v = makeNewId(d, b); return cat([functionPrefix(), " ", maybeName(d, b), "(", v,                       ")", makeFunctionBody(d, b.concat([v]))]); },
   function(d, b) {                          return cat([functionPrefix(), " ", maybeName(d, b), "(", makeFormalArgList(d, b), ")", makeFunctionBody(d, b)]); },
+  /* eslint-enable no-multi-spaces */
 
+  /* eslint-disable no-multi-spaces */
   // Arrow functions with one argument (no parens needed) (no destructuring allowed in this form?)
   function(d, b) { var v = makeNewId(d, b); return cat([     v,                            " => ", makeFunctionBody(d, b.concat([v]))]); },
+  /* eslint-enable no-multi-spaces */
 
+  /* eslint-disable no-multi-spaces */
   // Arrow functions with multiple arguments
   function(d, b) {                          return cat(["(", makeFormalArgList(d, b), ")", " => ", makeFunctionBody(d, b)]); },
+  /* eslint-enable no-multi-spaces */
 
   // The identity function
   function(d, b) { return functionPrefix() + "(q) { " + directivePrologue() + "return q; }"; },
@@ -1449,6 +1489,7 @@ function makeNumber(d, b)
   var signStr = rnd(2) ? "-" : "";
 
   switch (rnd(60)) {
+    /* eslint-disable no-multi-spaces */
     case 0:  return makeExpr(d - 2, b);
     case 1:  return signStr + "0";
     case 2:  return signStr + (rnd(1000) / 1000);
@@ -1476,6 +1517,7 @@ function makeNumber(d, b)
     ]);
     case 6:  return signStr + (Math.pow(2, rnd(66)) + (rnd(3) - 1));
     default: return signStr + rnd(30);
+    /* eslint-enable no-multi-spaces */
   }
 }
 
@@ -2014,9 +2056,11 @@ function makeArrayLiteralElem(d, b)
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   switch (rnd(5)) {
+    /* eslint-disable no-multi-spaces */
     case 0:  return "..." + makeIterable(d - 1, b); // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Spread_operator
     case 1:  return ""; // hole
     default: return makeExpr(d - 1, b);
+    /* eslint-enable no-multi-spaces */
   }
 }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -639,16 +639,16 @@ function makeTryBlock (d, b) { // eslint-disable-line require-jsdoc
   while (rnd(3) === 0) {
     // Add a guarded catch, using an expression or a function call.
     ++numCatches;
-    var catchId = makeId(d, b);
-    var catchBlock = makeExceptionyStatement(d, b.concat([catchId]));
+    let catchId = makeId(d, b);
+    let catchBlock = makeExceptionyStatement(d, b.concat([catchId]));
     if (rnd(2)) { s += cat(["catch", "(", catchId, " if ", makeExpr(d, b), ")", " { ", catchBlock, " } "]); } else { s += cat(["catch", "(", catchId, " if ", "(function(){", makeExceptionyStatement(d, b), "})())", " { ", catchBlock, " } "]); }
   }
 
   if (rnd(2)) {
     // Add an unguarded catch.
     ++numCatches;
-    var catchId = makeId(d, b);
-    var catchBlock = makeExceptionyStatement(d, b.concat([catchId]));
+    let catchId = makeId(d, b); // eslint-disable-line no-redeclare
+    let catchBlock = makeExceptionyStatement(d, b.concat([catchId])); // eslint-disable-line no-redeclare
     s += cat(["catch", "(", catchId, ")", " { ", catchBlock, " } "]);
   }
 
@@ -1045,7 +1045,7 @@ function makeShapeyConstructor (d, b) { // eslint-disable-line require-jsdoc
   }
 
   var nStatements = rnd(11);
-  for (var i = 0; i < nStatements; ++i) {
+  for (var j = 0; j < nStatements; ++j) {
     var propName = Random.index(propNames);
     var tprop = t + "[" + propName + "]";
     if (rnd(5) === 0) {
@@ -1360,7 +1360,7 @@ function makeTypedArrayStatements (d, b) { // eslint-disable-line require-jsdoc
     if (rnd(3)) { statements += viewZero + " = " + makeNumber(d - 2, b) + "; "; }
     bv.push(view + "[" + rnd(11) + "]");
   }
-  for (var j = 0; j < numExtraStatements; ++j) {
+  for (var k = 0; k < numExtraStatements; ++k) {
     statements += makeStatement(d - numExtraStatements, bv);
   }
   return statements;
@@ -1844,7 +1844,7 @@ function makeMixedTypeArray (d, b) { // eslint-disable-line require-jsdoc
   // Pick two to five values to use as array entries.
   var q = rnd(4) + 2;
   var picks = [];
-  for (var j = 0; j < q; ++j) {
+  for (var i = 0; i < q; ++i) {
     picks.push(mixedTypeArrayElem(d, b));
   }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -3,6 +3,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global allMethodNames, allPropertyNames, arrayBufferType, asmJSInterior, binaryMathFunctions, builtinFunctions */
+/* global builtinObjectNames, builtinProperties, cat, constructors, engine, ENGINE_JAVASCRIPTCORE, evalcx */
+/* global fuzzTestingFunctionsCtor, jsshell, js_src_tests_dir, libdir, loopCount, loopModulo, makeBuilderStatement */
+/* global makeEvilCallback, makeImmediateRecursiveCall, makeMathExpr, makeMathFunction, makeMathyFunAndTest */
+/* global makeMathyFunRef, makeProxyHandler, makeProxyHandlerFactory, makeRegex, makeRegexUseBlock, makeRegexUseExpr */
+/* global makeRegisterStompBody, oomTest, Random, read, regressionTestList, regressionTestsRoot, rnd, simpleSource */
+/* global stripSemicolon, TOTALLY_RANDOM, totallyRandom, unaryMathFunctions, uneval, UNTERMINATED_COMMENT */
+/* global w_pltfrm_res_dir, XPCNativeWrapper, xpcshell */
+
 /****************************
  * GRAMMAR-BASED GENERATION *
  ****************************/

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -423,8 +423,8 @@ function regressionTestDependencies(maintest)
 
     // Include web-platform-test-shims.js and testharness.js for streams tests
     if (maintest.indexOf("web-platform") != -1) {
-      files.push(js_src_tests_dir + "web-platform-test-shims.js");
-      files.push(w_pltfrm_res_dir + "testharness.js");
+      files.push(js_src_tests_dir + "web-platform-test-shims.js"); // eslint-disable-line camelcase
+      files.push(w_pltfrm_res_dir + "testharness.js"); // eslint-disable-line camelcase
     }
   }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -735,8 +735,9 @@ function makeExpr(d, b)
 
 var binaryOps = [
   // Long-standing JavaScript operators, roughly in order from http://www.codehouse.com/javascript/precedence/
-  " * ", " / ", " % ", " + ", " - ", " << ", " >> ", " >>> ", " < ", " > ", " <= ", " >= ", " instanceof ", " in ", " == ", " != ", " === ", " !== ",
-  " & ", " | ", " ^ ", " && ", " || ", " = ", " *= ", " /= ", " %= ", " += ", " -= ", " <<= ", " >>= ", " >>>= ", " &= ", " ^= ", " |= ", " , ", " ** ", " **= "
+  " * ", " / ", " % ", " + ", " - ", " << ", " >> ", " >>> ", " < ", " > ", " <= ", " >= ", " instanceof ",
+  " in ", " == ", " != ", " === ", " !== ", " & ", " | ", " ^ ", " && ", " || ", " = ", " *= ", " /= ",
+  " %= ", " += ", " -= ", " <<= ", " >>= ", " >>>= ", " &= ", " ^= ", " |= ", " , ", " ** ", " **= ",
 ];
 
 var leftUnaryOps = [
@@ -1392,7 +1393,7 @@ if (typeof XPCNativeWrapper == "function") {
 
 if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
   functionMakers = functionMakers.concat([
-    function(d, b) { return "oomTest"; }
+    function(d, b) { return "oomTest"; },
   ]);
 }
 
@@ -1407,7 +1408,7 @@ var typedArrayConstructors = [
   "Uint32Array",
   "Float32Array",
   "Float64Array",
-  "Uint8ClampedArray"
+  "Uint8ClampedArray",
 ];
 
 function makeTypedArrayStatements(d, b)
@@ -1745,7 +1746,7 @@ var destructuringLValueMakers = [
     Ti.push("}");
 
     return cat(Ti);
-  }
+  },
 ];
 
 // Allow "holes".
@@ -1891,7 +1892,7 @@ function makeShapeyValue(d, b)
     "0x2D413CCC", "0x5a827999", "0xB504F332", "-0x2D413CCC", "-0x5a827999", "-0xB504F332", "0x50505050", "(0x50505050 >> 1)",
 
     // various powers of two, with values near JSVAL_INT_MAX especially tested
-    "0x10000000", "0x20000000", "0x3FFFFFFE", "0x3FFFFFFF", "0x40000000", "0x40000001"
+    "0x10000000", "0x20000000", "0x3FFFFFFE", "0x3FFFFFFF", "0x40000000", "0x40000001",
     ],
 
     // Boundaries
@@ -1952,7 +1953,7 @@ function makeShapeyValue(d, b)
     [ "objectEmulatingUndefined()" ],
 
     // Actual variables (slightly dangerous)
-    [ b.length ? Random.index(b) : "x" ]
+    [ b.length ? Random.index(b) : "x" ],
   ];
 
   return Random.index(Random.index(a));

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -1428,12 +1428,12 @@ function makeTypedArrayStatements(d, b)
     var type = Random.index(typedArrayConstructors);
     statements += "var " + view + " = new " + type + "(" + buffer + "); ";
     bv.push(view);
-    var view_0 = view + "[0]";
-    bv.push(view_0);
+    var viewZero = view + "[0]";
+    bv.push(viewZero);
     if (rnd(3) === 0)
-      statements += "print(" + view_0 + "); ";
+      statements += "print(" + viewZero + "); ";
     if (rnd(3))
-      statements += view_0 + " = " + makeNumber(d - 2, b) + "; ";
+      statements += viewZero + " = " + makeNumber(d - 2, b) + "; ";
     bv.push(view + "[" + rnd(11) + "]");
   }
   for (var j = 0; j < numExtraStatements; ++j) {

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -1279,8 +1279,10 @@ var functionMakers = [
   // Wrapping with upvar: escaping, may or may not be modified
   function (d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap2*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; var " + v2 + " = " + makeFunction(d, b.concat([v1])) + "; return " + v2 + ";})()"; },
 
+  /* eslint-disable no-multi-spaces */
   // Wrapping with upvar: non-escaping
-  function (d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap3*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; (" + makeFunction(d, b.concat([v1])) + ")(); })"; },
+  function (d, b) { var v1 = uniqueVarName();                           return "/*wrap3*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; (" + makeFunction(d, b.concat([v1])) + ")(); })"; },
+  /* eslint-enable no-multi-spaces */
 
   // Apply, call
   function (d, b) { return "(" + makeFunction(d - 1, b) + ").apply"; },

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -680,7 +680,7 @@ function makeTryBlock(d, b)
 
   var numCatches = 0;
 
-  while(rnd(3) === 0) {
+  while (rnd(3) === 0) {
     // Add a guarded catch, using an expression or a function call.
     ++numCatches;
     var catchId = makeId(d, b);
@@ -1065,7 +1065,7 @@ function makeGlobal(d, b)
     return "this";
 
   var gs;
-  switch(rnd(4)) {
+  switch (rnd(4)) {
     case 0:  gs = "evalcx('')"; break;
     case 1:  gs = "evalcx('lazy')"; break;
     default: gs = "newGlobal(" + makeNewGlobalArg(d - 1, b) + ")"; break;
@@ -1111,7 +1111,7 @@ function makeShapeyConstructor(d, b)
     if (rnd(5) === 0) {
       funText += "if (" + (rnd(2) ? argName : makeExpr(d, bp)) + ") ";
     }
-    switch(rnd(8)) {
+    switch (rnd(8)) {
       case 0:  funText += "delete " + tprop + ";"; break;
       case 1:  funText += "Object.defineProperty(" + t + ", " + (rnd(2) ? propName : makePropertyName(d, b)) + ", " + makePropertyDescriptor(d, bp) + ");"; break;
       case 2:  funText += "{ " + makeStatement(d, bp) + " } "; break;
@@ -1169,7 +1169,7 @@ function makePropertyDescriptor(d, b)
 
   var s = "({";
 
-  switch(rnd(3)) {
+  switch (rnd(3)) {
     case 0:
     // Data descriptor. Can have 'value' and 'writable'.
       if (rnd(2)) s += "value: " + makeExpr(d, b) + ", ";
@@ -1197,7 +1197,7 @@ function makePropertyDescriptor(d, b)
 function makeBoolean(d, b)
 {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
-  switch(rnd(4)) {
+  switch (rnd(4)) {
     case 0:   return "true";
     case 1:   return "false";
     case 2:   return makeExpr(d - 2, b);
@@ -1210,7 +1210,7 @@ function makeObjLiteralPart(d, b)
 {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  switch(rnd(8))
+  switch (rnd(8))
   {
   // Literal getter/setter
   // Surprisingly, string literals, integer literals, and float literals are also good!
@@ -1228,7 +1228,7 @@ function makeToXFunction(d, b)
 {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  switch(rnd(4)) {
+  switch (rnd(4)) {
     case 0:  return "function() { return " + makeExpr(d, b) + "; }";
     case 1:  return "function() { return this; }";
     case 2:  return makeEvilCallback(d, b);
@@ -1241,7 +1241,7 @@ function makeObjLiteralName(d, b)
 {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  switch(rnd(6))
+  switch (rnd(6))
   {
     case 0:  return simpleSource(makeNumber(d, b)); // a quoted number
     case 1:  return makeNumber(d, b);
@@ -1258,7 +1258,7 @@ function makeFunction(d, b)
 
   d = d - 1;
 
-  if(rnd(5) === 1)
+  if (rnd(5) === 1)
     return makeExpr(d, b);
 
   if (rnd(4) === 1)
@@ -1290,7 +1290,7 @@ function makeFunctionBody(d, b)
 {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  switch(rnd(6)) {
+  switch (rnd(6)) {
     case 0:  return cat([" { ", directivePrologue(), makeStatement(d - 1, b),   " } "]);
     case 1:  return cat([" { ", directivePrologue(), "return ", makeExpr(d, b), " } "]);
     case 2:  return cat([" { ", directivePrologue(), "yield ",  makeExpr(d, b), " } "]);
@@ -1448,7 +1448,7 @@ function makeNumber(d, b)
 
   var signStr = rnd(2) ? "-" : "";
 
-  switch(rnd(60)) {
+  switch (rnd(60)) {
     case 0:  return makeExpr(d - 2, b);
     case 1:  return signStr + "0";
     case 2:  return signStr + (rnd(1000) / 1000);
@@ -1572,7 +1572,7 @@ function makeId(d, b)
   if (rnd(3) === 1 && b.length)
     return Random.index(b);
 
-  switch(rnd(200))
+  switch (rnd(200))
   {
     case 0:
       return makeTerm(d, b);
@@ -1618,7 +1618,7 @@ function makeComprehension(d, b)
   if (d < 0)
     return "";
 
-  switch(rnd(7)) {
+  switch (rnd(7)) {
     case 0:
       return "";
     case 1:

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -24,9 +24,9 @@ function makeScript(d, ignoredB)
 
 function makeScriptBody(d, ignoredB)
 {
-  if (rnd(3) == 0) {
+  if (rnd(3) == 0) 
     return makeMathyFunAndTest(d, ["x"]);
-  }
+  
   return makeStatement(d, ["x"]);
 }
 
@@ -78,20 +78,20 @@ function forLoopHead(d, b, v, reps)
     case 0: // Generates constructs like `for (var x = 3; x > 0; x--) { ... }`
       sInit = Random.index(varBinderFor) + v + " = " + reps;
       sCond = v + " > 0";
-      if (rnd(2)) {
+      if (rnd(2)) 
         sNext = "--" + v;
-      } else {
+      else 
         sNext = v + "--";
-      }
+      
       break;
     default: // Generates constructs like `for (var x = 0; x < 3; x++) { ... }`
       sInit = Random.index(varBinderFor) + v + " = 0";
       sCond = v + " < " + reps;
-      if (rnd(2)) {
+      if (rnd(2)) 
         sNext = "++" + v;
-      } else {
+      else 
         sNext = v + "++";
-      }
+      
   }
 
   while (rnd(10) === 0)
@@ -420,39 +420,39 @@ var statementMakers = Random.weighted([
   // makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
 ]);
 
-if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
+if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) 
   statementMakers = statementMakers.concat([
     function(d, b) { return "oomTest(" + makeFunction(d - 1, b) + ")"; },
     function(d, b) { return "oomTest(" + makeFunction(d - 1, b) + ", { keepFailing: true })"; },
   ]);
-}
+
 
 
 function makeUseRegressionTest(d, b)
 {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (typeof regressionTestList != "object") {
+  if (typeof regressionTestList != "object") 
     return "/* no regression tests found */";
-  }
+  
 
   var maintest = regressionTestsRoot + Random.index(regressionTestList);
   var files = regressionTestDependencies(maintest);
 
   var s = "";
 
-  if (rnd(5) == 0) {
+  if (rnd(5) == 0) 
     // Many tests call assertEq, intending to throw if something unexpected happens.
     // Sometimes, override it with a function that compares but does not throw.
     s += "assertEq = function(x, y) { if (x != y) { print(0); } }; ";
-  }
+  
 
   for (var i = 0; i < files.length; ++i) {
     var file = files[i];
 
-    if (regressionTestIsEvil(read(file))) {
+    if (regressionTestIsEvil(read(file))) 
       continue;
-    }
+    
 
     switch (rnd(2)) {
       case 0:
@@ -472,14 +472,14 @@ function makeUseRegressionTest(d, b)
 
 function regressionTestIsEvil(contents)
 {
-  if (contents.indexOf("SIMD") != -1) {
+  if (contents.indexOf("SIMD") != -1) 
     // Disable SIMD testing until it's more stable (and we can get better stacks?)
     return true;
-  }
-  if (contents.indexOf("print = ") != -1) {
+  
+  if (contents.indexOf("print = ") != -1) 
     // A testcase that clobbers the |print| function would confuse js_interesting
     return true;
-  }
+  
   return false;
 }
 
@@ -505,11 +505,11 @@ function inlineTest(filename)
     "PerfMeasurement",
   ];
 
-  for (var f of noDiffTestingFunctions) {
-    if (s.indexOf(f) != -1) {
+  for (var f of noDiffTestingFunctions) 
+    if (s.indexOf(f) != -1) 
       return "/*NODIFF*/ " + s;
-    }
-  }
+    
+  
 
   return s;
 }
@@ -521,19 +521,19 @@ function regressionTestDependencies(maintest)
 
   if (rnd(3)) {
     // Include the chain of 'shell.js' files in their containing directories (starting from regressionTestsRoot)
-    for (var i = regressionTestsRoot.length; i < maintest.length; ++i) {
+    for (var i = regressionTestsRoot.length; i < maintest.length; ++i) 
       if (maintest.charAt(i) == "/" || maintest.charAt(i) == "\\") {
         var shelljs = maintest.substr(0, i + 1) + "shell.js";
-        if (regressionTestList.indexOf(shelljs) != -1) {
+        if (regressionTestList.indexOf(shelljs) != -1) 
           files.push(shelljs);
-        }
+        
       }
-    }
+    
 
     // Include prologue.js for jit-tests
-    if (maintest.indexOf("jit-test") != -1) {
+    if (maintest.indexOf("jit-test") != -1) 
       files.push(libdir + "prologue.js");
-    }
+    
 
     // Include web-platform-test-shims.js and testharness.js for streams tests
     if (maintest.indexOf("web-platform") != -1) {
@@ -561,18 +561,18 @@ function makeNamedFunctionAndUse(d, b) {
   var bv = formalArgList.length == 1 ? b.concat(formalArgList) : b;
   var declStatement = cat(["/*hhh*/function ", funcName, "(", formalArgList, ")", "{", makeStatement(d - 1, bv), "}"]);
   var useStatement;
-  if (rnd(2)) {
+  if (rnd(2)) 
     // Direct call
     useStatement = cat([funcName, "(", makeActualArgList(d, b), ")", ";"]);
-  } else {
+  else 
     // Any statement, allowed to use the name of the function
     useStatement = "/*iii*/" + makeStatement(d - 1, b.concat([funcName]));
-  }
-  if (rnd(2)) {
+  
+  if (rnd(2)) 
     return declStatement + useStatement;
-  } else {
+  else 
     return useStatement + declStatement;
-  }
+  
 }
 
 function makePrintStatement(d, b)
@@ -833,10 +833,10 @@ function makeTryBlock(d, b)
     s +=   cat(["catch", "(", catchId, ")", " { ", catchBlock, " } "]);
   }
 
-  if (numCatches == 0 || rnd(2) === 1) {
+  if (numCatches == 0 || rnd(2) === 1) 
     // Add a finally.
     s += cat(["finally", " { ", makeExceptionyStatement(d, b), " } "]);
-  }
+  
 
   return s;
 }
@@ -1221,21 +1221,21 @@ function makeTestingFunctionCall(d, b)
 
 // SpiderMonkey shell (but not xpcshell) has an "evalcx" function and a "newGlobal" function.
 // This tests sandboxes and cross-compartment wrappers.
-if (typeof evalcx == "function") {
+if (typeof evalcx == "function") 
   exprMakers = exprMakers.concat([
     function(d, b) { return makeGlobal(d, b); },
     function(d, b) { return "evalcx(" + uneval(makeScriptForEval(d, b)) + ", " + makeExpr(d, b) + ")"; },
     function(d, b) { return "evalcx(" + uneval(makeScriptForEval(d, b)) + ", " + makeGlobal(d, b) + ")"; },
   ]);
-}
+
 
 // xpcshell (but not SpiderMonkey shell) has some XPC wrappers available.
-if (typeof XPCNativeWrapper == "function") {
+if (typeof XPCNativeWrapper == "function") 
   exprMakers = exprMakers.extend([
     function(d, b) { return "new XPCNativeWrapper(" + makeExpr(d, b) + ")"; },
     function(d, b) { return "new XPCSafeJSObjectWrapper(" + makeExpr(d, b) + ")"; },
   ]);
-}
+
 
 function makeNewGlobalArg(d, b)
 {
@@ -1278,7 +1278,7 @@ function makeGlobal(d, b)
   return gs;
 }
 
-if (xpcshell) {
+if (xpcshell) 
   exprMakers = exprMakers.concat([
     function(d, b) { var n = rnd(4); return "newGeckoSandbox(" + n + ")"; },
     function(d, b) { var n = rnd(4); return "s" + n + " = newGeckoSandbox(" + n + ")"; },
@@ -1290,7 +1290,7 @@ if (xpcshell) {
     function(d, b) { return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", " + makeExpr(d, b) + ")"; },
     function(d, b) { return "(Components.classes ? quit() : gc()); }"; },
   ]);
-}
+
 
 
 function makeShapeyConstructor(d, b)
@@ -1303,17 +1303,17 @@ function makeShapeyConstructor(d, b)
 
   var nPropNames = rnd(6) + 1;
   var propNames = [];
-  for (var i = 0; i < nPropNames; ++i) {
+  for (var i = 0; i < nPropNames; ++i) 
     propNames[i] = makePropertyName(d, b);
-  }
+  
 
   var nStatements = rnd(11);
   for (var i = 0; i < nStatements; ++i) {
     var propName = Random.index(propNames);
     var tprop = t + "[" + propName + "]";
-    if (rnd(5) === 0) {
+    if (rnd(5) === 0) 
       funText += "if (" + (rnd(2) ? argName : makeExpr(d, bp)) + ") ";
-    }
+    
     switch (rnd(8)) {
       /* eslint-disable no-multi-spaces */
       case 0:  funText += "delete " + tprop + ";"; break;
@@ -1640,18 +1640,18 @@ var functionMakers = [
   function(d, b) { return Random.index(constructors); },
 ];
 
-if (typeof XPCNativeWrapper == "function") {
+if (typeof XPCNativeWrapper == "function") 
   functionMakers = functionMakers.concat([
     function(d, b) { return "XPCNativeWrapper"; },
     function(d, b) { return "XPCSafeJSObjectWrapper"; },
   ]);
-}
 
-if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) {
+
+if (typeof oomTest == "function" && engine != ENGINE_JAVASCRIPTCORE) 
   functionMakers = functionMakers.concat([
     function(d, b) { return "oomTest"; },
   ]);
-}
+
 
 
 
@@ -1692,9 +1692,9 @@ function makeTypedArrayStatements(d, b)
       statements += viewZero + " = " + makeNumber(d - 2, b) + "; ";
     bv.push(view + "[" + rnd(11) + "]");
   }
-  for (var j = 0; j < numExtraStatements; ++j) {
+  for (var j = 0; j < numExtraStatements; ++j) 
     statements += makeStatement(d - numExtraStatements, bv);
-  }
+  
   return statements;
 }
 
@@ -1793,14 +1793,14 @@ function makeFormalArgList(d, b)
   var argList = [];
 
   var nArgs = rnd(5) ? rnd(3) : rnd(100);
-  for (var i = 0; i < nArgs; ++i) {
+  for (var i = 0; i < nArgs; ++i) 
     argList.push(makeFormalArg(d - i, b));
-  }
+  
 
-  if (rnd(5) === 0) {
+  if (rnd(5) === 0) 
     // https://developer.mozilla.org/en-US/docs/JavaScript/Reference/rest_parameters
     argList.push("..." + makeId(d, b));
-  }
+  
 
   return argList.join(", ");
 }
@@ -2069,9 +2069,9 @@ var termMakers = [
 function randomUnitStringLiteral()
 {
   var s = "\"\\u";
-  for (var i = 0; i < 4; ++i) {
+  for (var i = 0; i < 4; ++i) 
     s += "0123456789ABCDEF".charAt(rnd(16));
-  }
+  
   s += "\"";
   return s;
 }
@@ -2088,12 +2088,12 @@ function maybeMakeTerm(d, b)
 
 function makeCrazyToken()
 {
-  if (rnd(3) === 0) {
+  if (rnd(3) === 0) 
     return String.fromCharCode(32 + rnd(128 - 32));
-  }
-  if (rnd(6) === 0) {
+  
+  if (rnd(6) === 0) 
     return String.fromCharCode(rnd(65536));
-  }
+  
 
   return Random.index([
 
@@ -2243,9 +2243,9 @@ function makeMixedTypeArray(d, b)
   // Pick two to five values to use as array entries.
   var q = rnd(4) + 2;
   var picks = [];
-  for (var j = 0; j < q; ++j) {
+  for (var j = 0; j < q; ++j) 
     picks.push(mixedTypeArrayElem(d, b));
-  }
+  
 
   // Create a large array literal by randomly repeating the values.
   var c = [];
@@ -2256,9 +2256,9 @@ function makeMixedTypeArray(d, b)
     // (This is needed for shape warmup, but not for JIT warmup)
     var repeat = count === 0 ? rnd(4)===0 : rnd(50)===0;
     var repeats = repeat ? rnd(30) : 1;
-    for (var k = 0; k < repeats; ++k) {
+    for (var k = 0; k < repeats; ++k) 
       c.push(elem);
-    }
+    
   }
 
   return "/*MARR*/" + "[" + c.join(", ") + "]";

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported linkedList, makeAsmJSFunction, makeAsmJSModule, makeCrazyToken, maybeMakeTerm, strTimes */
 /* global allMethodNames, allPropertyNames, arrayBufferType, asmJSInterior, binaryMathFunctions, builtinFunctions */
 /* global builtinObjectNames, builtinProperties, cat, constructors, engine, ENGINE_JAVASCRIPTCORE, evalcx */
 /* global fuzzTestingFunctionsCtor, jsshell, js_src_tests_dir, libdir, loopCount, loopModulo, makeBuilderStatement */

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -239,9 +239,9 @@ var statementMakers = Random.weighted([
   // With "var" or "const", the entire thing is hoisted.
   // With "let", only the value is hoisted, and it can be elim'ed as a useless statement.
   // The last form is specific to JavaScript 1.7 (only).
-  { w: 1, v: function(d, b) {                                               return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeId(d, b),         " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b);                      return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                    " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
-  { w: 1, v: function(d, b) { var v = makeNewId(d, b), w = makeNewId(d, b); return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), "[", v, ", ", w, "]", " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v, w]))]); } },
+  { w: 1, v: function(d, b) {                                                   return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeId(d, b),         " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b);                          return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                    " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function(d, b) { var v = makeNewId(d, b); var w = makeNewId(d, b); return cat([maybeLabel(), "for", "(", Random.index(varBinderFor), "[", v, ", ", w, "]", " = ", makeExpr(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v, w]))]); } },
   /* eslint-enable no-multi-spaces */
 
   // do..while
@@ -494,8 +494,8 @@ function maybeLabel()
 function uniqueVarName()
 {
   // Make a random variable name.
-  var i, s = "";
-  for (i = 0; i < 6; ++i)
+  var s = "";
+  for (var i = 0; i < 6; ++i)
     s += String.fromCharCode(97 + rnd(26)); // a lowercase english letter
   return s;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -2117,7 +2117,7 @@ function makeAsmJSModule(d, b)
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior([]);
-  return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + ' })';
+  return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })";
 }
 
 function makeAsmJSFunction(d, b)
@@ -2125,5 +2125,5 @@ function makeAsmJSFunction(d, b)
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior(["ff"]);
-  return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + ' })(this, {ff: ' + makeFunction(d - 2, b) + '}, new ' + arrayBufferType() + '(4096))';
+  return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })(this, {ff: " + makeFunction(d - 2, b) + "}, new " + arrayBufferType() + "(4096))";
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -69,7 +69,7 @@ var binaryMathFunctions = [
   "pow"
 ];
 
-function makeMathFunction (d, b, i) {
+function makeMathFunction (d, b, i) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var ivars = ["x", "y"];
@@ -80,7 +80,7 @@ function makeMathFunction (d, b, i) {
   return "(function(x, y) { " + directivePrologue() + "return " + makeMathExpr(d, ivars, i) + "; })";
 }
 
-function makeMathExpr (d, b, i) {
+function makeMathExpr (d, b, i) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // As depth decreases, make it more likely to bottom out
@@ -93,12 +93,12 @@ function makeMathExpr (d, b, i) {
 
   if (rnd(500) == 0 && d > 0) { return makeExpr(d - 1, b); }
 
-  function r () { return makeMathExpr(d - 1, b, i); }
+  function r () { return makeMathExpr(d - 1, b, i); } // eslint-disable-line require-jsdoc
 
   // Frequently, coerce both the inputs and outputs to the same "numeric sub-type"
   // (asm.js formalizes this concept, but JITs may have their own variants)
   var commonCoercion = rnd(10);
-  function mc (expr) {
+  function mc (expr) { // eslint-disable-line require-jsdoc
     switch (rnd(3) ? commonCoercion : rnd(10)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return "(" + " + " + expr + ")";     // f64 (asm.js)

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -17,11 +17,11 @@ var binaryMathOps = [
   " == ", " != ",
   " === ", " !== ",
   " & ", " | ", " ^ ", " && ", " || ",
-  " , ",
+  " , "
 ];
 
 var leftUnaryMathOps = [
-  " ! ", " + ", " - ", " ~ ",
+  " ! ", " + ", " - ", " ~ "
 ];
 
 // unaryMathFunctions and binaryMathFunctions updated on 2017-01-21 and added from:
@@ -56,7 +56,7 @@ var unaryMathFunctions = [
   "sqrt",
   "tan",
   "tanh",
-  "trunc",
+  "trunc"
 ];
 
 // n-ary functions will also be tested with varying numbers of parameters by makeFunction
@@ -66,11 +66,10 @@ var binaryMathFunctions = [
   "imul",
   "max", // n-ary
   "min", // n-ary
-  "pow",
+  "pow"
 ];
 
-function makeMathFunction(d, b, i)
-{
+function makeMathFunction (d, b, i) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var ivars = ["x", "y"];
@@ -81,8 +80,7 @@ function makeMathFunction(d, b, i)
   return "(function(x, y) { " + directivePrologue() + "return " + makeMathExpr(d, ivars, i) + "; })";
 }
 
-function makeMathExpr(d, b, i)
-{
+function makeMathExpr (d, b, i) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // As depth decreases, make it more likely to bottom out
@@ -93,15 +91,14 @@ function makeMathExpr(d, b, i)
     return Random.index(numericVals);
   }
 
-  if (rnd(500) == 0 && d > 0)
-    return makeExpr(d - 1, b);
+  if (rnd(500) == 0 && d > 0) { return makeExpr(d - 1, b); }
 
-  function r() { return makeMathExpr(d - 1, b, i); }
+  function r () { return makeMathExpr(d - 1, b, i); }
 
   // Frequently, coerce both the inputs and outputs to the same "numeric sub-type"
   // (asm.js formalizes this concept, but JITs may have their own variants)
   var commonCoercion = rnd(10);
-  function mc(expr) {
+  function mc (expr) {
     switch (rnd(3) ? commonCoercion : rnd(10)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return "(" + " + " + expr + ")";     // f64 (asm.js)

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -70,10 +70,10 @@ var binaryMathFunctions = [
 ];
 
 function makeMathFunction (d, b, i) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var ivars = ["x", "y"];
-  if (rnd(10) === 0) {
+  if (rnd(10) == 0) {
     // Also use variables from the enclosing scope
     ivars = ivars.concat(b);
   }
@@ -81,7 +81,7 @@ function makeMathFunction (d, b, i) { // eslint-disable-line require-jsdoc
 }
 
 function makeMathExpr (d, b, i) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   // As depth decreases, make it more likely to bottom out
   if (d < rnd(5)) {
@@ -91,7 +91,7 @@ function makeMathExpr (d, b, i) { // eslint-disable-line require-jsdoc
     return Random.index(numericVals);
   }
 
-  if (rnd(500) === 0 && d > 0) { return makeExpr(d - 1, b); }
+  if (rnd(500) == 0 && d > 0) { return makeExpr(d - 1, b); }
 
   function r () { return makeMathExpr(d - 1, b, i); } // eslint-disable-line require-jsdoc
 
@@ -110,12 +110,12 @@ function makeMathExpr (d, b, i) { // eslint-disable-line require-jsdoc
     }
   }
 
-  if (i > 0 && rnd(10) === 0) {
+  if (i > 0 && rnd(10) == 0) {
     // Call a *lower-numbered* mathy function. (This avoids infinite recursion.)
     return mc("mathy" + rnd(i) + "(" + mc(r()) + ", " + mc(r()) + ")");
   }
 
-  if (rnd(20) === 0) {
+  if (rnd(20) == 0) {
     return mc("(" + mc(r()) + " ? " + mc(r()) + " : " + mc(r()) + ")");
   }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported makeMathFunction, NUM_MATH_FUNCTIONS */
 /* global directivePrologue, makeExpr, numericVals, Random, rnd, TOTALLY_RANDOM, totallyRandom */
 
 const NUM_MATH_FUNCTIONS = 6;

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -101,7 +101,7 @@ function makeMathExpr(d, b, i)
   // (asm.js formalizes this concept, but JITs may have their own variants)
   var commonCoercion = rnd(10);
   function mc(expr) {
-    switch(rnd(3) ? commonCoercion : rnd(10)) {
+    switch (rnd(3) ? commonCoercion : rnd(10)) {
       case 0: return "(" + " + " + expr + ")";     // f64 (asm.js)
       case 1: return "Math.fround(" + expr + ")";  // f32
       case 2: return "(" + expr + " | 0)";         // i32 (asm.js)
@@ -119,7 +119,7 @@ function makeMathExpr(d, b, i)
     return mc("(" + mc(r()) + " ? " + mc(r()) + " : " + mc(r()) + ")");
   }
 
-  switch(rnd(4)) {
+  switch (rnd(4)) {
     case 0:  return mc("(" + mc(r()) + Random.index(binaryMathOps) + mc(r()) + ")");
     case 1:  return mc("(" + Random.index(leftUnaryMathOps) + mc(r()) + ")");
     case 2:  return mc("Math." + Random.index(unaryMathFunctions) + "(" + mc(r()) + ")");

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -102,11 +102,13 @@ function makeMathExpr(d, b, i)
   var commonCoercion = rnd(10);
   function mc(expr) {
     switch (rnd(3) ? commonCoercion : rnd(10)) {
-      case 0: return "(" + " + " + expr + ")";     // f64 (asm.js)
-      case 1: return "Math.fround(" + expr + ")";  // f32
-      case 2: return "(" + expr + " | 0)";         // i32 (asm.js)
-      case 3: return "(" + expr + " >>> 0)";       // u32
+      /* eslint-disable no-multi-spaces */
+      case 0:  return "(" + " + " + expr + ")";     // f64 (asm.js)
+      case 1:  return "Math.fround(" + expr + ")";  // f32
+      case 2:  return "(" + expr + " | 0)";         // i32 (asm.js)
+      case 3:  return "(" + expr + " >>> 0)";       // u32
       default: return expr;
+      /* eslint-enable no-multi-spaces */
     }
   }
 
@@ -120,9 +122,11 @@ function makeMathExpr(d, b, i)
   }
 
   switch (rnd(4)) {
+    /* eslint-disable no-multi-spaces */
     case 0:  return mc("(" + mc(r()) + Random.index(binaryMathOps) + mc(r()) + ")");
     case 1:  return mc("(" + Random.index(leftUnaryMathOps) + mc(r()) + ")");
     case 2:  return mc("Math." + Random.index(unaryMathFunctions) + "(" + mc(r()) + ")");
     default: return mc("Math." + Random.index(binaryMathFunctions) + "(" + mc(r()) + ", " + mc(r()) + ")");
+    /* eslint-enable no-multi-spaces */
   }
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -73,10 +73,10 @@ function makeMathFunction(d, b, i)
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var ivars = ["x", "y"];
-  if (rnd(10) == 0) {
+  if (rnd(10) == 0) 
     // Also use variables from the enclosing scope
     ivars = ivars.concat(b);
-  }
+  
   return "(function(x, y) { " + directivePrologue() + "return " + makeMathExpr(d, ivars, i) + "; })";
 }
 
@@ -86,9 +86,9 @@ function makeMathExpr(d, b, i)
 
   // As depth decreases, make it more likely to bottom out
   if (d < rnd(5)) {
-    if (rnd(4)) {
+    if (rnd(4)) 
       return Random.index(b);
-    }
+    
     return Random.index(numericVals);
   }
 
@@ -112,14 +112,14 @@ function makeMathExpr(d, b, i)
     }
   }
 
-  if (i > 0 && rnd(10) == 0) {
+  if (i > 0 && rnd(10) == 0) 
     // Call a *lower-numbered* mathy function. (This avoids infinite recursion.)
     return mc("mathy" + rnd(i) + "(" + mc(r()) + ", " + mc(r()) + ")");
-  }
+  
 
-  if (rnd(20) == 0) {
+  if (rnd(20) == 0) 
     return mc("(" + mc(r()) + " ? " + mc(r()) + " : " + mc(r()) + ")");
-  }
+  
 
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global directivePrologue, makeExpr, numericVals, Random, rnd, TOTALLY_RANDOM, totallyRandom */
+
 const NUM_MATH_FUNCTIONS = 6;
 
 var binaryMathOps = [

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -73,10 +73,10 @@ function makeMathFunction(d, b, i)
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var ivars = ["x", "y"];
-  if (rnd(10) == 0) 
+  if (rnd(10) == 0) {
     // Also use variables from the enclosing scope
     ivars = ivars.concat(b);
-  
+  }
   return "(function(x, y) { " + directivePrologue() + "return " + makeMathExpr(d, ivars, i) + "; })";
 }
 
@@ -86,9 +86,9 @@ function makeMathExpr(d, b, i)
 
   // As depth decreases, make it more likely to bottom out
   if (d < rnd(5)) {
-    if (rnd(4)) 
+    if (rnd(4)) {
       return Random.index(b);
-    
+    }
     return Random.index(numericVals);
   }
 
@@ -112,14 +112,14 @@ function makeMathExpr(d, b, i)
     }
   }
 
-  if (i > 0 && rnd(10) == 0) 
+  if (i > 0 && rnd(10) == 0) {
     // Call a *lower-numbered* mathy function. (This avoids infinite recursion.)
     return mc("mathy" + rnd(i) + "(" + mc(r()) + ", " + mc(r()) + ")");
-  
+  }
 
-  if (rnd(20) == 0) 
+  if (rnd(20) == 0) {
     return mc("(" + mc(r()) + " ? " + mc(r()) + " : " + mc(r()) + ")");
-  
+  }
 
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -70,10 +70,10 @@ var binaryMathFunctions = [
 ];
 
 function makeMathFunction (d, b, i) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var ivars = ["x", "y"];
-  if (rnd(10) == 0) {
+  if (rnd(10) === 0) {
     // Also use variables from the enclosing scope
     ivars = ivars.concat(b);
   }
@@ -81,7 +81,7 @@ function makeMathFunction (d, b, i) { // eslint-disable-line require-jsdoc
 }
 
 function makeMathExpr (d, b, i) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   // As depth decreases, make it more likely to bottom out
   if (d < rnd(5)) {
@@ -91,7 +91,7 @@ function makeMathExpr (d, b, i) { // eslint-disable-line require-jsdoc
     return Random.index(numericVals);
   }
 
-  if (rnd(500) == 0 && d > 0) { return makeExpr(d - 1, b); }
+  if (rnd(500) === 0 && d > 0) { return makeExpr(d - 1, b); }
 
   function r () { return makeMathExpr(d - 1, b, i); } // eslint-disable-line require-jsdoc
 
@@ -110,12 +110,12 @@ function makeMathExpr (d, b, i) { // eslint-disable-line require-jsdoc
     }
   }
 
-  if (i > 0 && rnd(10) == 0) {
+  if (i > 0 && rnd(10) === 0) {
     // Call a *lower-numbered* mathy function. (This avoids infinite recursion.)
     return mc("mathy" + rnd(i) + "(" + mc(r()) + ", " + mc(r()) + ")");
   }
 
-  if (rnd(20) == 0) {
+  if (rnd(20) === 0) {
     return mc("(" + mc(r()) + " ? " + mc(r()) + " : " + mc(r()) + ")");
   }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -99,7 +99,7 @@ function makeProxyHandlerFactory(d, b)
       if (proxyHandlerProperties[p][preferred] && rnd(10) <= fidelity) {
         funText = proxyMunge(proxyHandlerProperties[p][preferred], p);
       } else {
-        switch(rnd(7)) {
+        switch (rnd(7)) {
           case 0:  funText = makeFunction(d - 3, bp); break;
           case 1:  funText = "undefined"; break;
           case 2:  funText = "function() { throw 3; }"; break;
@@ -112,7 +112,7 @@ function makeProxyHandlerFactory(d, b)
     handlerFactoryText += "}; })";
 
     return handlerFactoryText;
-  } catch(e) {
+  } catch (e) {
     return "({/* :( */})";
   }
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -71,7 +71,7 @@ var proxyHandlerProperties = {
   }
 };
 
-function makeProxyHandlerFactory (d, b) {
+function makeProxyHandlerFactory (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d < 1) { return "({/*TOODEEP*/})"; }
@@ -118,12 +118,12 @@ function makeProxyHandlerFactory (d, b) {
   }
 }
 
-function proxyMunge (funText, p) {
+function proxyMunge (funText, p) { // eslint-disable-line require-jsdoc
   // funText = funText.replace(/\{/, "{ var yum = 'PCAL'; dumpln(yum + 'LED: " + p + "');");
   return funText;
 }
 
-function makeProxyHandler (d, b) {
+function makeProxyHandler (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return makeProxyHandlerFactory(d, b) + "(" + makeExpr(d - 3, b) + ")";

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -100,10 +100,12 @@ function makeProxyHandlerFactory(d, b)
         funText = proxyMunge(proxyHandlerProperties[p][preferred], p);
       } else {
         switch (rnd(7)) {
+          /* eslint-disable no-multi-spaces */
           case 0:  funText = makeFunction(d - 3, bp); break;
           case 1:  funText = "undefined"; break;
           case 2:  funText = "function() { throw 3; }"; break;
           default: funText = proxyMunge(proxyHandlerProperties[p][fallback], p);
+          /* eslint-enable no-multi-spaces */
         }
       }
       handlerFactoryText += p + ": " + funText + ", ";

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global bp:writable, makeExpr, makeFunction, Random, rnd, TOTALLY_RANDOM, totallyRandom */
+
 // In addition, can always use "undefined" or makeFunction
 // Forwarding proxy code based on http://wiki.ecmascript.org/doku.php?id=harmony:proxies "Example: a no-op forwarding proxy"
 // The letter 'x' is special.

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -11,72 +11,70 @@
 // The letter 'x' is special.
 var proxyHandlerProperties = {
   getOwnPropertyDescriptor: {
-    empty:    "function(){}",
-    forward:  "function(name) { var desc = Object.getOwnPropertyDescriptor(x); desc.configurable = true; return desc; }",
-    throwing: "function(name) { return {get: function() { throw 4; }, set: function() { throw 5; }}; }",
+    empty: "function(){}",
+    forward: "function(name) { var desc = Object.getOwnPropertyDescriptor(x); desc.configurable = true; return desc; }",
+    throwing: "function(name) { return {get: function() { throw 4; }, set: function() { throw 5; }}; }"
   },
   defineProperty: {
-    empty:    "function(){}",
-    forward:  "function(name, desc) { Object.defineProperty(x, name, desc); }",
+    empty: "function(){}",
+    forward: "function(name, desc) { Object.defineProperty(x, name, desc); }"
   },
   getOwnPropertyNames: {
-    empty:    "function() { return []; }",
-    forward:  "function() { return Object.getOwnPropertyNames(x); }",
+    empty: "function() { return []; }",
+    forward: "function() { return Object.getOwnPropertyNames(x); }"
   },
   delete: {
-    empty:    "function() { return true; }",
-    yes:      "function() { return true; }",
-    no:       "function() { return false; }",
-    forward:  "function(name) { return delete x[name]; }",
+    empty: "function() { return true; }",
+    yes: "function() { return true; }",
+    no: "function() { return false; }",
+    forward: "function(name) { return delete x[name]; }"
   },
   fix: {
-    empty:    "function() { return []; }",
-    yes:      "function() { return []; }",
-    no:       "function() { }",
-    forward:  "function() { if (Object.isFrozen(x)) { return Object.getOwnProperties(x); } }",
+    empty: "function() { return []; }",
+    yes: "function() { return []; }",
+    no: "function() { }",
+    forward: "function() { if (Object.isFrozen(x)) { return Object.getOwnProperties(x); } }"
   },
   has: {
-    empty:    "function() { return false; }",
-    yes:      "function() { return true; }",
-    no:       "function() { return false; }",
-    forward:  "function(name) { return name in x; }",
+    empty: "function() { return false; }",
+    yes: "function() { return true; }",
+    no: "function() { return false; }",
+    forward: "function(name) { return name in x; }"
   },
   hasOwn: {
-    empty:    "function() { return false; }",
-    yes:      "function() { return true; }",
-    no:       "function() { return false; }",
-    forward:  "function(name) { return Object.prototype.hasOwnProperty.call(x, name); }",
+    empty: "function() { return false; }",
+    yes: "function() { return true; }",
+    no: "function() { return false; }",
+    forward: "function(name) { return Object.prototype.hasOwnProperty.call(x, name); }"
   },
   get: {
-    empty:    "function() { return undefined }",
-    forward:  "function(receiver, name) { return x[name]; }",
-    bind:     "function(receiver, name) { var prop = x[name]; return (typeof prop) === 'function' ? prop.bind(x) : prop; }",
+    empty: "function() { return undefined }",
+    forward: "function(receiver, name) { return x[name]; }",
+    bind: "function(receiver, name) { var prop = x[name]; return (typeof prop) === 'function' ? prop.bind(x) : prop; }"
   },
   set: {
-    empty:    "function() { return true; }",
-    yes:      "function() { return true; }",
-    no:       "function() { return false; }",
-    forward:  "function(receiver, name, val) { x[name] = val; return true; }",
+    empty: "function() { return true; }",
+    yes: "function() { return true; }",
+    no: "function() { return false; }",
+    forward: "function(receiver, name, val) { x[name] = val; return true; }"
   },
   iterate: {
-    forward:  "function() { return (function() { for (var name in x) { yield name; } })(); }",
+    forward: "function() { return (function() { for (var name in x) { yield name; } })(); }"
   },
   enumerate: {
-    empty:    "function() { return []; }",
-    forward:  "function() { var result = []; for (var name in x) { result.push(name); }; return result; }",
+    empty: "function() { return []; }",
+    forward: "function() { var result = []; for (var name in x) { result.push(name); }; return result; }"
   },
   keys: {
-    empty:    "function() { return []; }",
-    forward:  "function() { return Object.keys(x); }",
-  },
+    empty: "function() { return []; }",
+    forward: "function() { return Object.keys(x); }"
+  }
 };
 
-function makeProxyHandlerFactory(d, b)
-{
+function makeProxyHandlerFactory (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
-  if (d < 1)
-    return "({/*TOODEEP*/})";
+  if (d < 1) { return "({/*TOODEEP*/})"; }
 
   try { // in case we screwed Object.prototype, breaking proxyHandlerProperties
     var preferred = Random.index(["empty", "forward", "yes", "no", "bind", "throwing"]);
@@ -120,14 +118,12 @@ function makeProxyHandlerFactory(d, b)
   }
 }
 
-function proxyMunge(funText, p)
-{
+function proxyMunge (funText, p) {
   // funText = funText.replace(/\{/, "{ var yum = 'PCAL'; dumpln(yum + 'LED: " + p + "');");
   return funText;
 }
 
-function makeProxyHandler(d, b)
-{
+function makeProxyHandler (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return makeProxyHandlerFactory(d, b) + "(" + makeExpr(d - 3, b) + ")";

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -99,9 +99,9 @@ function makeProxyHandlerFactory(d, b)
 
     for (var p in proxyHandlerProperties) {
       var funText;
-      if (proxyHandlerProperties[p][preferred] && rnd(10) <= fidelity) 
+      if (proxyHandlerProperties[p][preferred] && rnd(10) <= fidelity) {
         funText = proxyMunge(proxyHandlerProperties[p][preferred], p);
-      else 
+      } else {
         switch (rnd(7)) {
           /* eslint-disable no-multi-spaces */
           case 0:  funText = makeFunction(d - 3, bp); break;
@@ -110,7 +110,7 @@ function makeProxyHandlerFactory(d, b)
           default: funText = proxyMunge(proxyHandlerProperties[p][fallback], p);
           /* eslint-enable no-multi-spaces */
         }
-      
+      }
       handlerFactoryText += p + ": " + funText + ", ";
     }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -99,9 +99,9 @@ function makeProxyHandlerFactory(d, b)
 
     for (var p in proxyHandlerProperties) {
       var funText;
-      if (proxyHandlerProperties[p][preferred] && rnd(10) <= fidelity) {
+      if (proxyHandlerProperties[p][preferred] && rnd(10) <= fidelity) 
         funText = proxyMunge(proxyHandlerProperties[p][preferred], p);
-      } else {
+      else 
         switch (rnd(7)) {
           /* eslint-disable no-multi-spaces */
           case 0:  funText = makeFunction(d - 3, bp); break;
@@ -110,7 +110,7 @@ function makeProxyHandlerFactory(d, b)
           default: funText = proxyMunge(proxyHandlerProperties[p][fallback], p);
           /* eslint-enable no-multi-spaces */
         }
-      }
+      
       handlerFactoryText += p + ": " + funText + ", ";
     }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -16,58 +16,58 @@ var proxyHandlerProperties = {
   },
   defineProperty: {
     empty:    "function(){}",
-    forward:  "function(name, desc) { Object.defineProperty(x, name, desc); }"
+    forward:  "function(name, desc) { Object.defineProperty(x, name, desc); }",
   },
   getOwnPropertyNames: {
     empty:    "function() { return []; }",
-    forward:  "function() { return Object.getOwnPropertyNames(x); }"
+    forward:  "function() { return Object.getOwnPropertyNames(x); }",
   },
   delete: {
     empty:    "function() { return true; }",
     yes:      "function() { return true; }",
     no:       "function() { return false; }",
-    forward:  "function(name) { return delete x[name]; }"
+    forward:  "function(name) { return delete x[name]; }",
   },
   fix: {
     empty:    "function() { return []; }",
     yes:      "function() { return []; }",
     no:       "function() { }",
-    forward:  "function() { if (Object.isFrozen(x)) { return Object.getOwnProperties(x); } }"
+    forward:  "function() { if (Object.isFrozen(x)) { return Object.getOwnProperties(x); } }",
   },
   has: {
     empty:    "function() { return false; }",
     yes:      "function() { return true; }",
     no:       "function() { return false; }",
-    forward:  "function(name) { return name in x; }"
+    forward:  "function(name) { return name in x; }",
   },
   hasOwn: {
     empty:    "function() { return false; }",
     yes:      "function() { return true; }",
     no:       "function() { return false; }",
-    forward:  "function(name) { return Object.prototype.hasOwnProperty.call(x, name); }"
+    forward:  "function(name) { return Object.prototype.hasOwnProperty.call(x, name); }",
   },
   get: {
     empty:    "function() { return undefined }",
     forward:  "function(receiver, name) { return x[name]; }",
-    bind:     "function(receiver, name) { var prop = x[name]; return (typeof prop) === 'function' ? prop.bind(x) : prop; }"
+    bind:     "function(receiver, name) { var prop = x[name]; return (typeof prop) === 'function' ? prop.bind(x) : prop; }",
   },
   set: {
     empty:    "function() { return true; }",
     yes:      "function() { return true; }",
     no:       "function() { return false; }",
-    forward:  "function(receiver, name, val) { x[name] = val; return true; }"
+    forward:  "function(receiver, name, val) { x[name] = val; return true; }",
   },
   iterate: {
-    forward:  "function() { return (function() { for (var name in x) { yield name; } })(); }"
+    forward:  "function() { return (function() { for (var name in x) { yield name; } })(); }",
   },
   enumerate: {
     empty:    "function() { return []; }",
-    forward:  "function() { var result = []; for (var name in x) { result.push(name); }; return result; }"
+    forward:  "function() { var result = []; for (var name in x) { result.push(name); }; return result; }",
   },
   keys: {
     empty:    "function() { return []; }",
-    forward:  "function() { return Object.keys(x); }"
-  }
+    forward:  "function() { return Object.keys(x); }",
+  },
 };
 
 function makeProxyHandlerFactory(d, b)

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -100,10 +100,10 @@ function makeProxyHandlerFactory(d, b)
         funText = proxyMunge(proxyHandlerProperties[p][preferred], p);
       } else {
         switch(rnd(7)) {
-        case 0:  funText = makeFunction(d - 3, bp); break;
-        case 1:  funText = "undefined"; break;
-        case 2:  funText = "function() { throw 3; }"; break;
-        default: funText = proxyMunge(proxyHandlerProperties[p][fallback], p);
+          case 0:  funText = makeFunction(d - 3, bp); break;
+          case 1:  funText = "undefined"; break;
+          case 2:  funText = "function() { throw 3; }"; break;
+          default: funText = proxyMunge(proxyHandlerProperties[p][fallback], p);
         }
       }
       handlerFactoryText += p + ": " + funText + ", ";

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported makeProxyHandler */
 /* global bp:writable, makeExpr, makeFunction, Random, rnd, TOTALLY_RANDOM, totallyRandom */
 
 // In addition, can always use "undefined" or makeFunction

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -6,14 +6,12 @@
 /* global bp:writable, makeExpr, makeFunction, Random, rnd, TOTALLY_RANDOM, totallyRandom */
 
 // In addition, can always use "undefined" or makeFunction
-// Forwarding proxy code based on http://wiki.ecmascript.org/doku.php?id=harmony:proxies
-//   "Example: a no-op forwarding proxy"
+// Forwarding proxy code based on http://wiki.ecmascript.org/doku.php?id=harmony:proxies "Example: a no-op forwarding proxy"
 // The letter 'x' is special.
 var proxyHandlerProperties = {
   getOwnPropertyDescriptor: {
     empty:    "function(){}",
-    forward:  "function(name) { var desc = Object.getOwnPropertyDescriptor(x); "
-      + "desc.configurable = true; return desc; }",
+    forward:  "function(name) { var desc = Object.getOwnPropertyDescriptor(x); desc.configurable = true; return desc; }",
     throwing: "function(name) { return {get: function() { throw 4; }, set: function() { throw 5; }}; }",
   },
   defineProperty: {
@@ -51,8 +49,7 @@ var proxyHandlerProperties = {
   get: {
     empty:    "function() { return undefined }",
     forward:  "function(receiver, name) { return x[name]; }",
-    bind:     "function(receiver, name) { var prop = x[name]; "
-      + "return (typeof prop) === 'function' ? prop.bind(x) : prop; }",
+    bind:     "function(receiver, name) { var prop = x[name]; return (typeof prop) === 'function' ? prop.bind(x) : prop; }",
   },
   set: {
     empty:    "function() { return true; }",

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -72,7 +72,7 @@ var proxyHandlerProperties = {
 };
 
 function makeProxyHandlerFactory (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   if (d < 1) { return "({/*TOODEEP*/})"; }
 
@@ -124,7 +124,7 @@ function proxyMunge (funText, p) { // eslint-disable-line require-jsdoc
 }
 
 function makeProxyHandler (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return makeProxyHandlerFactory(d, b) + "(" + makeExpr(d - 3, b) + ")";
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -119,7 +119,7 @@ function makeProxyHandlerFactory(d, b)
 
 function proxyMunge(funText, p)
 {
-  //funText = funText.replace(/\{/, "{ var yum = 'PCAL'; dumpln(yum + 'LED: " + p + "');");
+  // funText = funText.replace(/\{/, "{ var yum = 'PCAL'; dumpln(yum + 'LED: " + p + "');");
   return funText;
 }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -87,7 +87,7 @@ function makeProxyHandlerFactory(d, b)
 
     if (rnd(2)) {
       // handlerFactory has an argument 'x'
-      bp = b.concat(['x']);
+      bp = b.concat(["x"]);
     } else {
       // handlerFactory has no argument
       handlerFactoryText = handlerFactoryText.replace(/x/, "");

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -72,7 +72,7 @@ var proxyHandlerProperties = {
 };
 
 function makeProxyHandlerFactory (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   if (d < 1) { return "({/*TOODEEP*/})"; }
 
@@ -124,7 +124,7 @@ function proxyMunge (funText, p) { // eslint-disable-line require-jsdoc
 }
 
 function makeProxyHandler (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   return makeProxyHandlerFactory(d, b) + "(" + makeExpr(d - 3, b) + ")";
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -6,12 +6,14 @@
 /* global bp:writable, makeExpr, makeFunction, Random, rnd, TOTALLY_RANDOM, totallyRandom */
 
 // In addition, can always use "undefined" or makeFunction
-// Forwarding proxy code based on http://wiki.ecmascript.org/doku.php?id=harmony:proxies "Example: a no-op forwarding proxy"
+// Forwarding proxy code based on http://wiki.ecmascript.org/doku.php?id=harmony:proxies
+//   "Example: a no-op forwarding proxy"
 // The letter 'x' is special.
 var proxyHandlerProperties = {
   getOwnPropertyDescriptor: {
     empty:    "function(){}",
-    forward:  "function(name) { var desc = Object.getOwnPropertyDescriptor(x); desc.configurable = true; return desc; }",
+    forward:  "function(name) { var desc = Object.getOwnPropertyDescriptor(x); "
+      + "desc.configurable = true; return desc; }",
     throwing: "function(name) { return {get: function() { throw 4; }, set: function() { throw 5; }}; }",
   },
   defineProperty: {
@@ -49,7 +51,8 @@ var proxyHandlerProperties = {
   get: {
     empty:    "function() { return undefined }",
     forward:  "function(receiver, name) { return x[name]; }",
-    bind:     "function(receiver, name) { var prop = x[name]; return (typeof prop) === 'function' ? prop.bind(x) : prop; }",
+    bind:     "function(receiver, name) { var prop = x[name]; "
+      + "return (typeof prop) === 'function' ? prop.bind(x) : prop; }",
   },
   set: {
     empty:    "function() { return true; }",

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -32,35 +32,35 @@ var recursiveFunctions = [
     // Unless the recursive call is in the tail position, this will throw.
     text: "(function too_much_recursion(depth) { @; if (depth > 0) { @; too_much_recursion(depth - 1); @ } else { @ } @ })",
     vars: ["depth"],
-    args: function(d, b) { return singleRecursionDepth(d, b); },
-    test: function(f) { try { f(5000); } catch (e) { } return true; },
+    args: function (d, b) { return singleRecursionDepth(d, b); },
+    test: function (f) { try { f(5000); } catch (e) { } return true; }
   },
   {
     text: "(function factorial(N) { @; if (N == 0) { @; return 1; } @; return N * factorial(N - 1); @ })",
     vars: ["N"],
-    args: function(d, b) { return singleRecursionDepth(d, b); },
-    test: function(f) { return f(10) == 3628800; },
+    args: function (d, b) { return singleRecursionDepth(d, b); },
+    test: function (f) { return f(10) == 3628800; }
   },
   {
     text: "(function factorial_tail(N, Acc) { @; if (N == 0) { @; return Acc; } @; return factorial_tail(N - 1, Acc * N); @ })",
     vars: ["N", "Acc"],
-    args: function(d, b) { return singleRecursionDepth(d, b) + ", 1"; },
-    test: function(f) { return f(10, 1) == 3628800; },
+    args: function (d, b) { return singleRecursionDepth(d, b) + ", 1"; },
+    test: function (f) { return f(10, 1) == 3628800; }
   },
   {
     // two recursive calls
     text: "(function fibonacci(N) { @; if (N <= 1) { @; return 1; } @; return fibonacci(N - 1) + fibonacci(N - 2); @ })",
     vars: ["N"],
-    args: function(d, b) { return "" + rnd(8); },
-    test: function(f) { return f(6) == 13; },
+    args: function (d, b) { return "" + rnd(8); },
+    test: function (f) { return f(6) == 13; }
   },
   {
     // do *anything* while indexing over mixed-type arrays
     text: "(function a_indexing(array, start) { @; if (array.length == start) { @; return EXPR1; } var thisitem = array[start]; var recval = a_indexing(array, start + 1); STATEMENT1 })",
     vars: ["array", "start", "thisitem", "recval"],
-    args: function(d, b) { return makeMixedTypeArray(d-1, b) + ", 0"; },
-    testSub: function(text) { return text.replace(/EXPR1/, "0").replace(/STATEMENT1/, "return thisitem + recval;"); },
-    randSub: function(text, varMap, d, b) {
+    args: function (d, b) { return makeMixedTypeArray(d - 1, b) + ", 0"; },
+    testSub: function (text) { return text.replace(/EXPR1/, "0").replace(/STATEMENT1/, "return thisitem + recval;"); },
+    randSub: function (text, varMap, d, b) {
       /* eslint-disable indent, no-multi-spaces */
       var expr1 =      makeExpr(d, b.concat([varMap["array"], varMap["start"]]));
       var statement1 = rnd(2) ?
@@ -70,26 +70,26 @@ var recursiveFunctions = [
       return (text.replace(/EXPR1/,      expr1)
                   .replace(/STATEMENT1/, statement1)
       /* eslint-enable indent, no-multi-spaces */
-      ); },
-    test: function(f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; },
+      );
+    },
+    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; }
   },
   {
     // this lets us play a little with mixed-type arrays
     text: "(function sum_indexing(array, start) { @; return array.length == start ? 0 : array[start] + sum_indexing(array, start + 1); })",
     vars: ["array", "start"],
-    args: function(d, b) { return makeMixedTypeArray(d-1, b) + ", 0"; },
-    test: function(f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; },
+    args: function (d, b) { return makeMixedTypeArray(d - 1, b) + ", 0"; },
+    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; }
   },
   {
     text: "(function sum_slicing(array) { @; return array.length == 0 ? 0 : array[0] + sum_slicing(array.slice(1)); })",
     vars: ["array"],
-    args: function(d, b) { return makeMixedTypeArray(d-1, b); },
-    test: function(f) { return f([1, 2, 3, "4", 5, 6, 7]) == "123418"; },
-  },
+    args: function (d, b) { return makeMixedTypeArray(d - 1, b); },
+    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7]) == "123418"; }
+  }
 ];
 
-function singleRecursionDepth(d, b)
-{
+function singleRecursionDepth (d, b) {
   if (rnd(2) === 0) {
     return "" + rnd(4);
   }
@@ -99,21 +99,18 @@ function singleRecursionDepth(d, b)
   return "" + rnd(100000);
 }
 
-(function testAllRecursiveFunctions() {
+(function testAllRecursiveFunctions () {
   for (var i = 0; i < recursiveFunctions.length; ++i) {
     var a = recursiveFunctions[i];
     var text = a.text;
     if (a.testSub) text = a.testSub(text);
     var f = eval(text.replace(/@/g, ""));
-    if (!a.test(f))
-      throw "Failed test of: " + a.text;
+    if (!a.test(f)) { throw "Failed test of: " + a.text; }
   }
 })();
 
-function makeImmediateRecursiveCall(d, b, cheat1, cheat2)
-{
-  if (rnd(10) !== 0)
-    return "(4277)";
+function makeImmediateRecursiveCall (d, b, cheat1, cheat2) {
+  if (rnd(10) !== 0) { return "(4277)"; }
 
   var a = (cheat1 == null) ? Random.index(recursiveFunctions) : recursiveFunctions[cheat1];
   var s = a.text;
@@ -125,7 +122,7 @@ function makeImmediateRecursiveCall(d, b, cheat1, cheat2)
   }
   var actualArgs = cheat2 == null ? a.args(d, b) : cheat2;
   s = s + "(" + actualArgs + ")";
-  s = s.replace(/@/g, function() { if (rnd(4) === 0) return makeStatement(d-2, b); return ""; });
+  s = s.replace(/@/g, function () { if (rnd(4) === 0) return makeStatement(d - 2, b); return ""; });
   if (a.randSub) s = a.randSub(s, varMap, d, b);
   s = "(" + s + ")";
   return s;

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -39,20 +39,20 @@ var recursiveFunctions = [
     text: "(function factorial(N) { @; if (N == 0) { @; return 1; } @; return N * factorial(N - 1); @ })",
     vars: ["N"],
     args: function (d, b) { return singleRecursionDepth(d, b); },
-    test: function (f) { return f(10) === 3628800; }
+    test: function (f) { return f(10) == 3628800; }
   },
   {
     text: "(function factorial_tail(N, Acc) { @; if (N == 0) { @; return Acc; } @; return factorial_tail(N - 1, Acc * N); @ })",
     vars: ["N", "Acc"],
     args: function (d, b) { return singleRecursionDepth(d, b) + ", 1"; },
-    test: function (f) { return f(10, 1) === 3628800; }
+    test: function (f) { return f(10, 1) == 3628800; }
   },
   {
     // two recursive calls
     text: "(function fibonacci(N) { @; if (N <= 1) { @; return 1; } @; return fibonacci(N - 1) + fibonacci(N - 2); @ })",
     vars: ["N"],
     args: function (d, b) { return "" + rnd(8); },
-    test: function (f) { return f(6) === 13; }
+    test: function (f) { return f(6) == 13; }
   },
   {
     // do *anything* while indexing over mixed-type arrays
@@ -72,20 +72,20 @@ var recursiveFunctions = [
       /* eslint-enable indent, no-multi-spaces */
       );
     },
-    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) === "123418"; }
+    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; }
   },
   {
     // this lets us play a little with mixed-type arrays
     text: "(function sum_indexing(array, start) { @; return array.length == start ? 0 : array[start] + sum_indexing(array, start + 1); })",
     vars: ["array", "start"],
     args: function (d, b) { return makeMixedTypeArray(d - 1, b) + ", 0"; },
-    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) === "123418"; }
+    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; }
   },
   {
     text: "(function sum_slicing(array) { @; return array.length == 0 ? 0 : array[0] + sum_slicing(array.slice(1)); })",
     vars: ["array"],
     args: function (d, b) { return makeMixedTypeArray(d - 1, b); },
-    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7]) === "123418"; }
+    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7]) == "123418"; }
   }
 ];
 

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -39,20 +39,20 @@ var recursiveFunctions = [
     text: "(function factorial(N) { @; if (N == 0) { @; return 1; } @; return N * factorial(N - 1); @ })",
     vars: ["N"],
     args: function (d, b) { return singleRecursionDepth(d, b); },
-    test: function (f) { return f(10) == 3628800; }
+    test: function (f) { return f(10) === 3628800; }
   },
   {
     text: "(function factorial_tail(N, Acc) { @; if (N == 0) { @; return Acc; } @; return factorial_tail(N - 1, Acc * N); @ })",
     vars: ["N", "Acc"],
     args: function (d, b) { return singleRecursionDepth(d, b) + ", 1"; },
-    test: function (f) { return f(10, 1) == 3628800; }
+    test: function (f) { return f(10, 1) === 3628800; }
   },
   {
     // two recursive calls
     text: "(function fibonacci(N) { @; if (N <= 1) { @; return 1; } @; return fibonacci(N - 1) + fibonacci(N - 2); @ })",
     vars: ["N"],
     args: function (d, b) { return "" + rnd(8); },
-    test: function (f) { return f(6) == 13; }
+    test: function (f) { return f(6) === 13; }
   },
   {
     // do *anything* while indexing over mixed-type arrays
@@ -72,20 +72,20 @@ var recursiveFunctions = [
       /* eslint-enable indent, no-multi-spaces */
       );
     },
-    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; }
+    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) === "123418"; }
   },
   {
     // this lets us play a little with mixed-type arrays
     text: "(function sum_indexing(array, start) { @; return array.length == start ? 0 : array[start] + sum_indexing(array, start + 1); })",
     vars: ["array", "start"],
     args: function (d, b) { return makeMixedTypeArray(d - 1, b) + ", 0"; },
-    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; }
+    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) === "123418"; }
   },
   {
     text: "(function sum_slicing(array) { @; return array.length == 0 ? 0 : array[0] + sum_slicing(array.slice(1)); })",
     vars: ["array"],
     args: function (d, b) { return makeMixedTypeArray(d - 1, b); },
-    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7]) == "123418"; }
+    test: function (f) { return f([1, 2, 3, "4", 5, 6, 7]) === "123418"; }
   }
 ];
 

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -96,12 +96,12 @@ var recursiveFunctions = [
 
 function singleRecursionDepth(d, b)
 {
-  if (rnd(2) === 0) {
+  if (rnd(2) === 0) 
     return "" + rnd(4);
-  }
-  if (rnd(10) === 0) {
+  
+  if (rnd(10) === 0) 
     return makeExpr(d - 2, b);
-  }
+  
   return "" + rnd(100000);
 }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported makeImmediateRecursiveCall */
 /* global makeExpr, makeMixedTypeArray, makeStatement, Random, rnd, uniqueVarName */
 
 /*

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -8,7 +8,8 @@
 /*
 David Anderson suggested creating the following recursive structures:
   - recurse down an array of mixed types, car cdr kinda thing
-  - multiple recursive calls in a function, like binary search left/right, sometimes calls neither and sometimes calls both
+  - multiple recursive calls in a function, like binary search left/right,
+    sometimes calls neither and sometimes calls both
 
   the recursion support in spidermonkey only works with self-recursion.
   that is, two functions that call each other recursively will not be traced.
@@ -20,7 +21,8 @@ David Anderson suggested creating the following recursive structures:
   so far, what i've thought of means recursing from the top of a function and if..else.
   but i'd probably also want to recurse from other points, e.g. loops.
 
-  special code for tail recursion likely coming soon, but possibly as a separate patch, because it requires changes to the interpreter.
+  special code for tail recursion likely coming soon, but possibly as a separate patch,
+    because it requires changes to the interpreter.
 */
 
 // "@" indicates a point at which a statement can be inserted. XXX allow use of variables, as consts
@@ -29,7 +31,8 @@ David Anderson suggested creating the following recursive structures:
 var recursiveFunctions = [
   {
     // Unless the recursive call is in the tail position, this will throw.
-    text: "(function too_much_recursion(depth) { @; if (depth > 0) { @; too_much_recursion(depth - 1); @ } else { @ } @ })",
+    text: "(function too_much_recursion(depth) { @; if (depth > 0) { @; too_much_recursion(depth - 1); @ } "
+      + "else { @ } @ })",
     vars: ["depth"],
     args: function(d, b) { return singleRecursionDepth(d, b); },
     test: function(f) { try { f(5000); } catch (e) { } return true; },
@@ -41,21 +44,24 @@ var recursiveFunctions = [
     test: function(f) { return f(10) == 3628800; },
   },
   {
-    text: "(function factorial_tail(N, Acc) { @; if (N == 0) { @; return Acc; } @; return factorial_tail(N - 1, Acc * N); @ })",
+    text: "(function factorial_tail(N, Acc) { @; if (N == 0) { @; return Acc; } @; "
+      + "return factorial_tail(N - 1, Acc * N); @ })",
     vars: ["N", "Acc"],
     args: function(d, b) { return singleRecursionDepth(d, b) + ", 1"; },
     test: function(f) { return f(10, 1) == 3628800; },
   },
   {
     // two recursive calls
-    text: "(function fibonacci(N) { @; if (N <= 1) { @; return 1; } @; return fibonacci(N - 1) + fibonacci(N - 2); @ })",
+    text: "(function fibonacci(N) { @; if (N <= 1) { @; return 1; } @; "
+      + "return fibonacci(N - 1) + fibonacci(N - 2); @ })",
     vars: ["N"],
     args: function(d, b) { return "" + rnd(8); },
     test: function(f) { return f(6) == 13; },
   },
   {
     // do *anything* while indexing over mixed-type arrays
-    text: "(function a_indexing(array, start) { @; if (array.length == start) { @; return EXPR1; } var thisitem = array[start]; var recval = a_indexing(array, start + 1); STATEMENT1 })",
+    text: "(function a_indexing(array, start) { @; if (array.length == start) { @; return EXPR1; } "
+      + "var thisitem = array[start]; var recval = a_indexing(array, start + 1); STATEMENT1 })",
     vars: ["array", "start", "thisitem", "recval"],
     args: function(d, b) { return makeMixedTypeArray(d-1, b) + ", 0"; },
     testSub: function(text) { return text.replace(/EXPR1/, "0").replace(/STATEMENT1/, "return thisitem + recval;"); },
@@ -74,7 +80,8 @@ var recursiveFunctions = [
   },
   {
     // this lets us play a little with mixed-type arrays
-    text: "(function sum_indexing(array, start) { @; return array.length == start ? 0 : array[start] + sum_indexing(array, start + 1); })",
+    text: "(function sum_indexing(array, start) { @; "
+      + "return array.length == start ? 0 : array[start] + sum_indexing(array, start + 1); })",
     vars: ["array", "start"],
     args: function(d, b) { return makeMixedTypeArray(d-1, b) + ", 0"; },
     test: function(f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; },

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -32,7 +32,7 @@ var recursiveFunctions = [
     text: "(function too_much_recursion(depth) { @; if (depth > 0) { @; too_much_recursion(depth - 1); @ } else { @ } @ })",
     vars: ["depth"],
     args: function(d, b) { return singleRecursionDepth(d, b); },
-    test: function(f) { try { f(5000); } catch(e) { } return true; },
+    test: function(f) { try { f(5000); } catch (e) { } return true; },
   },
   {
     text: "(function factorial(N) { @; if (N == 0) { @; return 1; } @; return N * factorial(N - 1); @ })",

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -60,7 +60,7 @@ var recursiveFunctions = [
     args: function(d, b) { return makeMixedTypeArray(d-1, b) + ", 0"; },
     testSub: function(text) { return text.replace(/EXPR1/, "0").replace(/STATEMENT1/, "return thisitem + recval;"); },
     randSub: function(text, varMap, d, b) {
-      /* eslint-disable indent */
+      /* eslint-disable indent, no-multi-spaces */
       var expr1 =      makeExpr(d, b.concat([varMap["array"], varMap["start"]]));
       var statement1 = rnd(2) ?
                                  makeStatement(d, b.concat([varMap["thisitem"], varMap["recval"]]))        :
@@ -68,7 +68,7 @@ var recursiveFunctions = [
 
       return (text.replace(/EXPR1/,      expr1)
                   .replace(/STATEMENT1/, statement1)
-      /* eslint-enable indent */
+      /* eslint-enable indent, no-multi-spaces */
       ); },
     test: function(f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; },
   },

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -105,7 +105,7 @@ function singleRecursionDepth (d, b) { // eslint-disable-line require-jsdoc
     var text = a.text;
     if (a.testSub) text = a.testSub(text);
     var f = eval(text.replace(/@/g, "")); // eslint-disable-line no-eval
-    if (!a.test(f)) { throw "Failed test of: " + a.text; }
+    if (!a.test(f)) { throw new Error("Failed test of: " + a.text); }
   }
 })();
 

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -8,8 +8,7 @@
 /*
 David Anderson suggested creating the following recursive structures:
   - recurse down an array of mixed types, car cdr kinda thing
-  - multiple recursive calls in a function, like binary search left/right,
-    sometimes calls neither and sometimes calls both
+  - multiple recursive calls in a function, like binary search left/right, sometimes calls neither and sometimes calls both
 
   the recursion support in spidermonkey only works with self-recursion.
   that is, two functions that call each other recursively will not be traced.
@@ -21,8 +20,7 @@ David Anderson suggested creating the following recursive structures:
   so far, what i've thought of means recursing from the top of a function and if..else.
   but i'd probably also want to recurse from other points, e.g. loops.
 
-  special code for tail recursion likely coming soon, but possibly as a separate patch,
-    because it requires changes to the interpreter.
+  special code for tail recursion likely coming soon, but possibly as a separate patch, because it requires changes to the interpreter.
 */
 
 // "@" indicates a point at which a statement can be inserted. XXX allow use of variables, as consts
@@ -31,8 +29,7 @@ David Anderson suggested creating the following recursive structures:
 var recursiveFunctions = [
   {
     // Unless the recursive call is in the tail position, this will throw.
-    text: "(function too_much_recursion(depth) { @; if (depth > 0) { @; too_much_recursion(depth - 1); @ } "
-      + "else { @ } @ })",
+    text: "(function too_much_recursion(depth) { @; if (depth > 0) { @; too_much_recursion(depth - 1); @ } else { @ } @ })",
     vars: ["depth"],
     args: function(d, b) { return singleRecursionDepth(d, b); },
     test: function(f) { try { f(5000); } catch (e) { } return true; },
@@ -44,24 +41,21 @@ var recursiveFunctions = [
     test: function(f) { return f(10) == 3628800; },
   },
   {
-    text: "(function factorial_tail(N, Acc) { @; if (N == 0) { @; return Acc; } @; "
-      + "return factorial_tail(N - 1, Acc * N); @ })",
+    text: "(function factorial_tail(N, Acc) { @; if (N == 0) { @; return Acc; } @; return factorial_tail(N - 1, Acc * N); @ })",
     vars: ["N", "Acc"],
     args: function(d, b) { return singleRecursionDepth(d, b) + ", 1"; },
     test: function(f) { return f(10, 1) == 3628800; },
   },
   {
     // two recursive calls
-    text: "(function fibonacci(N) { @; if (N <= 1) { @; return 1; } @; "
-      + "return fibonacci(N - 1) + fibonacci(N - 2); @ })",
+    text: "(function fibonacci(N) { @; if (N <= 1) { @; return 1; } @; return fibonacci(N - 1) + fibonacci(N - 2); @ })",
     vars: ["N"],
     args: function(d, b) { return "" + rnd(8); },
     test: function(f) { return f(6) == 13; },
   },
   {
     // do *anything* while indexing over mixed-type arrays
-    text: "(function a_indexing(array, start) { @; if (array.length == start) { @; return EXPR1; } "
-      + "var thisitem = array[start]; var recval = a_indexing(array, start + 1); STATEMENT1 })",
+    text: "(function a_indexing(array, start) { @; if (array.length == start) { @; return EXPR1; } var thisitem = array[start]; var recval = a_indexing(array, start + 1); STATEMENT1 })",
     vars: ["array", "start", "thisitem", "recval"],
     args: function(d, b) { return makeMixedTypeArray(d-1, b) + ", 0"; },
     testSub: function(text) { return text.replace(/EXPR1/, "0").replace(/STATEMENT1/, "return thisitem + recval;"); },
@@ -80,8 +74,7 @@ var recursiveFunctions = [
   },
   {
     // this lets us play a little with mixed-type arrays
-    text: "(function sum_indexing(array, start) { @; "
-      + "return array.length == start ? 0 : array[start] + sum_indexing(array, start + 1); })",
+    text: "(function sum_indexing(array, start) { @; return array.length == start ? 0 : array[start] + sum_indexing(array, start + 1); })",
     vars: ["array", "start"],
     args: function(d, b) { return makeMixedTypeArray(d-1, b) + ", 0"; },
     test: function(f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; },

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -89,7 +89,7 @@ var recursiveFunctions = [
   }
 ];
 
-function singleRecursionDepth (d, b) {
+function singleRecursionDepth (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(2) === 0) {
     return "" + rnd(4);
   }
@@ -109,7 +109,7 @@ function singleRecursionDepth (d, b) {
   }
 })();
 
-function makeImmediateRecursiveCall (d, b, cheat1, cheat2) {
+function makeImmediateRecursiveCall (d, b, cheat1, cheat2) { // eslint-disable-line require-jsdoc
   if (rnd(10) !== 0) { return "(4277)"; }
 
   var a = (cheat1 == null) ? Random.index(recursiveFunctions) : recursiveFunctions[cheat1];

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -32,26 +32,26 @@ var recursiveFunctions = [
     text: "(function too_much_recursion(depth) { @; if (depth > 0) { @; too_much_recursion(depth - 1); @ } else { @ } @ })",
     vars: ["depth"],
     args: function(d, b) { return singleRecursionDepth(d, b); },
-    test: function(f) { try { f(5000); } catch(e) { } return true; }
+    test: function(f) { try { f(5000); } catch(e) { } return true; },
   },
   {
     text: "(function factorial(N) { @; if (N == 0) { @; return 1; } @; return N * factorial(N - 1); @ })",
     vars: ["N"],
     args: function(d, b) { return singleRecursionDepth(d, b); },
-    test: function(f) { return f(10) == 3628800; }
+    test: function(f) { return f(10) == 3628800; },
   },
   {
     text: "(function factorial_tail(N, Acc) { @; if (N == 0) { @; return Acc; } @; return factorial_tail(N - 1, Acc * N); @ })",
     vars: ["N", "Acc"],
     args: function(d, b) { return singleRecursionDepth(d, b) + ", 1"; },
-    test: function(f) { return f(10, 1) == 3628800; }
+    test: function(f) { return f(10, 1) == 3628800; },
   },
   {
     // two recursive calls
     text: "(function fibonacci(N) { @; if (N <= 1) { @; return 1; } @; return fibonacci(N - 1) + fibonacci(N - 2); @ })",
     vars: ["N"],
     args: function(d, b) { return "" + rnd(8); },
-    test: function(f) { return f(6) == 13; }
+    test: function(f) { return f(6) == 13; },
   },
   {
     // do *anything* while indexing over mixed-type arrays
@@ -68,21 +68,21 @@ var recursiveFunctions = [
         return (text.replace(/EXPR1/,      expr1)
                     .replace(/STATEMENT1/, statement1)
         ); },
-    test: function(f) { return f([1,2,3,"4",5,6,7], 0) == "123418"; }
+    test: function(f) { return f([1,2,3,"4",5,6,7], 0) == "123418"; },
   },
   {
     // this lets us play a little with mixed-type arrays
     text: "(function sum_indexing(array, start) { @; return array.length == start ? 0 : array[start] + sum_indexing(array, start + 1); })",
     vars: ["array", "start"],
     args: function(d, b) { return makeMixedTypeArray(d-1, b) + ", 0"; },
-    test: function(f) { return f([1,2,3,"4",5,6,7], 0) == "123418"; }
+    test: function(f) { return f([1,2,3,"4",5,6,7], 0) == "123418"; },
   },
   {
     text: "(function sum_slicing(array) { @; return array.length == 0 ? 0 : array[0] + sum_slicing(array.slice(1)); })",
     vars: ["array"],
     args: function(d, b) { return makeMixedTypeArray(d-1, b); },
-    test: function(f) { return f([1,2,3,"4",5,6,7]) == "123418"; }
-  }
+    test: function(f) { return f([1,2,3,"4",5,6,7]) == "123418"; },
+  },
 ];
 
 function singleRecursionDepth(d, b)

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -96,12 +96,12 @@ var recursiveFunctions = [
 
 function singleRecursionDepth(d, b)
 {
-  if (rnd(2) === 0) 
+  if (rnd(2) === 0) {
     return "" + rnd(4);
-  
-  if (rnd(10) === 0) 
+  }
+  if (rnd(10) === 0) {
     return makeExpr(d - 2, b);
-  
+  }
   return "" + rnd(100000);
 }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global makeExpr, makeMixedTypeArray, makeStatement, Random, rnd, uniqueVarName */
+
 /*
 David Anderson suggested creating the following recursive structures:
   - recurse down an array of mixed types, car cdr kinda thing

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -104,7 +104,7 @@ function singleRecursionDepth (d, b) { // eslint-disable-line require-jsdoc
     var a = recursiveFunctions[i];
     var text = a.text;
     if (a.testSub) text = a.testSub(text);
-    var f = eval(text.replace(/@/g, ""));
+    var f = eval(text.replace(/@/g, "")); // eslint-disable-line no-eval
     if (!a.test(f)) { throw "Failed test of: " + a.text; }
   }
 })();

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -60,14 +60,16 @@ var recursiveFunctions = [
     args: function(d, b) { return makeMixedTypeArray(d-1, b) + ", 0"; },
     testSub: function(text) { return text.replace(/EXPR1/, "0").replace(/STATEMENT1/, "return thisitem + recval;"); },
     randSub: function(text, varMap, d, b) {
-        var expr1 =      makeExpr(d, b.concat([varMap["array"], varMap["start"]]));
-        var statement1 = rnd(2) ?
-                                   makeStatement(d, b.concat([varMap["thisitem"], varMap["recval"]]))        :
-                            "return " + makeExpr(d, b.concat([varMap["thisitem"], varMap["recval"]])) + ";";
+      /* eslint-disable indent */
+      var expr1 =      makeExpr(d, b.concat([varMap["array"], varMap["start"]]));
+      var statement1 = rnd(2) ?
+                                 makeStatement(d, b.concat([varMap["thisitem"], varMap["recval"]]))        :
+                          "return " + makeExpr(d, b.concat([varMap["thisitem"], varMap["recval"]])) + ";";
 
-        return (text.replace(/EXPR1/,      expr1)
-                    .replace(/STATEMENT1/, statement1)
-        ); },
+      return (text.replace(/EXPR1/,      expr1)
+                  .replace(/STATEMENT1/, statement1)
+      /* eslint-enable indent */
+      ); },
     test: function(f) { return f([1,2,3,"4",5,6,7], 0) == "123418"; },
   },
   {

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -70,20 +70,20 @@ var recursiveFunctions = [
                   .replace(/STATEMENT1/, statement1)
       /* eslint-enable indent */
       ); },
-    test: function(f) { return f([1,2,3,"4",5,6,7], 0) == "123418"; },
+    test: function(f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; },
   },
   {
     // this lets us play a little with mixed-type arrays
     text: "(function sum_indexing(array, start) { @; return array.length == start ? 0 : array[start] + sum_indexing(array, start + 1); })",
     vars: ["array", "start"],
     args: function(d, b) { return makeMixedTypeArray(d-1, b) + ", 0"; },
-    test: function(f) { return f([1,2,3,"4",5,6,7], 0) == "123418"; },
+    test: function(f) { return f([1, 2, 3, "4", 5, 6, 7], 0) == "123418"; },
   },
   {
     text: "(function sum_slicing(array) { @; return array.length == 0 ? 0 : array[0] + sum_slicing(array.slice(1)); })",
     vars: ["array"],
     args: function(d, b) { return makeMixedTypeArray(d-1, b); },
-    test: function(f) { return f([1,2,3,"4",5,6,7]) == "123418"; },
+    test: function(f) { return f([1, 2, 3, "4", 5, 6, 7]) == "123418"; },
   },
 ];
 

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -223,16 +223,6 @@ function regexTerm () { // eslint-disable-line require-jsdoc
   return Random.index(regexTermMakers)();
 }
 
-// Alternative regexTerm implementation that was no longer used
-// function regexTerm () { // eslint-disable-line require-jsdoc
-//   var [re, oneString] = regexTermPair();
-//   var strings = [];
-//   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
-//     strings[i] = rnd(5) ? oneString : regexTermPair()[1];
-//   }
-//   return [re, strings];
-// }
-
 // Returns a pair: [(regex char class), (POTENTIAL_MATCHES number of strings that might match)]
 // e.g. ["[a-z0-9]", ["a", "8", ...]]
 function regexCharacterClass () { // eslint-disable-line require-jsdoc

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -27,9 +27,9 @@ var POTENTIAL_MATCHES = 10;
 
 // Stored captures
 var backrefHack = [];
-for (var j = 0; j < POTENTIAL_MATCHES; ++j) 
+for (var j = 0; j < POTENTIAL_MATCHES; ++j) {
   backrefHack[j] = "";
-
+}
 
 function regexNumberOfMatches()
 {
@@ -88,12 +88,12 @@ function quantifierHelper(pm, min, max, pms)
   var repeats = Math.min(min + rnd(max - min + 5) - 2, 10);
   var returnValue = "";
   for (var i = 0; i < repeats; i++)
-  
+  {
     if (rnd(100) < 80)
       returnValue = returnValue + pm;
     else
       returnValue = returnValue + Random.index(pms);
-  
+  }
   return returnValue;
 }
 
@@ -158,9 +158,9 @@ function regexGrouped(prefix, dr, postfix)
   var newStrings = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     newStrings[i] = rnd(5) ? strings[i] : "";
-    if (prefix == "(" && strings[i].length < 40 && rnd(3) === 0) 
+    if (prefix == "(" && strings[i].length < 40 && rnd(3) === 0) {
       backrefHack[i] = strings[i];
-    
+    }
   }
   return [prefix + re + postfix, newStrings];
 }
@@ -182,9 +182,9 @@ function regexTerm()
 {
   var [re, oneString] = regexTermPair();
   var strings = [];
-  for (var i = 0; i < POTENTIAL_MATCHES; ++i) 
+  for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     strings[i] = rnd(5) ? oneString : regexTermPair()[1];
-  
+  }
   return [re, strings];
 }
 
@@ -253,9 +253,9 @@ var regexBuiltInCharClasses = [
 // Returns POTENTIAL_MATCHES one-character strings, mostly consisting of the input characters
 function regexOneCharStringsWith(frequentChars) {
   var matches = [];
-  for (var i = 0; i < POTENTIAL_MATCHES; ++i) 
+  for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     matches.push(rnd(8) ? Random.index(frequentChars) : String.fromCharCode(regexCharCode()));
-  
+  }
   return matches;
 }
 
@@ -264,9 +264,9 @@ function regexShortStringsWith(frequentChars) {
   var matches = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     var s = "";
-    while (rnd(3)) 
+    while (rnd(3)) {
       s += rnd(4) ? Random.index(frequentChars) : String.fromCharCode(regexCharCode());
-    
+    }
     matches.push(s);
   }
   return matches;
@@ -302,9 +302,9 @@ function regexCharacterClass()
   var charBucket = [String.fromCharCode(regexCharCode())]; // from which potenial matches will be drawn
 
   var re = "[";
-  if (!inRange) 
+  if (!inRange) {
     re += "^";
-  
+  }
 
   var lo;
   var hi;
@@ -313,9 +313,9 @@ function regexCharacterClass()
     if (rnd(100) == 0) {
       // Confuse things by tossing in an extra "-"
       re += "-";
-      if (rnd(2)) 
+      if (rnd(2)) {
         re += String.fromCharCode(regexCharCode());
-      
+      }
     }
 
     if (rnd(3) == 1) {
@@ -328,11 +328,11 @@ function regexCharacterClass()
       // Add a range, like "a-z"
       var a = regexCharacter();
       var b = regexCharacter();
-      if ((a[1] <= b[1]) == !!rnd(10)) 
+      if ((a[1] <= b[1]) == !!rnd(10)) {
         [lo, hi] = [a, b];
-      else 
+      } else {
         [lo, hi] = [b, a];
-      
+      }
 
       re += lo[0] + "-" + hi[0];
       charBucket.push(String.fromCharCode(lo[1] + rnd(3) - 1));
@@ -353,8 +353,8 @@ function regexCharacterClass()
 function pickN(bucket, picks)
 {
   var picked = [];
-  for (var i = 0; i < picks; ++i) 
+  for (var i = 0; i < picks; ++i) {
     picked.push(Random.index(bucket));
-  
+  }
   return picked;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -61,12 +61,12 @@ var regexMakers =
     function(dr) { return regexQuantified(dr, "*?", 0, 1); },
     function(dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + "}", x, x); },
     function(dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + ",}", x, x + rnd(10)); },
-    function(dr) { var min = regexNumberOfMatches(); var max = min + regexNumberOfMatches(); return regexQuantified(dr, "{" + min + "," + max + "}", min, max); }
+    function(dr) { var min = regexNumberOfMatches(); var max = min + regexNumberOfMatches(); return regexQuantified(dr, "{" + min + "," + max + "}", min, max); },
   ],
   [
     // Combinations: concatenation, disjunction
     function(dr) { return regexConcatenation(dr); },
-    function(dr) { return regexDisjunction(dr); }
+    function(dr) { return regexDisjunction(dr); },
   ],
   [
     // Grouping
@@ -74,8 +74,8 @@ var regexMakers =
     function(dr) { return regexGrouped("(", dr, ")");   }, // capturing: feeds \1 and exec() result
     function(dr) { return regexGrouped("(?:", dr, ")"); }, // non-capturing
     function(dr) { return regexGrouped("(?=", dr, ")"); }, // lookahead
-    function(dr) { return regexGrouped("(?!", dr, ")"); }  // lookahead(not)
-  ]
+    function(dr) { return regexGrouped("(?!", dr, ")"); },  // lookahead(not)
+  ],
 ];
 
 
@@ -170,7 +170,7 @@ var hexDigits = [
   "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
   "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
   "a", "b", "c", "d", "e", "f",
-  "A", "B", "C", "D", "E", "F"
+  "A", "B", "C", "D", "E", "F",
 ];
 
 function regexTerm()

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -27,9 +27,9 @@ var POTENTIAL_MATCHES = 10;
 
 // Stored captures
 var backrefHack = [];
-for (var j = 0; j < POTENTIAL_MATCHES; ++j) {
+for (var j = 0; j < POTENTIAL_MATCHES; ++j) 
   backrefHack[j] = "";
-}
+
 
 function regexNumberOfMatches()
 {
@@ -88,12 +88,12 @@ function quantifierHelper(pm, min, max, pms)
   var repeats = Math.min(min + rnd(max - min + 5) - 2, 10);
   var returnValue = "";
   for (var i = 0; i < repeats; i++)
-  {
+  
     if (rnd(100) < 80)
       returnValue = returnValue + pm;
     else
       returnValue = returnValue + Random.index(pms);
-  }
+  
   return returnValue;
 }
 
@@ -158,9 +158,9 @@ function regexGrouped(prefix, dr, postfix)
   var newStrings = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     newStrings[i] = rnd(5) ? strings[i] : "";
-    if (prefix == "(" && strings[i].length < 40 && rnd(3) === 0) {
+    if (prefix == "(" && strings[i].length < 40 && rnd(3) === 0) 
       backrefHack[i] = strings[i];
-    }
+    
   }
   return [prefix + re + postfix, newStrings];
 }
@@ -182,9 +182,9 @@ function regexTerm()
 {
   var [re, oneString] = regexTermPair();
   var strings = [];
-  for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
+  for (var i = 0; i < POTENTIAL_MATCHES; ++i) 
     strings[i] = rnd(5) ? oneString : regexTermPair()[1];
-  }
+  
   return [re, strings];
 }
 
@@ -253,9 +253,9 @@ var regexBuiltInCharClasses = [
 // Returns POTENTIAL_MATCHES one-character strings, mostly consisting of the input characters
 function regexOneCharStringsWith(frequentChars) {
   var matches = [];
-  for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
+  for (var i = 0; i < POTENTIAL_MATCHES; ++i) 
     matches.push(rnd(8) ? Random.index(frequentChars) : String.fromCharCode(regexCharCode()));
-  }
+  
   return matches;
 }
 
@@ -264,9 +264,9 @@ function regexShortStringsWith(frequentChars) {
   var matches = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     var s = "";
-    while (rnd(3)) {
+    while (rnd(3)) 
       s += rnd(4) ? Random.index(frequentChars) : String.fromCharCode(regexCharCode());
-    }
+    
     matches.push(s);
   }
   return matches;
@@ -302,9 +302,9 @@ function regexCharacterClass()
   var charBucket = [String.fromCharCode(regexCharCode())]; // from which potenial matches will be drawn
 
   var re = "[";
-  if (!inRange) {
+  if (!inRange) 
     re += "^";
-  }
+  
 
   var lo;
   var hi;
@@ -313,9 +313,9 @@ function regexCharacterClass()
     if (rnd(100) == 0) {
       // Confuse things by tossing in an extra "-"
       re += "-";
-      if (rnd(2)) {
+      if (rnd(2)) 
         re += String.fromCharCode(regexCharCode());
-      }
+      
     }
 
     if (rnd(3) == 1) {
@@ -328,11 +328,11 @@ function regexCharacterClass()
       // Add a range, like "a-z"
       var a = regexCharacter();
       var b = regexCharacter();
-      if ((a[1] <= b[1]) == !!rnd(10)) {
+      if ((a[1] <= b[1]) == !!rnd(10)) 
         [lo, hi] = [a, b];
-      } else {
+      else 
         [lo, hi] = [b, a];
-      }
+      
 
       re += lo[0] + "-" + hi[0];
       charBucket.push(String.fromCharCode(lo[1] + rnd(3) - 1));
@@ -353,8 +353,8 @@ function regexCharacterClass()
 function pickN(bucket, picks)
 {
   var picked = [];
-  for (var i = 0; i < picks; ++i) {
+  for (var i = 0; i < picks; ++i) 
     picked.push(Random.index(bucket));
-  }
+  
   return picked;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -27,8 +27,8 @@ var POTENTIAL_MATCHES = 10;
 
 // Stored captures
 var backrefHack = [];
-for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
-  backrefHack[i] = "";
+for (var j = 0; j < POTENTIAL_MATCHES; ++j) {
+  backrefHack[j] = "";
 }
 
 function regexNumberOfMatches()

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -162,9 +162,10 @@ function regexGrouped(prefix, dr, postfix)
 }
 
 
-var letters =
-["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
- "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"];
+var letters = [
+  "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+  "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
+];
 
 var hexDigits = [
   "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
@@ -223,9 +224,9 @@ function regexCharacter()
 
 
 var regexBuiltInCharClasses = [
-    "\\d", "\\D", // digit
-    "\\s", "\\S", // space
-    "\\w", "\\W", // "word" character (alphanumeric plus underscore)
+  "\\d", "\\D", // digit
+  "\\s", "\\S", // space
+  "\\w", "\\W", // "word" character (alphanumeric plus underscore)
 ];
 
 // Returns POTENTIAL_MATCHES one-character strings, mostly consisting of the input characters

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -4,7 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /* exported letters */
-/* global Random, regexTermPair, rnd */
+/* global Random, rnd */
 
 /* ***************************** *
  * GENERATING REGEXPS AND INPUTS *

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -284,7 +284,8 @@ function regexCharacterClass()
     re += "^";
   }
 
-  var lo, hi;
+  var lo;
+  var hi;
 
   for (var i = 0; i < ranges; ++i) {
     if (rnd(100) == 0) {

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -192,7 +192,7 @@ function regexCharCode()
 // These return matching pairs: [regex fragment, charcode for a matching one-character string].
 var regexCharacterMakers = Random.weighted([
   // Possibly incorrect
-  { w:20, v: function() { var cc = regexCharCode(); return [       String.fromCharCode(cc), cc]; } }, // literal that doesn't need to be escaped (OR wrong)
+  { w: 20, v: function() { var cc = regexCharCode(); return [      String.fromCharCode(cc), cc]; } }, // literal that doesn't need to be escaped (OR wrong)
   { w: 4, v: function() { var cc = regexCharCode(); return ["\\" + String.fromCharCode(cc), cc]; } }, // escaped special character OR unnecessary escape (OR wrong)
   { w: 1, v: function() { return ["\\0",  0]; } },  // null [ignoring the "do not follow this with another digit" rule which would turn it into an octal escape]
   { w: 1, v: function() { return ["\\B", 66]; } },  // literal B -- ONLY within a character class. (Elsewhere, it's a "zero-width non-word boundary".)

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -38,7 +38,7 @@ function regexNumberOfMatches () { // eslint-disable-line require-jsdoc
 }
 
 function regexPattern (depth, parentWasQuantifier) { // eslint-disable-line require-jsdoc
-  if (depth === 0 || (rnd(depth) === 0)) { return regexTerm(); }
+  if (depth == 0 || (rnd(depth) == 0)) { return regexTerm(); }
 
   var dr = depth - 1;
 
@@ -121,7 +121,7 @@ function regexGrouped (prefix, dr, postfix) { // eslint-disable-line require-jsd
   var newStrings = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     newStrings[i] = rnd(5) ? strings[i] : "";
-    if (prefix === "(" && strings[i].length < 40 && rnd(3) === 0) {
+    if (prefix == "(" && strings[i].length < 40 && rnd(3) === 0) {
       backrefHack[i] = strings[i];
     }
   }
@@ -239,7 +239,7 @@ function regexCharacterClass () { // eslint-disable-line require-jsdoc
   var hi;
 
   for (var i = 0; i < ranges; ++i) {
-    if (rnd(100) === 0) {
+    if (rnd(100) == 0) {
       // Confuse things by tossing in an extra "-"
       re += "-";
       if (rnd(2)) {
@@ -247,7 +247,7 @@ function regexCharacterClass () { // eslint-disable-line require-jsdoc
       }
     }
 
-    if (rnd(3) === 1) {
+    if (rnd(3) == 1) {
       // Add a built-in class, like "\d"
       re += Random.index(regexBuiltInCharClasses);
       charBucket.push("a");
@@ -257,7 +257,7 @@ function regexCharacterClass () { // eslint-disable-line require-jsdoc
       // Add a range, like "a-z"
       var a = regexCharacter();
       var b = regexCharacter();
-      if ((a[1] <= b[1]) === !!rnd(10)) {
+      if ((a[1] <= b[1]) == !!rnd(10)) {
         [lo, hi] = [a, b];
       } else {
         [lo, hi] = [b, a];

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -71,9 +71,9 @@ var regexMakers =
   [
     // Grouping
     function(dr) { return ["\\" + (rnd(3) + 1), backrefHack.slice(0)]; }, // backref
-    function(dr) { return regexGrouped("(", dr, ")");   }, // capturing: feeds \1 and exec() result
-    function(dr) { return regexGrouped("(?:", dr, ")"); }, // non-capturing
-    function(dr) { return regexGrouped("(?=", dr, ")"); }, // lookahead
+    function(dr) { return regexGrouped("(", dr, ")"); },    // capturing: feeds \1 and exec() result
+    function(dr) { return regexGrouped("(?:", dr, ")"); },  // non-capturing
+    function(dr) { return regexGrouped("(?=", dr, ")"); },  // lookahead
     function(dr) { return regexGrouped("(?!", dr, ")"); },  // lookahead(not)
   ],
 ];
@@ -215,10 +215,12 @@ function regexCharacter()
 {
   var [matcher, charcode] = Random.index(regexCharacterMakers)();
   switch (rnd(10)) {
-    case 0:  return [matcher, charcode + 32]; // lowercase
-    case 1:  return [matcher, charcode - 32]; // uppercase
+    /* eslint-disable no-multi-spaces */
+    case 0:  return [matcher, charcode + 32];   // lowercase
+    case 1:  return [matcher, charcode - 32];   // uppercase
     case 2:  return [matcher, regexCharCode()]; // some other character
     default: return [matcher, charcode];
+    /* eslint-enable no-multi-spaces */
   }
 }
 
@@ -253,6 +255,7 @@ function regexShortStringsWith(frequentChars) {
 
 var regexTermMakers =
   [
+    /* eslint-disable no-multi-spaces */
     function() { return regexCharacterClass(); },
     function() { var [re, cc] = regexCharacter();   return [re, regexOneCharStringsWith([String.fromCharCode(cc)])]; },
     function() { return [Random.index(regexBuiltInCharClasses), regexOneCharStringsWith(["0", "a", "_"])]; },
@@ -260,6 +263,7 @@ var regexTermMakers =
     function() { return [".",                                   regexOneCharStringsWith(["\n"])];     },
     function() { return [Random.index(["^", "$"]),              regexShortStringsWith(["\n"])];     },            // string boundaries or line boundaries (with /m)
     function() { return [Random.index(["\\b", "\\B"]),          regexShortStringsWith([" ", "\n", "a", "1"])]; }, // word boundaries
+    /* eslint-enable no-multi-spaces */
   ];
 
 function regexTerm()

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -38,7 +38,7 @@ function regexNumberOfMatches () { // eslint-disable-line require-jsdoc
 }
 
 function regexPattern (depth, parentWasQuantifier) { // eslint-disable-line require-jsdoc
-  if (depth == 0 || (rnd(depth) == 0)) { return regexTerm(); }
+  if (depth === 0 || (rnd(depth) === 0)) { return regexTerm(); }
 
   var dr = depth - 1;
 
@@ -121,7 +121,7 @@ function regexGrouped (prefix, dr, postfix) { // eslint-disable-line require-jsd
   var newStrings = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     newStrings[i] = rnd(5) ? strings[i] : "";
-    if (prefix == "(" && strings[i].length < 40 && rnd(3) === 0) {
+    if (prefix === "(" && strings[i].length < 40 && rnd(3) === 0) {
       backrefHack[i] = strings[i];
     }
   }
@@ -239,7 +239,7 @@ function regexCharacterClass () { // eslint-disable-line require-jsdoc
   var hi;
 
   for (var i = 0; i < ranges; ++i) {
-    if (rnd(100) == 0) {
+    if (rnd(100) === 0) {
       // Confuse things by tossing in an extra "-"
       re += "-";
       if (rnd(2)) {
@@ -247,7 +247,7 @@ function regexCharacterClass () { // eslint-disable-line require-jsdoc
       }
     }
 
-    if (rnd(3) == 1) {
+    if (rnd(3) === 1) {
       // Add a built-in class, like "\d"
       re += Random.index(regexBuiltInCharClasses);
       charBucket.push("a");
@@ -257,7 +257,7 @@ function regexCharacterClass () { // eslint-disable-line require-jsdoc
       // Add a range, like "a-z"
       var a = regexCharacter();
       var b = regexCharacter();
-      if ((a[1] <= b[1]) == !!rnd(10)) {
+      if ((a[1] <= b[1]) === !!rnd(10)) {
         [lo, hi] = [a, b];
       } else {
         [lo, hi] = [b, a];

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global Random, regexTermPair, rnd */
+
 /*********************************
  * GENERATING REGEXPS AND INPUTS *
  *********************************/

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported letters */
 /* global Random, regexTermPair, rnd */
 
 /* ***************************** *

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -140,15 +140,6 @@ var hexDigits = [
   "A", "B", "C", "D", "E", "F"
 ];
 
-function regexTerm () { // eslint-disable-line require-jsdoc
-  var [re, oneString] = regexTermPair();
-  var strings = [];
-  for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
-    strings[i] = rnd(5) ? oneString : regexTermPair()[1];
-  }
-  return [re, strings];
-}
-
 function regexCharCode () { // eslint-disable-line require-jsdoc
   return rnd(2) ? rnd(256) : rnd(65536);
 }
@@ -232,6 +223,16 @@ function regexTerm () { // eslint-disable-line require-jsdoc
   return Random.index(regexTermMakers)();
 }
 
+// Alternative regexTerm implementation that was no longer used
+// function regexTerm () { // eslint-disable-line require-jsdoc
+//   var [re, oneString] = regexTermPair();
+//   var strings = [];
+//   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
+//     strings[i] = rnd(5) ? oneString : regexTermPair()[1];
+//   }
+//   return [re, strings];
+// }
+
 // Returns a pair: [(regex char class), (POTENTIAL_MATCHES number of strings that might match)]
 // e.g. ["[a-z0-9]", ["a", "8", ...]]
 function regexCharacterClass () { // eslint-disable-line require-jsdoc
@@ -278,9 +279,9 @@ function regexCharacterClass () { // eslint-disable-line require-jsdoc
       charBucket.push(String.fromCharCode(lo[1] + rnd(Math.max(hi[1] - lo[1], 1)))); // something in the middle
     } else {
       // Add a single character
-      var a = regexCharacter();
-      re += a[0];
-      charBucket.push(String.fromCharCode(a[1]));
+      let c = regexCharacter();
+      re += c[0];
+      charBucket.push(String.fromCharCode(c[1]));
     }
   }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -32,12 +32,12 @@ for (var j = 0; j < POTENTIAL_MATCHES; ++j) {
   backrefHack[j] = "";
 }
 
-function regexNumberOfMatches () {
+function regexNumberOfMatches () { // eslint-disable-line require-jsdoc
   if (rnd(10)) { return rnd(5); }
   return Math.pow(2, rnd(40)) + rnd(3) - 1;
 }
 
-function regexPattern (depth, parentWasQuantifier) {
+function regexPattern (depth, parentWasQuantifier) { // eslint-disable-line require-jsdoc
   if (depth == 0 || (rnd(depth) == 0)) { return regexTerm(); }
 
   var dr = depth - 1;
@@ -75,7 +75,7 @@ var regexMakers =
   ]
 ];
 
-function quantifierHelper (pm, min, max, pms) {
+function quantifierHelper (pm, min, max, pms) { // eslint-disable-line require-jsdoc
   var repeats = Math.min(min + rnd(max - min + 5) - 2, 10);
   var returnValue = "";
   for (var i = 0; i < repeats; i++) {
@@ -84,14 +84,14 @@ function quantifierHelper (pm, min, max, pms) {
   return returnValue;
 }
 
-function regexQuantified (dr, operator, min, max) {
+function regexQuantified (dr, operator, min, max) { // eslint-disable-line require-jsdoc
   var [re, pms] = regexPattern(dr, true);
   var newpms = [];
   for (var i = 0; i < POTENTIAL_MATCHES; i++) { newpms[i] = quantifierHelper(pms[i], min, max, pms); }
   return [re + operator, newpms];
 }
 
-function regexConcatenation (dr) {
+function regexConcatenation (dr) { // eslint-disable-line require-jsdoc
   var [re1, strings1] = regexPattern(dr, false);
   var [re2, strings2] = regexPattern(dr, false);
   var newStrings = [];
@@ -104,7 +104,7 @@ function regexConcatenation (dr) {
   return [re1 + re2, newStrings];
 }
 
-function regexDisjunction (dr) {
+function regexDisjunction (dr) { // eslint-disable-line require-jsdoc
   var [re1, strings1] = regexPattern(dr, false);
   var [re2, strings2] = regexPattern(dr, false);
   var newStrings = [];
@@ -116,7 +116,7 @@ function regexDisjunction (dr) {
   return [re1 + "|" + re2, newStrings];
 }
 
-function regexGrouped (prefix, dr, postfix) {
+function regexGrouped (prefix, dr, postfix) { // eslint-disable-line require-jsdoc
   var [re, strings] = regexPattern(dr, false);
   var newStrings = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
@@ -140,7 +140,7 @@ var hexDigits = [
   "A", "B", "C", "D", "E", "F"
 ];
 
-function regexTerm () {
+function regexTerm () { // eslint-disable-line require-jsdoc
   var [re, oneString] = regexTermPair();
   var strings = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
@@ -149,7 +149,7 @@ function regexTerm () {
   return [re, strings];
 }
 
-function regexCharCode () {
+function regexCharCode () { // eslint-disable-line require-jsdoc
   return rnd(2) ? rnd(256) : rnd(65536);
 }
 
@@ -175,7 +175,7 @@ var regexCharacterMakers = Random.weighted([
   { w: 5, v: function () { var fourHex = Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits); return ["\\u" + fourHex, parseInt(fourHex, 16)]; } }
 ]);
 
-function regexCharacter () {
+function regexCharacter () { // eslint-disable-line require-jsdoc
   var [matcher, charcode] = Random.index(regexCharacterMakers)();
   switch (rnd(10)) {
     /* eslint-disable no-multi-spaces */
@@ -194,7 +194,7 @@ var regexBuiltInCharClasses = [
 ];
 
 // Returns POTENTIAL_MATCHES one-character strings, mostly consisting of the input characters
-function regexOneCharStringsWith (frequentChars) {
+function regexOneCharStringsWith (frequentChars) { // eslint-disable-line require-jsdoc
   var matches = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     matches.push(rnd(8) ? Random.index(frequentChars) : String.fromCharCode(regexCharCode()));
@@ -203,7 +203,7 @@ function regexOneCharStringsWith (frequentChars) {
 }
 
 // Returns POTENTIAL_MATCHES short strings, using the input characters a lot.
-function regexShortStringsWith (frequentChars) {
+function regexShortStringsWith (frequentChars) { // eslint-disable-line require-jsdoc
   var matches = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     var s = "";
@@ -228,13 +228,13 @@ var regexTermMakers =
     /* eslint-enable no-multi-spaces */
   ];
 
-function regexTerm () {
+function regexTerm () { // eslint-disable-line require-jsdoc
   return Random.index(regexTermMakers)();
 }
 
 // Returns a pair: [(regex char class), (POTENTIAL_MATCHES number of strings that might match)]
 // e.g. ["[a-z0-9]", ["a", "8", ...]]
-function regexCharacterClass () {
+function regexCharacterClass () { // eslint-disable-line require-jsdoc
   var ranges = rnd(5);
   var inRange = rnd(2);
   var charBucket = [String.fromCharCode(regexCharCode())]; // from which potenial matches will be drawn
@@ -288,7 +288,7 @@ function regexCharacterClass () {
   return [re, pickN(charBucket, POTENTIAL_MATCHES)];
 }
 
-function pickN (bucket, picks) {
+function pickN (bucket, picks) { // eslint-disable-line require-jsdoc
   var picked = [];
   for (var i = 0; i < picks; ++i) {
     picked.push(Random.index(bucket));

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -61,7 +61,11 @@ var regexMakers =
     function(dr) { return regexQuantified(dr, "*?", 0, 1); },
     function(dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + "}", x, x); },
     function(dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + ",}", x, x + rnd(10)); },
-    function(dr) { var min = regexNumberOfMatches(); var max = min + regexNumberOfMatches(); return regexQuantified(dr, "{" + min + "," + max + "}", min, max); },
+    function(dr) {
+      var min = regexNumberOfMatches();
+      var max = min + regexNumberOfMatches();
+      return regexQuantified(dr, "{" + min + "," + max + "}", min, max);
+    },
   ],
   [
     // Combinations: concatenation, disjunction
@@ -192,11 +196,16 @@ function regexCharCode()
 // These return matching pairs: [regex fragment, charcode for a matching one-character string].
 var regexCharacterMakers = Random.weighted([
   // Possibly incorrect
-  { w: 20, v: function() { var cc = regexCharCode(); return [      String.fromCharCode(cc), cc]; } }, // literal that doesn't need to be escaped (OR wrong)
-  { w: 4, v: function() { var cc = regexCharCode(); return ["\\" + String.fromCharCode(cc), cc]; } }, // escaped special character OR unnecessary escape (OR wrong)
-  { w: 1, v: function() { return ["\\0",  0]; } },  // null [ignoring the "do not follow this with another digit" rule which would turn it into an octal escape]
-  { w: 1, v: function() { return ["\\B", 66]; } },  // literal B -- ONLY within a character class. (Elsewhere, it's a "zero-width non-word boundary".)
-  { w: 1, v: function() { return ["\\b",  8]; } },  // backspace -- ONLY within a character class. (Elsewhere, it's a "zero-width word boundary".)
+  // literal that doesn't need to be escaped (OR wrong)
+  { w: 20, v: function() { var cc = regexCharCode(); return [      String.fromCharCode(cc), cc]; } },
+  // escaped special character OR unnecessary escape (OR wrong)
+  { w: 4, v: function() { var cc = regexCharCode(); return ["\\" + String.fromCharCode(cc), cc]; } },
+  // null [ignoring the "do not follow this with another digit" rule which would turn it into an octal escape]
+  { w: 1, v: function() { return ["\\0",  0]; } },
+  // literal B -- ONLY within a character class. (Elsewhere, it's a "zero-width non-word boundary".)
+  { w: 1, v: function() { return ["\\B", 66]; } },
+  // backspace -- ONLY within a character class. (Elsewhere, it's a "zero-width word boundary".)
+  { w: 1, v: function() { return ["\\b",  8]; } },
 
   // Correct, unless I screwed up
   { w: 1, v: function() { return ["\\t",  9]; } },  // tab
@@ -204,11 +213,21 @@ var regexCharacterMakers = Random.weighted([
   { w: 1, v: function() { return ["\\v", 11]; } },  // vertical tab
   { w: 1, v: function() { return ["\\f", 12]; } },  // form feed
   { w: 1, v: function() { return ["\\r", 13]; } },  // carriage return
-  { w: 5, v: function() { var controlCharacterCode = rnd(26) + 1; return ["\\c" + String.fromCharCode(64 + controlCharacterCode), controlCharacterCode]; } },
+  { w: 5, v: function() { var controlCharacterCode = rnd(26) + 1; return ["\\c"
+    + String.fromCharCode(64 + controlCharacterCode), controlCharacterCode];
+  } },
   // { w: 5, v: function() { var cc = regexCharCode(); return ["\\0" + cc.toString(8), cc] } }, // octal escape
-  { w: 5, v: function() { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\x" + twoHex, parseInt(twoHex, 16)]; } },
-  { w: 5, v: function() { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\u00" + twoHex, parseInt(twoHex, 16)]; } },
-  { w: 5, v: function() { var fourHex = Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits); return ["\\u" + fourHex, parseInt(fourHex, 16)]; } },
+  { w: 5, v: function() {
+    var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\x" + twoHex, parseInt(twoHex, 16)];
+  } },
+  { w: 5, v: function() {
+    var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\u00" + twoHex, parseInt(twoHex, 16)];
+  } },
+  { w: 5, v: function() {
+    var fourHex = Random.index(hexDigits) + Random.index(hexDigits)
+      + Random.index(hexDigits) + Random.index(hexDigits);
+    return ["\\u" + fourHex, parseInt(fourHex, 16)];
+  } },
 ]);
 
 function regexCharacter()
@@ -261,8 +280,11 @@ var regexTermMakers =
     function() { return [Random.index(regexBuiltInCharClasses), regexOneCharStringsWith(["0", "a", "_"])]; },
     function() { return ["[^]",                                 regexOneCharStringsWith(["\n"])];     },
     function() { return [".",                                   regexOneCharStringsWith(["\n"])];     },
-    function() { return [Random.index(["^", "$"]),              regexShortStringsWith(["\n"])];     },            // string boundaries or line boundaries (with /m)
-    function() { return [Random.index(["\\b", "\\B"]),          regexShortStringsWith([" ", "\n", "a", "1"])]; }, // word boundaries
+    // string boundaries or line boundaries (with /m)
+    function() { return [Random.index(["^", "$"]), regexShortStringsWith(["\n"])];     },
+    function() { return [Random.index(["\\b", "\\B"]),
+      regexShortStringsWith([" ", "\n", "a", "1"])];
+    }, // word boundaries
     /* eslint-enable no-multi-spaces */
   ];
 

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -147,7 +147,7 @@ function regexCharCode () { // eslint-disable-line require-jsdoc
 // These return matching pairs: [regex fragment, charcode for a matching one-character string].
 var regexCharacterMakers = Random.weighted([
   // Possibly incorrect
-  { w: 20, v: function () { var cc = regexCharCode(); return [ String.fromCharCode(cc), cc]; } }, // literal that doesn't need to be escaped (OR wrong)
+  { w: 20, v: function () { var cc = regexCharCode(); return [String.fromCharCode(cc), cc]; } }, // literal that doesn't need to be escaped (OR wrong)
   { w: 4, v: function () { var cc = regexCharCode(); return ["\\" + String.fromCharCode(cc), cc]; } }, // escaped special character OR unnecessary escape (OR wrong)
   { w: 1, v: function () { return ["\\0", 0]; } }, // null [ignoring the "do not follow this with another digit" rule which would turn it into an octal escape]
   { w: 1, v: function () { return ["\\B", 66]; } }, // literal B -- ONLY within a character class. (Elsewhere, it's a "zero-width non-word boundary".)

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -5,9 +5,9 @@
 
 /* global Random, regexTermPair, rnd */
 
-/*********************************
+/* ***************************** *
  * GENERATING REGEXPS AND INPUTS *
- *********************************/
+ * ***************************** */
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
@@ -204,7 +204,7 @@ var regexCharacterMakers = Random.weighted([
   { w: 1, v: function() { return ["\\f", 12]; } },  // form feed
   { w: 1, v: function() { return ["\\r", 13]; } },  // carriage return
   { w: 5, v: function() { var controlCharacterCode = rnd(26) + 1; return ["\\c" + String.fromCharCode(64 + controlCharacterCode), controlCharacterCode]; } },
-  //{ w: 5, v: function() { var cc = regexCharCode(); return ["\\0" + cc.toString(8), cc] } }, // octal escape
+  // { w: 5, v: function() { var cc = regexCharCode(); return ["\\0" + cc.toString(8), cc] } }, // octal escape
   { w: 5, v: function() { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\x" + twoHex, parseInt(twoHex, 16)]; } },
   { w: 5, v: function() { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\u00" + twoHex, parseInt(twoHex, 16)]; } },
   { w: 5, v: function() { var fourHex = Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits); return ["\\u" + fourHex, parseInt(fourHex, 16)]; } },

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -214,7 +214,7 @@ var regexCharacterMakers = Random.weighted([
 function regexCharacter()
 {
   var [matcher, charcode] = Random.index(regexCharacterMakers)();
-  switch(rnd(10)) {
+  switch (rnd(10)) {
     case 0:  return [matcher, charcode + 32]; // lowercase
     case 1:  return [matcher, charcode - 32]; // uppercase
     case 2:  return [matcher, regexCharCode()]; // some other character

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -61,11 +61,7 @@ var regexMakers =
     function(dr) { return regexQuantified(dr, "*?", 0, 1); },
     function(dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + "}", x, x); },
     function(dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + ",}", x, x + rnd(10)); },
-    function(dr) {
-      var min = regexNumberOfMatches();
-      var max = min + regexNumberOfMatches();
-      return regexQuantified(dr, "{" + min + "," + max + "}", min, max);
-    },
+    function(dr) { var min = regexNumberOfMatches(); var max = min + regexNumberOfMatches(); return regexQuantified(dr, "{" + min + "," + max + "}", min, max); },
   ],
   [
     // Combinations: concatenation, disjunction
@@ -196,16 +192,11 @@ function regexCharCode()
 // These return matching pairs: [regex fragment, charcode for a matching one-character string].
 var regexCharacterMakers = Random.weighted([
   // Possibly incorrect
-  // literal that doesn't need to be escaped (OR wrong)
-  { w: 20, v: function() { var cc = regexCharCode(); return [      String.fromCharCode(cc), cc]; } },
-  // escaped special character OR unnecessary escape (OR wrong)
-  { w: 4, v: function() { var cc = regexCharCode(); return ["\\" + String.fromCharCode(cc), cc]; } },
-  // null [ignoring the "do not follow this with another digit" rule which would turn it into an octal escape]
-  { w: 1, v: function() { return ["\\0",  0]; } },
-  // literal B -- ONLY within a character class. (Elsewhere, it's a "zero-width non-word boundary".)
-  { w: 1, v: function() { return ["\\B", 66]; } },
-  // backspace -- ONLY within a character class. (Elsewhere, it's a "zero-width word boundary".)
-  { w: 1, v: function() { return ["\\b",  8]; } },
+  { w: 20, v: function() { var cc = regexCharCode(); return [      String.fromCharCode(cc), cc]; } }, // literal that doesn't need to be escaped (OR wrong)
+  { w: 4, v: function() { var cc = regexCharCode(); return ["\\" + String.fromCharCode(cc), cc]; } }, // escaped special character OR unnecessary escape (OR wrong)
+  { w: 1, v: function() { return ["\\0",  0]; } },  // null [ignoring the "do not follow this with another digit" rule which would turn it into an octal escape]
+  { w: 1, v: function() { return ["\\B", 66]; } },  // literal B -- ONLY within a character class. (Elsewhere, it's a "zero-width non-word boundary".)
+  { w: 1, v: function() { return ["\\b",  8]; } },  // backspace -- ONLY within a character class. (Elsewhere, it's a "zero-width word boundary".)
 
   // Correct, unless I screwed up
   { w: 1, v: function() { return ["\\t",  9]; } },  // tab
@@ -213,21 +204,11 @@ var regexCharacterMakers = Random.weighted([
   { w: 1, v: function() { return ["\\v", 11]; } },  // vertical tab
   { w: 1, v: function() { return ["\\f", 12]; } },  // form feed
   { w: 1, v: function() { return ["\\r", 13]; } },  // carriage return
-  { w: 5, v: function() { var controlCharacterCode = rnd(26) + 1; return ["\\c"
-    + String.fromCharCode(64 + controlCharacterCode), controlCharacterCode];
-  } },
+  { w: 5, v: function() { var controlCharacterCode = rnd(26) + 1; return ["\\c" + String.fromCharCode(64 + controlCharacterCode), controlCharacterCode]; } },
   // { w: 5, v: function() { var cc = regexCharCode(); return ["\\0" + cc.toString(8), cc] } }, // octal escape
-  { w: 5, v: function() {
-    var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\x" + twoHex, parseInt(twoHex, 16)];
-  } },
-  { w: 5, v: function() {
-    var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\u00" + twoHex, parseInt(twoHex, 16)];
-  } },
-  { w: 5, v: function() {
-    var fourHex = Random.index(hexDigits) + Random.index(hexDigits)
-      + Random.index(hexDigits) + Random.index(hexDigits);
-    return ["\\u" + fourHex, parseInt(fourHex, 16)];
-  } },
+  { w: 5, v: function() { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\x" + twoHex, parseInt(twoHex, 16)]; } },
+  { w: 5, v: function() { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\u00" + twoHex, parseInt(twoHex, 16)]; } },
+  { w: 5, v: function() { var fourHex = Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits); return ["\\u" + fourHex, parseInt(fourHex, 16)]; } },
 ]);
 
 function regexCharacter()
@@ -280,11 +261,8 @@ var regexTermMakers =
     function() { return [Random.index(regexBuiltInCharClasses), regexOneCharStringsWith(["0", "a", "_"])]; },
     function() { return ["[^]",                                 regexOneCharStringsWith(["\n"])];     },
     function() { return [".",                                   regexOneCharStringsWith(["\n"])];     },
-    // string boundaries or line boundaries (with /m)
-    function() { return [Random.index(["^", "$"]), regexShortStringsWith(["\n"])];     },
-    function() { return [Random.index(["\\b", "\\B"]),
-      regexShortStringsWith([" ", "\n", "a", "1"])];
-    }, // word boundaries
+    function() { return [Random.index(["^", "$"]),              regexShortStringsWith(["\n"])];     },            // string boundaries or line boundaries (with /m)
+    function() { return [Random.index(["\\b", "\\B"]),          regexShortStringsWith([" ", "\n", "a", "1"])]; }, // word boundaries
     /* eslint-enable no-multi-spaces */
   ];
 

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -32,17 +32,13 @@ for (var j = 0; j < POTENTIAL_MATCHES; ++j) {
   backrefHack[j] = "";
 }
 
-function regexNumberOfMatches()
-{
-  if (rnd(10))
-    return rnd(5);
+function regexNumberOfMatches () {
+  if (rnd(10)) { return rnd(5); }
   return Math.pow(2, rnd(40)) + rnd(3) - 1;
 }
 
-function regexPattern(depth, parentWasQuantifier)
-{
-  if (depth == 0 || (rnd(depth) == 0))
-    return regexTerm();
+function regexPattern (depth, parentWasQuantifier) {
+  if (depth == 0 || (rnd(depth) == 0)) { return regexTerm(); }
 
   var dr = depth - 1;
 
@@ -55,102 +51,72 @@ var regexMakers =
 [
   [
     // Quantifiers
-    function(dr) { return regexQuantified(dr, "+", 1, rnd(10)); },
-    function(dr) { return regexQuantified(dr, "*", 0, rnd(10)); },
-    function(dr) { return regexQuantified(dr, "?", 0, 1); },
-    function(dr) { return regexQuantified(dr, "+?", 1, 1); },
-    function(dr) { return regexQuantified(dr, "*?", 0, 1); },
-    function(dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + "}", x, x); },
-    function(dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + ",}", x, x + rnd(10)); },
-    function(dr) { var min = regexNumberOfMatches(); var max = min + regexNumberOfMatches(); return regexQuantified(dr, "{" + min + "," + max + "}", min, max); },
+    function (dr) { return regexQuantified(dr, "+", 1, rnd(10)); },
+    function (dr) { return regexQuantified(dr, "*", 0, rnd(10)); },
+    function (dr) { return regexQuantified(dr, "?", 0, 1); },
+    function (dr) { return regexQuantified(dr, "+?", 1, 1); },
+    function (dr) { return regexQuantified(dr, "*?", 0, 1); },
+    function (dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + "}", x, x); },
+    function (dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + ",}", x, x + rnd(10)); },
+    function (dr) { var min = regexNumberOfMatches(); var max = min + regexNumberOfMatches(); return regexQuantified(dr, "{" + min + "," + max + "}", min, max); }
   ],
   [
     // Combinations: concatenation, disjunction
-    function(dr) { return regexConcatenation(dr); },
-    function(dr) { return regexDisjunction(dr); },
+    function (dr) { return regexConcatenation(dr); },
+    function (dr) { return regexDisjunction(dr); }
   ],
   [
     // Grouping
-    function(dr) { return ["\\" + (rnd(3) + 1), backrefHack.slice(0)]; }, // backref
-    function(dr) { return regexGrouped("(", dr, ")"); },    // capturing: feeds \1 and exec() result
-    function(dr) { return regexGrouped("(?:", dr, ")"); },  // non-capturing
-    function(dr) { return regexGrouped("(?=", dr, ")"); },  // lookahead
-    function(dr) { return regexGrouped("(?!", dr, ")"); },  // lookahead(not)
-  ],
+    function (dr) { return ["\\" + (rnd(3) + 1), backrefHack.slice(0)]; }, // backref
+    function (dr) { return regexGrouped("(", dr, ")"); }, // capturing: feeds \1 and exec() result
+    function (dr) { return regexGrouped("(?:", dr, ")"); }, // non-capturing
+    function (dr) { return regexGrouped("(?=", dr, ")"); }, // lookahead
+    function (dr) { return regexGrouped("(?!", dr, ")"); } // lookahead(not)
+  ]
 ];
 
-
-function quantifierHelper(pm, min, max, pms)
-{
+function quantifierHelper (pm, min, max, pms) {
   var repeats = Math.min(min + rnd(max - min + 5) - 2, 10);
   var returnValue = "";
-  for (var i = 0; i < repeats; i++)
-  {
-    if (rnd(100) < 80)
-      returnValue = returnValue + pm;
-    else
-      returnValue = returnValue + Random.index(pms);
+  for (var i = 0; i < repeats; i++) {
+    if (rnd(100) < 80) { returnValue = returnValue + pm; } else { returnValue = returnValue + Random.index(pms); }
   }
   return returnValue;
 }
 
-function regexQuantified(dr, operator, min, max)
-{
+function regexQuantified (dr, operator, min, max) {
   var [re, pms] = regexPattern(dr, true);
   var newpms = [];
-  for (var i = 0; i < POTENTIAL_MATCHES; i++)
-    newpms[i] = quantifierHelper(pms[i], min, max, pms);
+  for (var i = 0; i < POTENTIAL_MATCHES; i++) { newpms[i] = quantifierHelper(pms[i], min, max, pms); }
   return [re + operator, newpms];
 }
 
-
-function regexConcatenation(dr)
-{
+function regexConcatenation (dr) {
   var [re1, strings1] = regexPattern(dr, false);
   var [re2, strings2] = regexPattern(dr, false);
   var newStrings = [];
 
-  for (var i = 0; i < POTENTIAL_MATCHES; i++)
-  {
+  for (var i = 0; i < POTENTIAL_MATCHES; i++) {
     var chance = rnd(100);
-    if (chance < 10)
-      newStrings[i] = "";
-    else if (chance < 20)
-      newStrings[i] = strings1[i];
-    else if (chance < 30)
-      newStrings[i] = strings2[i];
-    else if (chance < 65)
-      newStrings[i] = strings1[i] + strings2[i];
-    else
-      newStrings[i] = Random.index(strings1) + Random.index(strings2);
+    if (chance < 10) { newStrings[i] = ""; } else if (chance < 20) { newStrings[i] = strings1[i]; } else if (chance < 30) { newStrings[i] = strings2[i]; } else if (chance < 65) { newStrings[i] = strings1[i] + strings2[i]; } else { newStrings[i] = Random.index(strings1) + Random.index(strings2); }
   }
 
   return [re1 + re2, newStrings];
 }
 
-function regexDisjunction(dr)
-{
+function regexDisjunction (dr) {
   var [re1, strings1] = regexPattern(dr, false);
   var [re2, strings2] = regexPattern(dr, false);
   var newStrings = [];
 
-  for (var i = 0; i < POTENTIAL_MATCHES; i++)
-  {
+  for (var i = 0; i < POTENTIAL_MATCHES; i++) {
     var chance = rnd(100);
-    if (chance < 10)
-      newStrings[i] = "";
-    else if (chance < 20)
-      newStrings[i] = Random.index(strings1) + Random.index(strings2);
-    else if (chance < 60)
-      newStrings[i] = strings1[i];
-    else
-      newStrings[i] = strings2[i];
+    if (chance < 10) { newStrings[i] = ""; } else if (chance < 20) { newStrings[i] = Random.index(strings1) + Random.index(strings2); } else if (chance < 60) { newStrings[i] = strings1[i]; } else { newStrings[i] = strings2[i]; }
   }
   return [re1 + "|" + re2, newStrings];
 }
 
-function regexGrouped(prefix, dr, postfix)
-{
+function regexGrouped (prefix, dr, postfix) {
   var [re, strings] = regexPattern(dr, false);
   var newStrings = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
@@ -162,7 +128,6 @@ function regexGrouped(prefix, dr, postfix)
   return [prefix + re + postfix, newStrings];
 }
 
-
 var letters = [
   "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
   "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"
@@ -172,11 +137,10 @@ var hexDigits = [
   "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
   "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
   "a", "b", "c", "d", "e", "f",
-  "A", "B", "C", "D", "E", "F",
+  "A", "B", "C", "D", "E", "F"
 ];
 
-function regexTerm()
-{
+function regexTerm () {
   var [re, oneString] = regexTermPair();
   var strings = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
@@ -185,35 +149,33 @@ function regexTerm()
   return [re, strings];
 }
 
-function regexCharCode()
-{
+function regexCharCode () {
   return rnd(2) ? rnd(256) : rnd(65536);
 }
 
 // These return matching pairs: [regex fragment, charcode for a matching one-character string].
 var regexCharacterMakers = Random.weighted([
   // Possibly incorrect
-  { w: 20, v: function() { var cc = regexCharCode(); return [      String.fromCharCode(cc), cc]; } }, // literal that doesn't need to be escaped (OR wrong)
-  { w: 4, v: function() { var cc = regexCharCode(); return ["\\" + String.fromCharCode(cc), cc]; } }, // escaped special character OR unnecessary escape (OR wrong)
-  { w: 1, v: function() { return ["\\0",  0]; } },  // null [ignoring the "do not follow this with another digit" rule which would turn it into an octal escape]
-  { w: 1, v: function() { return ["\\B", 66]; } },  // literal B -- ONLY within a character class. (Elsewhere, it's a "zero-width non-word boundary".)
-  { w: 1, v: function() { return ["\\b",  8]; } },  // backspace -- ONLY within a character class. (Elsewhere, it's a "zero-width word boundary".)
+  { w: 20, v: function () { var cc = regexCharCode(); return [ String.fromCharCode(cc), cc]; } }, // literal that doesn't need to be escaped (OR wrong)
+  { w: 4, v: function () { var cc = regexCharCode(); return ["\\" + String.fromCharCode(cc), cc]; } }, // escaped special character OR unnecessary escape (OR wrong)
+  { w: 1, v: function () { return ["\\0", 0]; } }, // null [ignoring the "do not follow this with another digit" rule which would turn it into an octal escape]
+  { w: 1, v: function () { return ["\\B", 66]; } }, // literal B -- ONLY within a character class. (Elsewhere, it's a "zero-width non-word boundary".)
+  { w: 1, v: function () { return ["\\b", 8]; } }, // backspace -- ONLY within a character class. (Elsewhere, it's a "zero-width word boundary".)
 
   // Correct, unless I screwed up
-  { w: 1, v: function() { return ["\\t",  9]; } },  // tab
-  { w: 1, v: function() { return ["\\n", 10]; } },  // line break
-  { w: 1, v: function() { return ["\\v", 11]; } },  // vertical tab
-  { w: 1, v: function() { return ["\\f", 12]; } },  // form feed
-  { w: 1, v: function() { return ["\\r", 13]; } },  // carriage return
-  { w: 5, v: function() { var controlCharacterCode = rnd(26) + 1; return ["\\c" + String.fromCharCode(64 + controlCharacterCode), controlCharacterCode]; } },
+  { w: 1, v: function () { return ["\\t", 9]; } }, // tab
+  { w: 1, v: function () { return ["\\n", 10]; } }, // line break
+  { w: 1, v: function () { return ["\\v", 11]; } }, // vertical tab
+  { w: 1, v: function () { return ["\\f", 12]; } }, // form feed
+  { w: 1, v: function () { return ["\\r", 13]; } }, // carriage return
+  { w: 5, v: function () { var controlCharacterCode = rnd(26) + 1; return ["\\c" + String.fromCharCode(64 + controlCharacterCode), controlCharacterCode]; } },
   // { w: 5, v: function() { var cc = regexCharCode(); return ["\\0" + cc.toString(8), cc] } }, // octal escape
-  { w: 5, v: function() { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\x" + twoHex, parseInt(twoHex, 16)]; } },
-  { w: 5, v: function() { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\u00" + twoHex, parseInt(twoHex, 16)]; } },
-  { w: 5, v: function() { var fourHex = Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits); return ["\\u" + fourHex, parseInt(fourHex, 16)]; } },
+  { w: 5, v: function () { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\x" + twoHex, parseInt(twoHex, 16)]; } },
+  { w: 5, v: function () { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\u00" + twoHex, parseInt(twoHex, 16)]; } },
+  { w: 5, v: function () { var fourHex = Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits); return ["\\u" + fourHex, parseInt(fourHex, 16)]; } }
 ]);
 
-function regexCharacter()
-{
+function regexCharacter () {
   var [matcher, charcode] = Random.index(regexCharacterMakers)();
   switch (rnd(10)) {
     /* eslint-disable no-multi-spaces */
@@ -225,15 +187,14 @@ function regexCharacter()
   }
 }
 
-
 var regexBuiltInCharClasses = [
   "\\d", "\\D", // digit
   "\\s", "\\S", // space
-  "\\w", "\\W", // "word" character (alphanumeric plus underscore)
+  "\\w", "\\W" // "word" character (alphanumeric plus underscore)
 ];
 
 // Returns POTENTIAL_MATCHES one-character strings, mostly consisting of the input characters
-function regexOneCharStringsWith(frequentChars) {
+function regexOneCharStringsWith (frequentChars) {
   var matches = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     matches.push(rnd(8) ? Random.index(frequentChars) : String.fromCharCode(regexCharCode()));
@@ -242,7 +203,7 @@ function regexOneCharStringsWith(frequentChars) {
 }
 
 // Returns POTENTIAL_MATCHES short strings, using the input characters a lot.
-function regexShortStringsWith(frequentChars) {
+function regexShortStringsWith (frequentChars) {
   var matches = [];
   for (var i = 0; i < POTENTIAL_MATCHES; ++i) {
     var s = "";
@@ -257,25 +218,23 @@ function regexShortStringsWith(frequentChars) {
 var regexTermMakers =
   [
     /* eslint-disable no-multi-spaces */
-    function() { return regexCharacterClass(); },
-    function() { var [re, cc] = regexCharacter();   return [re, regexOneCharStringsWith([String.fromCharCode(cc)])]; },
-    function() { return [Random.index(regexBuiltInCharClasses), regexOneCharStringsWith(["0", "a", "_"])]; },
-    function() { return ["[^]",                                 regexOneCharStringsWith(["\n"])];     },
-    function() { return [".",                                   regexOneCharStringsWith(["\n"])];     },
-    function() { return [Random.index(["^", "$"]),              regexShortStringsWith(["\n"])];     },            // string boundaries or line boundaries (with /m)
-    function() { return [Random.index(["\\b", "\\B"]),          regexShortStringsWith([" ", "\n", "a", "1"])]; }, // word boundaries
+    function () { return regexCharacterClass(); },
+    function () { var [re, cc] = regexCharacter();   return [re, regexOneCharStringsWith([String.fromCharCode(cc)])]; },
+    function () { return [Random.index(regexBuiltInCharClasses), regexOneCharStringsWith(["0", "a", "_"])]; },
+    function () { return ["[^]",                                 regexOneCharStringsWith(["\n"])];     },
+    function () { return [".",                                   regexOneCharStringsWith(["\n"])];     },
+    function () { return [Random.index(["^", "$"]),              regexShortStringsWith(["\n"])];     },            // string boundaries or line boundaries (with /m)
+    function () { return [Random.index(["\\b", "\\B"]),          regexShortStringsWith([" ", "\n", "a", "1"])]; } // word boundaries
     /* eslint-enable no-multi-spaces */
   ];
 
-function regexTerm()
-{
+function regexTerm () {
   return Random.index(regexTermMakers)();
 }
 
 // Returns a pair: [(regex char class), (POTENTIAL_MATCHES number of strings that might match)]
 // e.g. ["[a-z0-9]", ["a", "8", ...]]
-function regexCharacterClass()
-{
+function regexCharacterClass () {
   var ranges = rnd(5);
   var inRange = rnd(2);
   var charBucket = [String.fromCharCode(regexCharCode())]; // from which potenial matches will be drawn
@@ -329,8 +288,7 @@ function regexCharacterClass()
   return [re, pickN(charBucket, POTENTIAL_MATCHES)];
 }
 
-function pickN(bucket, picks)
-{
+function pickN (bucket, picks) {
   var picked = [];
   for (var i = 0; i < picks; ++i) {
     picked.push(Random.index(bucket));

--- a/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
@@ -12,9 +12,9 @@ function makeRegisterStompFunction(d, b, pure)
 {
   var args = [];
   var nArgs = (rnd(10) ? rnd(20) : rnd(100)) + 1;
-  for (var i = 0; i < nArgs; ++i) 
+  for (var i = 0; i < nArgs; ++i) {
     args.push("a" + i);
-  
+  }
 
   var bv = b.concat(args);
 
@@ -42,7 +42,7 @@ function makeRegisterStompBody(d, b, pure)
     return value() + Random.index([" + ", " - ", " / ", " * ", " % ", " | ", " & ", " ^ "]) + value();
   }
 
-  while (rnd(100)) 
+  while (rnd(100)) {
     if (bv.length == 0 || rnd(4)) {
       var newVar = "r" + lastRVar;
       ++lastRVar;
@@ -53,7 +53,7 @@ function makeRegisterStompBody(d, b, pure)
     } else {
       s += Random.index(bv) + " = " + expr() + "; ";
     }
-  
+  }
 
   return s;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
@@ -9,8 +9,7 @@
 // Using up all the registers can find bugs where a caller does not store its
 // registers properly, or a callee violates an ABI.
 
-function makeRegisterStompFunction(d, b, pure)
-{
+function makeRegisterStompFunction (d, b, pure) {
   var args = [];
   var nArgs = (rnd(10) ? rnd(20) : rnd(100)) + 1;
   for (var i = 0; i < nArgs; ++i) {
@@ -27,19 +26,16 @@ function makeRegisterStompFunction(d, b, pure)
   );
 }
 
-function makeRegisterStompBody(d, b, pure)
-{
+function makeRegisterStompBody (d, b, pure) {
   var bv = b.slice(0);
   var lastRVar = 0;
   var s = "";
 
-  function value()
-  {
+  function value () {
     return rnd(3) && bv.length ? Random.index(bv) : "" + rnd(10);
   }
 
-  function expr()
-  {
+  function expr () {
     return value() + Random.index([" + ", " - ", " / ", " * ", " % ", " | ", " & ", " ^ "]) + value();
   }
 
@@ -58,4 +54,3 @@ function makeRegisterStompBody(d, b, pure)
 
   return s;
 }
-

--- a/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
@@ -40,7 +40,7 @@ function makeRegisterStompBody (d, b, pure) { // eslint-disable-line require-jsd
   }
 
   while (rnd(100)) {
-    if (bv.length === 0 || rnd(4)) {
+    if (bv.length == 0 || rnd(4)) {
       var newVar = "r" + lastRVar;
       ++lastRVar;
       s += "var " + newVar + " = " + expr() + "; ";

--- a/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
@@ -40,7 +40,7 @@ function makeRegisterStompBody (d, b, pure) { // eslint-disable-line require-jsd
   }
 
   while (rnd(100)) {
-    if (bv.length == 0 || rnd(4)) {
+    if (bv.length === 0 || rnd(4)) {
       var newVar = "r" + lastRVar;
       ++lastRVar;
       s += "var " + newVar + " = " + expr() + "; ";

--- a/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported makeRegisterStompFunction */
 /* global Random, rnd */
 
 // Using up all the registers can find bugs where a caller does not store its

--- a/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global Random, rnd */
+
 // Using up all the registers can find bugs where a caller does not store its
 // registers properly, or a callee violates an ABI.
 

--- a/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
@@ -12,9 +12,9 @@ function makeRegisterStompFunction(d, b, pure)
 {
   var args = [];
   var nArgs = (rnd(10) ? rnd(20) : rnd(100)) + 1;
-  for (var i = 0; i < nArgs; ++i) {
+  for (var i = 0; i < nArgs; ++i) 
     args.push("a" + i);
-  }
+  
 
   var bv = b.concat(args);
 
@@ -42,7 +42,7 @@ function makeRegisterStompBody(d, b, pure)
     return value() + Random.index([" + ", " - ", " / ", " * ", " % ", " | ", " & ", " ^ "]) + value();
   }
 
-  while (rnd(100)) {
+  while (rnd(100)) 
     if (bv.length == 0 || rnd(4)) {
       var newVar = "r" + lastRVar;
       ++lastRVar;
@@ -53,7 +53,7 @@ function makeRegisterStompBody(d, b, pure)
     } else {
       s += Random.index(bv) + " = " + expr() + "; ";
     }
-  }
+  
 
   return s;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
@@ -9,7 +9,7 @@
 // Using up all the registers can find bugs where a caller does not store its
 // registers properly, or a callee violates an ABI.
 
-function makeRegisterStompFunction (d, b, pure) {
+function makeRegisterStompFunction (d, b, pure) { // eslint-disable-line require-jsdoc
   var args = [];
   var nArgs = (rnd(10) ? rnd(20) : rnd(100)) + 1;
   for (var i = 0; i < nArgs; ++i) {
@@ -26,16 +26,16 @@ function makeRegisterStompFunction (d, b, pure) {
   );
 }
 
-function makeRegisterStompBody (d, b, pure) {
+function makeRegisterStompBody (d, b, pure) { // eslint-disable-line require-jsdoc
   var bv = b.slice(0);
   var lastRVar = 0;
   var s = "";
 
-  function value () {
+  function value () { // eslint-disable-line require-jsdoc
     return rnd(3) && bv.length ? Random.index(bv) : "" + rnd(10);
   }
 
-  function expr () {
+  function expr () { // eslint-disable-line require-jsdoc
     return value() + Random.index([" + ", " - ", " / ", " * ", " % ", " | ", " & ", " ^ "]) + value();
   }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -3,6 +3,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global builtinFunctions, builtinObjects, builtinProperties, loopCount, makeAsmJSFunction, makeAsmJSModule */
+/* global makeBoolean, makeExpr, makeFunction, makeFunctionBody, makeFunOnCallChain, makeGlobal, makeIterable */
+/* global makePropertyDescriptor, makePropertyName, makeRegex, makeRegexUseBlock, makeRegisterStompFunction */
+/* global makeScriptForEval, makeStatement, Random, rnd, simpleSource, typedArrayConstructors, uniqueVarName */
+/* global varBinder */
+
 /***********************
  * TEST BUILT-IN TYPES *
  ***********************/

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -146,7 +146,7 @@ var makeEvilCallback;
     )
       .replace(/X/g, m())
       .replace(/Z/g, function() {
-        switch (rnd(20)){
+        switch (rnd(20)) {
           case 0:  return "return " + m();
           case 1:  return "throw " + m();
           default: return makeBuilderStatement(d - 2, b);

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -67,8 +67,7 @@ var makeEvilCallback;
         "Object.defineProperty(" +
         (rnd(8)?"this":m("og")) + ", " +
         simpleSource(m(t)) + ", " +
-        "{ " + propertyDescriptorPrefix(d-1, b) + " get: function() { " +
-        (rnd(8)?"":makeBuilderStatement(d-1, b)) + " return " + rhs + "; } }" +
+        "{ " + propertyDescriptorPrefix(d-1, b) + " get: function() { " + (rnd(8)?"":makeBuilderStatement(d-1, b)) + " return " + rhs + "; } }" +
       ");"
       );
       case 1:  return Random.index(varBinder) + m(t) + " = " + rhs + ";";
@@ -115,19 +114,12 @@ var makeEvilCallback;
   }
 
   var builderFunctionMakers = Random.weighted([
-    { w: 9,  v: function(d, b) { return "(function() { " + makeBuilderStatements(d, b) +
-      " return " + m() + "; })";
-    } },
+    { w: 9,  v: function(d, b) { return "(function() { " + makeBuilderStatements(d, b) + " return " + m() + "; })"; } },
     { w: 1,  v: function(d, b) { return "(function() { " + makeBuilderStatements(d, b) + " throw " + m() + "; })"; } },
-    // a function that just makes one call is begging to be inlined
-    { w: 1,  v: function(d, b) { return "(function(j) { " + m("f") + "(j); })"; } },
+    { w: 1,  v: function(d, b) { return "(function(j) { " + m("f") + "(j); })"; } }, // a function that just makes one call is begging to be inlined
     // The following pair create and use boolean-using functions.
-    { w: 4,  v: function(d, b) { return "(function(j) { if (j) { " + makeBuilderStatements(d, b)
-      + " } else { " + makeBuilderStatements(d, b) + " } })";
-    } },
-    { w: 4,  v: function(d, b) { return "(function() { for (var j=0;j<" + loopCount() + ";++j) { "
-      + m("f") + "(j%"+(2+rnd(4))+"=="+rnd(2)+"); } })";
-    } },
+    { w: 4,  v: function(d, b) { return "(function(j) { if (j) { " + makeBuilderStatements(d, b) + " } else { " + makeBuilderStatements(d, b) + " } })"; } },
+    { w: 4,  v: function(d, b) { return "(function() { for (var j=0;j<" + loopCount() + ";++j) { " + m("f") + "(j%"+(2+rnd(4))+"=="+rnd(2)+"); } })"; } },
     { w: 1,  v: function(d, b) { return Random.index(builtinFunctions) + ".bind(" + m() + ")"; } },
     { w: 5,  v: function(d, b) { return m("f"); } },
     { w: 3,  v: makeCounterClosure },
@@ -140,15 +132,12 @@ var makeEvilCallback;
     return (Random.index(builderFunctionMakers))(d - 1, b);
   };
 
-  var handlerTraps = ["getOwnPropertyDescriptor", "defineProperty", "getOwnPropertyNames", "delete", "fix",
-    "has", "hasOwn", "get", "set", "iterate", "enumerate", "keys"
-  ];
+  var handlerTraps = ["getOwnPropertyDescriptor", "defineProperty", "getOwnPropertyNames", "delete", "fix", "has", "hasOwn", "get", "set", "iterate", "enumerate", "keys"];
 
   function forwardingHandler(d, b) {
     return (
       "({"+
-        "getOwnPropertyDescriptor: function(name) { Z; var desc = Object.getOwnPropertyDescriptor(X); " +
-        "desc.configurable = true; return desc; }, " +
+        "getOwnPropertyDescriptor: function(name) { Z; var desc = Object.getOwnPropertyDescriptor(X); desc.configurable = true; return desc; }, " +
         "defineProperty: function(name, desc) { Z; Object.defineProperty(X, name, desc); }, " +
         "getOwnPropertyNames: function() { Z; return Object.getOwnPropertyNames(X); }, " +
         "delete: function(name) { Z; return delete X[name]; }, " +
@@ -278,78 +267,45 @@ var makeEvilCallback;
     { w: 8,  v: function(d, b) { return assign(d, b, "v", m("at") + ".length"); } },
     { w: 4,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + " = " + val(d, b) + ";"; } },
     { w: 4,  v: function(d, b) { return val(d, b) + " = " + m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
-    // a read-only arguments object
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", makeFunOnCallChain(d, b) + ".arguments"); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "a", makeFunOnCallChain(d, b) + ".arguments"); } }, // a read-only arguments object
     { w: 1,  v: function(d, b) { return assign(d, b, "a", "arguments"); } }, // a read-write arguments object
 
     // Array indexing
     { w: 3,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
     { w: 3,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "] = " + makeExpr(d, b) + ";"; } },
-    { w: 1,  v: function(d, b) { return "/*ADP-1*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", "
-      + makePropertyDescriptor(d, b) + ");";
-    } },
-    { w: 1,  v: function(d, b) { return "/*ADP-2*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { "
-      + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });";
-    } },
-    { w: 1,  v: function(d, b) { return "/*ADP-3*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { "
-      + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; }
-    },
+    { w: 1,  v: function(d, b) { return "/*ADP-1*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
+    { w: 1,  v: function(d, b) { return "/*ADP-2*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
+    { w: 1,  v: function(d, b) { return "/*ADP-3*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
 
     // Array mutators
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "push",
-      severalargs(function() { return val(d, b); })) + ";";
-    } },
+    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "push", severalargs(function() { return val(d, b); })) + ";"; } },
     { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "pop", []) + ";"; } },
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "unshift",
-      severalargs(function() { return val(d, b); })) + ";";
-    } },
+    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "unshift", severalargs(function() { return val(d, b); })) + ";"; } },
     { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "shift", []) + ";"; } },
     { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "reverse", []) + ";"; } },
     { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "sort", [makeEvilCallback(d, b)]) + ";"; } },
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "splice", [
-      arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b)
-    ]) + ";"; } },
+    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "splice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b)]) + ";"; } },
     // Array accessors
     { w: 1,  v: function(d, b) { return assign(d, b, "s", method(d, b, "Array", m("a"), "join", [m("s")])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b,
-      "Array", m("a"), "concat", severalargs(function() { return m("at"); })
-    )); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "slice",[
-      arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b) - arrayIndex(d, b)
-    ])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "concat", severalargs(function() { return m("at"); }))); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "slice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b) - arrayIndex(d, b)])); } },
 
     // Array iterators
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "forEach", [
-      makeEvilCallback(d, b)
-    ]) + ";"; } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "map", [
-      makeEvilCallback(d, b)
-    ])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "filter", [
-      makeEvilCallback(d, b)
-    ])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "some", [
-      makeEvilCallback(d, b)
-    ])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "every", [
-      makeEvilCallback(d, b)
-    ])); } },
+    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "forEach", [makeEvilCallback(d, b)]) + ";"; } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "map", [makeEvilCallback(d, b)])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "filter", [makeEvilCallback(d, b)])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "some", [makeEvilCallback(d, b)])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "every", [makeEvilCallback(d, b)])); } },
 
     // Array reduction, either with a starting value or with the default of starting with the first two elements.
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"),
-      Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b)]
-    )); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"),
-      Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b), val(d, b)]
-    )); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b)])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b), val(d, b)])); } },
 
     // Typed Objects (aka Binary Data)
-    // http://wiki.ecmascript.org/doku.php?id=harmony:typed_objects
-    // (does not match what's in spidermonkey as of 2014-02-11)
+    // http://wiki.ecmascript.org/doku.php?id=harmony:typed_objects (does not match what's in spidermonkey as of 2014-02-11)
     // Do I need to keep track of 'types', 'objects of those types', and 'arrays of objects of those types'?
     // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".flatten()"); } },
-    // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d")
-    //   + ".partition(" + (rnd(2)?m("v"):rnd(10)) + ")"); } },
+    // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".partition(" + (rnd(2)?m("v"):rnd(10)) + ")"); } },
 
     // o: Object
     { w: 1,  v: function(d, b) { return assign(d, b, "o", "{}"); } },
@@ -386,20 +342,15 @@ var makeEvilCallback;
     // b: Buffer
     { w: 1,  v: function(d, b) { return assign(d, b, "b", "new " + arrayBufferType() + "(" + bufsize() + ")"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "b", m("t") + ".buffer"); } },
-    { w: 1,  v: function(d, b) { return "neuter(" + m("b") + ", "
-      + (rnd(2) ? '"same-data"' : '"change-data"') + ");"; } },
+    { w: 1,  v: function(d, b) { return "neuter(" + m("b") + ", " + (rnd(2) ? '"same-data"' : '"change-data"') + ");"; } },
 
     // t: Typed arrays, aka ArrayBufferViews
     // Can be constructed using a length, typed array, sequence (e.g. array), or buffer with optional offsets!
-    { w: 1,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors)
-      + "(" + arrayIndex(d, b) + ")"); } },
-    { w: 3,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors)
-      + "(" + m("abt") + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors)
-      + "(" + m("b") + ", " + bufsize() + ", " + arrayIndex(d, b) + ")"); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + arrayIndex(d, b) + ")"); } },
+    { w: 3,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + m("abt") + ")"); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + m("b") + ", " + bufsize() + ", " + arrayIndex(d, b) + ")"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ", "
-      + arrayIndex(d, b) + ")"); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ", " + arrayIndex(d, b) + ")"); } },
     { w: 3,  v: function(d, b) { return m("t") + ".set(" + m("at") + ", " + arrayIndex(d, b) + ");"; } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", m("tb") + ".byteLength"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", m("t") + ".byteOffset"); } },
@@ -409,12 +360,10 @@ var makeEvilCallback;
     { w: 1,  v: function(d, b) { return assign(d, b, "h", "{}"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "h", forwardingHandler(d, b)); } },
     { w: 1,  v: function(d, b) { return "delete " + m("h") + "." + Random.index(handlerTraps) + ";"; } },
-    { w: 4,  v: function(d, b) { return m("h") + "." + Random.index(handlerTraps) + " = "
-      + makeEvilCallback(d, b) + ";"; } },
+    { w: 4,  v: function(d, b) { return m("h") + "." + Random.index(handlerTraps) + " = " + makeEvilCallback(d, b) + ";"; } },
     { w: 4,  v: function(d, b) { return m("h") + "." + Random.index(handlerTraps) + " = " + m("f") + ";"; } },
     { w: 1,  v: function(d, b) { return assign(d, b, null, "Proxy.create(" + m("h") + ", " + m() + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "f", "Proxy.createFunction(" + m("h") + ", "
-      + m("f") + ", " + m("f") + ")"); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "f", "Proxy.createFunction(" + m("h") + ", " + m("f") + ", " + m("f") + ")"); } },
 
     // r: regexp
     // The separate regex code is better at matching strings with regexps, but this is better at reusing the objects.
@@ -423,34 +372,22 @@ var makeEvilCallback;
     { w: 1,  v: function(d, b) { return assign(d, b, "a", m("r") + ".exec(" + m("s") + ")"); } },
     { w: 3,  v: function(d, b) { return makeRegexUseBlock(d, b, m("r")); } },
     { w: 3,  v: function(d, b) { return makeRegexUseBlock(d, b, m("r"), m("s")); } },
-    { w: 3,  v: function(d, b) { return assign(d, b, "v", m("r") + "."
-      + Random.index(builtinObjects["RegExp.prototype"])
-    ); } },
+    { w: 3,  v: function(d, b) { return assign(d, b, "v", m("r") + "." + Random.index(builtinObjects["RegExp.prototype"])); } },
 
     // g: global or sandbox
     { w: 1,  v: function(d, b) { return assign(d, b, "g", makeGlobal(d, b)); } },
     { w: 5,  v: function(d, b) { return assign(d, b, "v", m("g") + ".eval(" + strToEval(d, b) + ")"); } },
     { w: 5,  v: function(d, b) { return assign(d, b, "v", "evalcx(" + strToEval(d, b) + ", " + m("g") + ")"); } },
-    { w: 5,  v: function(d, b) { return assign(d, b, "v", "evaluate(" + strToEval(d, b) + ", "
-      + evaluateFlags(d, b) + ")"
-    ); } },
+    { w: 5,  v: function(d, b) { return assign(d, b, "v", "evaluate(" + strToEval(d, b) + ", " + evaluateFlags(d, b) + ")"); } },
     { w: 2,  v: function(d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ");"; } },
-    { w: 3,  v: function(d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ", "
-      + evaluateFlags(d, b) + ");";
-    } },
+    { w: 3,  v: function(d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ", " + evaluateFlags(d, b) + ");"; } },
     { w: 5,  v: function(d, b) { return assign(d, b, "v", m("g") + ".runOffThreadScript()"); } },
     { w: 3,  v: function(d, b) { return "(void schedulegc(" + m("g") + "));"; } },
 
     // Mix builtins between globals
-    { w: 3,  v: function(d, b) { return "/*MXX1*/" + assign(d, b, "o", m("g") + "."
-      + Random.index(builtinProperties)
-    ); } },
-    { w: 3,  v: function(d, b) { return "/*MXX2*/" + m("g") + "." + Random.index(builtinProperties) + " = "
-      + m() + ";";
-    } },
-    { w: 3,  v: function(d, b) { var prop = Random.index(builtinProperties);
-      return "/*MXX3*/" + m("g") + "." + prop + " = " + m("g") + "." + prop + ";";
-    } },
+    { w: 3,  v: function(d, b) { return "/*MXX1*/" + assign(d, b, "o", m("g") + "." + Random.index(builtinProperties)); } },
+    { w: 3,  v: function(d, b) { return "/*MXX2*/" + m("g") + "." + Random.index(builtinProperties) + " = " + m() + ";"; } },
+    { w: 3,  v: function(d, b) { var prop = Random.index(builtinProperties); return "/*MXX3*/" + m("g") + "." + prop + " = " + m("g") + "." + prop + ";"; } },
 
     // f: function (?)
     // Could probably do better with args / b
@@ -459,27 +396,16 @@ var makeEvilCallback;
     { w: 2,  v: function(d, b) { return m("f") + "(" + m() + ");"; } },
 
     // v: Primitive
-    { w: 2,  v: function(d, b) { return assign(d, b, "v",
-      Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"])
-    ); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", "new Number("
-      + Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"]) + ")"
-    ); } },
+    { w: 2,  v: function(d, b) { return assign(d, b, "v", Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "v", "new Number(" + Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"]) + ")"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", "new Number(" + m() + ")"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", makeBoolean(d, b)); } },
     { w: 2,  v: function(d, b) { return assign(d, b, "v", Random.index(["undefined", "null", "true", "false"])); } },
 
     // evil things we can do to any object property
-    { w: 1,  v: function(d, b) { return "/*ODP-1*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b)
-      + ", " + makePropertyDescriptor(d, b) + ");";
-    } },
-    { w: 1,  v: function(d, b) { return "/*ODP-2*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { "
-      + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b)
-      + " });";
-    } },
-    { w: 1,  v: function(d, b) { return "/*ODP-3*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { "
-      + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });";
-    } },
+    { w: 1,  v: function(d, b) { return "/*ODP-1*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
+    { w: 1,  v: function(d, b) { return "/*ODP-2*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
+    { w: 1,  v: function(d, b) { return "/*ODP-3*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
     { w: 1,  v: function(d, b) { return "delete " + m() + "[" + makePropertyName(d, b) + "];"; } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", m() + "[" + makePropertyName(d, b) + "]"); } },
     { w: 1,  v: function(d, b) { return m() + "[" + makePropertyName(d, b) + "] = " + val(d, b) + ";"; } },
@@ -498,12 +424,8 @@ var makeEvilCallback;
     { w: 10, v: function(d, b) { return m() + " + " + m() + ";"; } }, // valueOf
     { w: 10, v: function(d, b) { return m() + " + '';"; } }, // toString
     { w: 10, v: function(d, b) { return m("v") + " = (" + m() + " instanceof " + m() + ");"; } },
-    { w: 10, v: function(d, b) { return m("v") + " = Object.prototype.isPrototypeOf.call(" + m() + ", "
-      + m() + ");";
-    } },
-    { w: 2,  v: function(d, b) { return "Object." + Random.index(["preventExtensions", "seal", "freeze"])
-      + "(" + m() + ");";
-    } },
+    { w: 10, v: function(d, b) { return m("v") + " = Object.prototype.isPrototypeOf.call(" + m() + ", " + m() + ");"; } },
+    { w: 2,  v: function(d, b) { return "Object." + Random.index(["preventExtensions", "seal", "freeze"]) + "(" + m() + ");"; } },
 
     // Be promiscuous with the rest of jsfunfuzz
     { w: 1,  v: function(d, b) { return m() + " = x;"; } },
@@ -524,8 +446,7 @@ function infrequentCondition(v, n)
     case 0: return true;
     case 1: return false;
     case 2: return v + " > " + rnd(n);
-    default: var mod = rnd(n) + 2; var target = rnd(mod); return "/*ICCD*/" +
-      v + " % " + mod + (rnd(8) ? " == " : " != ") + target;
+    default: var mod = rnd(n) + 2; var target = rnd(mod); return "/*ICCD*/" + v + " % " + mod + (rnd(8) ? " == " : " != ") + target;
   }
 }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -22,7 +22,7 @@ var makeEvilCallback;
   var smallPowersOfTwo = [1, 2, 4, 8]; // The largest typed array views are 64-bit aka 8-byte
   function bufsize() { return rnd(ARRAY_SIZE) * Random.index(smallPowersOfTwo); }
   function arrayIndex(d, b) {
-    switch(rnd(8)) {
+    switch (rnd(8)) {
       case 0:  return m("v");
       case 1:  return makeExpr(d - 1, b);
       case 2:  return "({valueOf: function() { " + makeStatement(d, b) + "return " + rnd(ARRAY_SIZE) + "; }})";
@@ -37,7 +37,7 @@ var makeEvilCallback;
       t = "aosmevbtihgfp";
     t = t.charAt(rnd(t.length));
     var name = t + rnd(OBJECTS_PER_TYPE);
-    switch(rnd(16)) {
+    switch (rnd(16)) {
       case 0:  return m("o") + "." + name;
       case 1:  return m("g") + "." + name;
       case 2:  return "this." + name;
@@ -55,7 +55,7 @@ var makeEvilCallback;
   // Emit an assignment (or a roughly-equivalent getter)
   function assign(d, b, t, rhs)
   {
-    switch(rnd(18)) {
+    switch (rnd(18)) {
     // Could have two forms of the getter: one that computes it each time on demand, and one that computes a constant-function closure
       case 0:  return (
         "Object.defineProperty(" +
@@ -146,7 +146,7 @@ var makeEvilCallback;
     )
       .replace(/X/g, m())
       .replace(/Z/g, function() {
-        switch(rnd(20)){
+        switch (rnd(20)){
           case 0:  return "return " + m();
           case 1:  return "throw " + m();
           default: return makeBuilderStatement(d - 2, b);
@@ -161,7 +161,7 @@ var makeEvilCallback;
 
   function strToEval(d, b)
   {
-    switch(rnd(5)) {
+    switch (rnd(5)) {
       case 0:  return simpleSource(fdecl(d, b));
       case 1:  return simpleSource(makeBuilderStatement(d, b));
       default: return simpleSource(makeScriptForEval(d, b));

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -61,7 +61,7 @@ var makeEvilCallback;
         "Object.defineProperty(" +
         (rnd(8)?"this":m("og")) + ", " +
         simpleSource(m(t)) + ", " +
-        "{ " + propertyDescriptorPrefix(d-1, b) + " get: function() { " + (rnd(8)?"":makeBuilderStatement(d-1,b)) + " return " + rhs + "; } }" +
+        "{ " + propertyDescriptorPrefix(d-1, b) + " get: function() { " + (rnd(8)?"":makeBuilderStatement(d-1, b)) + " return " + rhs + "; } }" +
       ");"
       );
       case 1:  return Random.index(varBinder) + m(t) + " = " + rhs + ";";
@@ -261,8 +261,8 @@ var makeEvilCallback;
     { w: 3,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
     { w: 3,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "] = " + makeExpr(d, b) + ";"; } },
     { w: 1,  v: function(d, b) { return "/*ADP-1*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
-    { w: 1,  v: function(d, b) { return "/*ADP-2*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d,b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
-    { w: 1,  v: function(d, b) { return "/*ADP-3*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d,b) + ", value: " + val(d, b) + " });"; } },
+    { w: 1,  v: function(d, b) { return "/*ADP-2*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
+    { w: 1,  v: function(d, b) { return "/*ADP-3*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
 
     // Array mutators
     { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "push", severalargs(function() { return val(d, b); })) + ";"; } },
@@ -391,8 +391,8 @@ var makeEvilCallback;
 
     // evil things we can do to any object property
     { w: 1,  v: function(d, b) { return "/*ODP-1*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
-    { w: 1,  v: function(d, b) { return "/*ODP-2*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d,b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
-    { w: 1,  v: function(d, b) { return "/*ODP-3*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d,b) + ", value: " + val(d, b) + " });"; } },
+    { w: 1,  v: function(d, b) { return "/*ODP-2*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
+    { w: 1,  v: function(d, b) { return "/*ODP-3*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
     { w: 1,  v: function(d, b) { return "delete " + m() + "[" + makePropertyName(d, b) + "];"; } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", m() + "[" + makePropertyName(d, b) + "]"); } },
     { w: 1,  v: function(d, b) { return m() + "[" + makePropertyName(d, b) + "] = " + val(d, b) + ";"; } },

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -9,9 +9,9 @@
 /* global makeScriptForEval, makeStatement, Random, rnd, simpleSource, typedArrayConstructors, uniqueVarName */
 /* global varBinder */
 
-/***********************
+/* ******************* *
  * TEST BUILT-IN TYPES *
- ***********************/
+ * ******************* */
 
 var makeBuilderStatement;
 var makeEvilCallback;
@@ -291,8 +291,8 @@ var makeEvilCallback;
     // Typed Objects (aka Binary Data)
     // http://wiki.ecmascript.org/doku.php?id=harmony:typed_objects (does not match what's in spidermonkey as of 2014-02-11)
     // Do I need to keep track of 'types', 'objects of those types', and 'arrays of objects of those types'?
-    //{ w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".flatten()"); } },
-    //{ w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".partition(" + (rnd(2)?m("v"):rnd(10)) + ")"); } },
+    // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".flatten()"); } },
+    // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".partition(" + (rnd(2)?m("v"):rnd(10)) + ")"); } },
 
     // o: Object
     { w: 1,  v: function(d, b) { return assign(d, b, "o", "{}"); } },

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -23,10 +23,12 @@ var makeEvilCallback;
   function bufsize() { return rnd(ARRAY_SIZE) * Random.index(smallPowersOfTwo); }
   function arrayIndex(d, b) {
     switch (rnd(8)) {
+      /* eslint-disable no-multi-spaces */
       case 0:  return m("v");
       case 1:  return makeExpr(d - 1, b);
       case 2:  return "({valueOf: function() { " + makeStatement(d, b) + "return " + rnd(ARRAY_SIZE) + "; }})";
       default: return "" + rnd(ARRAY_SIZE);
+      /* eslint-enable no-multi-spaces */
     }
   }
 
@@ -38,10 +40,12 @@ var makeEvilCallback;
     t = t.charAt(rnd(t.length));
     var name = t + rnd(OBJECTS_PER_TYPE);
     switch (rnd(16)) {
+      /* eslint-disable no-multi-spaces */
       case 0:  return m("o") + "." + name;
       case 1:  return m("g") + "." + name;
       case 2:  return "this." + name;
       default: return name;
+      /* eslint-enable no-multi-spaces */
     }
   }
 
@@ -56,7 +60,9 @@ var makeEvilCallback;
   function assign(d, b, t, rhs)
   {
     switch (rnd(18)) {
-    // Could have two forms of the getter: one that computes it each time on demand, and one that computes a constant-function closure
+      // Could have two forms of the getter: one that computes it each time on demand,
+      // and one that computes a constant-function closure
+      /* eslint-disable no-multi-spaces */
       case 0:  return (
         "Object.defineProperty(" +
         (rnd(8)?"this":m("og")) + ", " +
@@ -66,6 +72,7 @@ var makeEvilCallback;
       );
       case 1:  return Random.index(varBinder) + m(t) + " = " + rhs + ";";
       default: return m(t) + " = " + rhs + ";";
+      /* eslint-enable no-multi-spaces */
     }
   }
 
@@ -100,7 +107,7 @@ var makeEvilCallback;
     var s = "";
     var extras = rnd(4);
     for (var i = 0; i < extras; ++i) {
-      s += "try { " + makeBuilderStatement(d - 2, b) +  " } catch(e" + i + ") { } ";
+      s += "try { " + makeBuilderStatement(d - 2, b) + " } catch(e" + i + ") { } ";
     }
     s += makeBuilderStatement(d - 1, b);
     return s;
@@ -147,9 +154,11 @@ var makeEvilCallback;
       .replace(/X/g, m())
       .replace(/Z/g, function() {
         switch (rnd(20)) {
+          /* eslint-disable no-multi-spaces */
           case 0:  return "return " + m();
           case 1:  return "throw " + m();
           default: return makeBuilderStatement(d - 2, b);
+          /* eslint-enable no-multi-spaces */
         }
       });
   }
@@ -162,9 +171,11 @@ var makeEvilCallback;
   function strToEval(d, b)
   {
     switch (rnd(5)) {
+      /* eslint-disable no-multi-spaces */
       case 0:  return simpleSource(fdecl(d, b));
       case 1:  return simpleSource(makeBuilderStatement(d, b));
       default: return simpleSource(makeScriptForEval(d, b));
+      /* eslint-enable no-multi-spaces */
     }
   }
 
@@ -229,9 +240,11 @@ var makeEvilCallback;
 
     // Emit a method call expression
     switch (rnd(4)) {
+      /* eslint-disable no-multi-spaces */
       case 0:  return clazz + ".prototype." + meth + ".apply(" + obj + ", [" + arglist.join(", ") + "])";
       case 1:  return clazz + ".prototype." + meth + ".call(" + [obj].concat(arglist).join(", ") + ")";
       default: return obj + "." + meth + "(" + arglist.join(", ") + ")";
+      /* eslint-enable no-multi-spaces */
     }
   }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -57,15 +57,15 @@ var makeEvilCallback;
   {
     switch(rnd(18)) {
     // Could have two forms of the getter: one that computes it each time on demand, and one that computes a constant-function closure
-    case 0:  return (
-      "Object.defineProperty(" +
+      case 0:  return (
+        "Object.defineProperty(" +
         (rnd(8)?"this":m("og")) + ", " +
         simpleSource(m(t)) + ", " +
         "{ " + propertyDescriptorPrefix(d-1, b) + " get: function() { " + (rnd(8)?"":makeBuilderStatement(d-1,b)) + " return " + rhs + "; } }" +
       ");"
-    );
-    case 1:  return Random.index(varBinder) + m(t) + " = " + rhs + ";";
-    default: return m(t) + " = " + rhs + ";";
+      );
+      case 1:  return Random.index(varBinder) + m(t) + " = " + rhs + ";";
+      default: return m(t) + " = " + rhs + ";";
     }
   }
 
@@ -81,8 +81,8 @@ var makeEvilCallback;
           "++" + v + "; " +
             (rnd(3) ?
               "if (" + infrequently + ") { dumpln('hit!'); " + makeBuilderStatements(d, b) + " } " +
-              "else { dumpln('miss!'); " + makeBuilderStatements(d, b) + " } "
-            : m("f") + "(" + infrequently + ");"
+              "else { dumpln('miss!'); " + makeBuilderStatements(d, b) + " } " :
+              m("f") + "(" + infrequently + ");"
             ) +
         "};" +
       "})()");
@@ -144,14 +144,14 @@ var makeEvilCallback;
         "keys: function() { Z; return Object.keys(X); } " +
       "})"
     )
-    .replace(/X/g, m())
-    .replace(/Z/g, function() {
-      switch(rnd(20)){
-        case 0:  return "return " + m();
-        case 1:  return "throw " + m();
-        default: return makeBuilderStatement(d - 2, b);
-      }
-    });
+      .replace(/X/g, m())
+      .replace(/Z/g, function() {
+        switch(rnd(20)){
+          case 0:  return "return " + m();
+          case 1:  return "throw " + m();
+          default: return makeBuilderStatement(d - 2, b);
+        }
+      });
   }
 
   function propertyDescriptorPrefix(d, b)
@@ -183,7 +183,7 @@ var makeEvilCallback;
         ((rnd(2) == 0) ? (", element: " + m("o")) : "") +
         ((rnd(2) == 0) ? (", elementAttributeName: " + m("s")) : "") +
         ((rnd(2) == 0) ? (", sourceMapURL: " + m("s")) : "")
-        ) : ""
+      ) : ""
       ) +
     " })");
   }

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -107,9 +107,9 @@ var makeEvilCallback;
   {
     var s = "";
     var extras = rnd(4);
-    for (var i = 0; i < extras; ++i) 
+    for (var i = 0; i < extras; ++i) {
       s += "try { " + makeBuilderStatement(d - 2, b) + " } catch(e" + i + ") { } ";
-    
+    }
     s += makeBuilderStatement(d - 1, b);
     return s;
   }
@@ -263,9 +263,9 @@ var makeEvilCallback;
   {
     var arglist = [];
     arglist.push(f());
-    while (rnd(2)) 
+    while (rnd(2)) {
       arglist.push(f());
-    
+    }
     return arglist;
   }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -20,8 +20,8 @@ var makeEvilCallback;
   var ARRAY_SIZE = 20;
   var OBJECTS_PER_TYPE = 3;
   var smallPowersOfTwo = [1, 2, 4, 8]; // The largest typed array views are 64-bit aka 8-byte
-  function bufsize () { return rnd(ARRAY_SIZE) * Random.index(smallPowersOfTwo); }
-  function arrayIndex (d, b) {
+  function bufsize () { return rnd(ARRAY_SIZE) * Random.index(smallPowersOfTwo); } // eslint-disable-line require-jsdoc
+  function arrayIndex (d, b) { // eslint-disable-line require-jsdoc
     switch (rnd(8)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return m("v");
@@ -33,7 +33,7 @@ var makeEvilCallback;
   }
 
   // Emit a variable name for type-abbreviation t.
-  function m (t) {
+  function m (t) { // eslint-disable-line require-jsdoc
     if (!t) { t = "aosmevbtihgfp"; }
     t = t.charAt(rnd(t.length));
     var name = t + rnd(OBJECTS_PER_TYPE);
@@ -47,13 +47,13 @@ var makeEvilCallback;
     }
   }
 
-  function val (d, b) {
+  function val (d, b) { // eslint-disable-line require-jsdoc
     if (rnd(10)) { return m(); }
     return makeExpr(d, b);
   }
 
   // Emit an assignment (or a roughly-equivalent getter)
-  function assign (d, b, t, rhs) {
+  function assign (d, b, t, rhs) { // eslint-disable-line require-jsdoc
     switch (rnd(18)) {
       // Could have two forms of the getter: one that computes it each time on demand,
       // and one that computes a constant-function closure
@@ -71,7 +71,7 @@ var makeEvilCallback;
     }
   }
 
-  function makeCounterClosure (d, b) {
+  function makeCounterClosure (d, b) { // eslint-disable-line require-jsdoc
     // A closure with a counter. Do stuff depending on the counter.
     var v = uniqueVarName();
     var infrequently = infrequentCondition(v, 10);
@@ -89,13 +89,13 @@ var makeEvilCallback;
       "})()");
   }
 
-  function fdecl (d, b) {
+  function fdecl (d, b) { // eslint-disable-line require-jsdoc
     var argName = m();
     var bv = b.concat([argName]);
     return "function " + m("f") + "(" + argName + ") " + makeFunctionBody(d, bv);
   }
 
-  function makeBuilderStatements (d, b) {
+  function makeBuilderStatements (d, b) { // eslint-disable-line require-jsdoc
     var s = "";
     var extras = rnd(4);
     for (var i = 0; i < extras; ++i) {
@@ -126,7 +126,7 @@ var makeEvilCallback;
 
   var handlerTraps = ["getOwnPropertyDescriptor", "defineProperty", "getOwnPropertyNames", "delete", "fix", "has", "hasOwn", "get", "set", "iterate", "enumerate", "keys"];
 
-  function forwardingHandler (d, b) {
+  function forwardingHandler (d, b) { // eslint-disable-line require-jsdoc
     return (
       "({" +
         "getOwnPropertyDescriptor: function(name) { Z; var desc = Object.getOwnPropertyDescriptor(X); desc.configurable = true; return desc; }, " +
@@ -155,11 +155,11 @@ var makeEvilCallback;
       });
   }
 
-  function propertyDescriptorPrefix (d, b) {
+  function propertyDescriptorPrefix (d, b) { // eslint-disable-line require-jsdoc
     return "configurable: " + makeBoolean(d, b) + ", " + "enumerable: " + makeBoolean(d, b) + ", ";
   }
 
-  function strToEval (d, b) {
+  function strToEval (d, b) { // eslint-disable-line require-jsdoc
     switch (rnd(5)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return simpleSource(fdecl(d, b));
@@ -169,7 +169,7 @@ var makeEvilCallback;
     }
   }
 
-  function evaluateFlags (d, b) {
+  function evaluateFlags (d, b) { // eslint-disable-line require-jsdoc
     // Options are in js.cpp: Evaluate() and ParseCompileOptions()
     return ("({ global: " + m("g") +
       ", fileName: " + Random.index(["'evaluate.js'", "null"]) +
@@ -189,7 +189,7 @@ var makeEvilCallback;
   }
 
   var initializedEverything = false;
-  function initializeEverything (d, b) {
+  function initializeEverything (d, b) { // eslint-disable-line require-jsdoc
     if (initializedEverything) { return ";"; }
     initializedEverything = true;
 
@@ -215,7 +215,7 @@ var makeEvilCallback;
   //   Array.prototype.push.apply(a1, [x])
   //   Array.prototype.push.call(a1, x)
   //   a1.push(x)
-  function method (d, b, clazz, obj, meth, arglist) {
+  function method (d, b, clazz, obj, meth, arglist) { // eslint-disable-line require-jsdoc
     // Sometimes ignore our arguments
     if (rnd(10) == 0) { arglist = []; }
 
@@ -232,7 +232,7 @@ var makeEvilCallback;
     }
   }
 
-  function severalargs (f) {
+  function severalargs (f) { // eslint-disable-line require-jsdoc
     var arglist = [];
     arglist.push(f());
     while (rnd(2)) {
@@ -422,7 +422,7 @@ var makeEvilCallback;
   };
 })();
 
-function infrequentCondition (v, n) {
+function infrequentCondition (v, n) { // eslint-disable-line require-jsdoc
   switch (rnd(20)) {
     case 0: return true;
     case 1: return false;

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -107,9 +107,9 @@ var makeEvilCallback;
   {
     var s = "";
     var extras = rnd(4);
-    for (var i = 0; i < extras; ++i) {
+    for (var i = 0; i < extras; ++i) 
       s += "try { " + makeBuilderStatement(d - 2, b) + " } catch(e" + i + ") { } ";
-    }
+    
     s += makeBuilderStatement(d - 1, b);
     return s;
   }
@@ -263,9 +263,9 @@ var makeEvilCallback;
   {
     var arglist = [];
     arglist.push(f());
-    while (rnd(2)) {
+    while (rnd(2)) 
       arglist.push(f());
-    }
+    
     return arglist;
   }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -16,12 +16,12 @@
 var makeBuilderStatement;
 var makeEvilCallback;
 
-(function setUpBuilderStuff() {
+(function setUpBuilderStuff () {
   var ARRAY_SIZE = 20;
   var OBJECTS_PER_TYPE = 3;
   var smallPowersOfTwo = [1, 2, 4, 8]; // The largest typed array views are 64-bit aka 8-byte
-  function bufsize() { return rnd(ARRAY_SIZE) * Random.index(smallPowersOfTwo); }
-  function arrayIndex(d, b) {
+  function bufsize () { return rnd(ARRAY_SIZE) * Random.index(smallPowersOfTwo); }
+  function arrayIndex (d, b) {
     switch (rnd(8)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return m("v");
@@ -33,10 +33,8 @@ var makeEvilCallback;
   }
 
   // Emit a variable name for type-abbreviation t.
-  function m(t)
-  {
-    if (!t)
-      t = "aosmevbtihgfp";
+  function m (t) {
+    if (!t) { t = "aosmevbtihgfp"; }
     t = t.charAt(rnd(t.length));
     var name = t + rnd(OBJECTS_PER_TYPE);
     switch (rnd(16)) {
@@ -49,25 +47,22 @@ var makeEvilCallback;
     }
   }
 
-  function val(d, b)
-  {
-    if (rnd(10))
-      return m();
+  function val (d, b) {
+    if (rnd(10)) { return m(); }
     return makeExpr(d, b);
   }
 
   // Emit an assignment (or a roughly-equivalent getter)
-  function assign(d, b, t, rhs)
-  {
+  function assign (d, b, t, rhs) {
     switch (rnd(18)) {
       // Could have two forms of the getter: one that computes it each time on demand,
       // and one that computes a constant-function closure
       /* eslint-disable no-multi-spaces */
       case 0:  return (
         "Object.defineProperty(" +
-        (rnd(8)?"this":m("og")) + ", " +
+        (rnd(8) ? "this" : m("og")) + ", " +
         simpleSource(m(t)) + ", " +
-        "{ " + propertyDescriptorPrefix(d-1, b) + " get: function() { " + (rnd(8)?"":makeBuilderStatement(d-1, b)) + " return " + rhs + "; } }" +
+        "{ " + propertyDescriptorPrefix(d - 1, b) + " get: function() { " + (rnd(8) ? "" : makeBuilderStatement(d - 1, b)) + " return " + rhs + "; } }" +
       ");"
       );
       case 1:  return Random.index(varBinder) + m(t) + " = " + rhs + ";";
@@ -76,8 +71,7 @@ var makeEvilCallback;
     }
   }
 
-  function makeCounterClosure(d, b)
-  {
+  function makeCounterClosure (d, b) {
     // A closure with a counter. Do stuff depending on the counter.
     var v = uniqueVarName();
     var infrequently = infrequentCondition(v, 10);
@@ -95,15 +89,13 @@ var makeEvilCallback;
       "})()");
   }
 
-  function fdecl(d, b)
-  {
+  function fdecl (d, b) {
     var argName = m();
     var bv = b.concat([argName]);
     return "function " + m("f") + "(" + argName + ") " + makeFunctionBody(d, bv);
   }
 
-  function makeBuilderStatements(d, b)
-  {
+  function makeBuilderStatements (d, b) {
     var s = "";
     var extras = rnd(4);
     for (var i = 0; i < extras; ++i) {
@@ -114,29 +106,29 @@ var makeEvilCallback;
   }
 
   var builderFunctionMakers = Random.weighted([
-    { w: 9,  v: function(d, b) { return "(function() { " + makeBuilderStatements(d, b) + " return " + m() + "; })"; } },
-    { w: 1,  v: function(d, b) { return "(function() { " + makeBuilderStatements(d, b) + " throw " + m() + "; })"; } },
-    { w: 1,  v: function(d, b) { return "(function(j) { " + m("f") + "(j); })"; } }, // a function that just makes one call is begging to be inlined
+    { w: 9, v: function (d, b) { return "(function() { " + makeBuilderStatements(d, b) + " return " + m() + "; })"; } },
+    { w: 1, v: function (d, b) { return "(function() { " + makeBuilderStatements(d, b) + " throw " + m() + "; })"; } },
+    { w: 1, v: function (d, b) { return "(function(j) { " + m("f") + "(j); })"; } }, // a function that just makes one call is begging to be inlined
     // The following pair create and use boolean-using functions.
-    { w: 4,  v: function(d, b) { return "(function(j) { if (j) { " + makeBuilderStatements(d, b) + " } else { " + makeBuilderStatements(d, b) + " } })"; } },
-    { w: 4,  v: function(d, b) { return "(function() { for (var j=0;j<" + loopCount() + ";++j) { " + m("f") + "(j%"+(2+rnd(4))+"=="+rnd(2)+"); } })"; } },
-    { w: 1,  v: function(d, b) { return Random.index(builtinFunctions) + ".bind(" + m() + ")"; } },
-    { w: 5,  v: function(d, b) { return m("f"); } },
-    { w: 3,  v: makeCounterClosure },
-    { w: 2,  v: makeFunction },
-    { w: 1,  v: makeAsmJSModule },
-    { w: 1,  v: makeAsmJSFunction },
-    { w: 1,  v: makeRegisterStompFunction },
+    { w: 4, v: function (d, b) { return "(function(j) { if (j) { " + makeBuilderStatements(d, b) + " } else { " + makeBuilderStatements(d, b) + " } })"; } },
+    { w: 4, v: function (d, b) { return "(function() { for (var j=0;j<" + loopCount() + ";++j) { " + m("f") + "(j%" + (2 + rnd(4)) + "==" + rnd(2) + "); } })"; } },
+    { w: 1, v: function (d, b) { return Random.index(builtinFunctions) + ".bind(" + m() + ")"; } },
+    { w: 5, v: function (d, b) { return m("f"); } },
+    { w: 3, v: makeCounterClosure },
+    { w: 2, v: makeFunction },
+    { w: 1, v: makeAsmJSModule },
+    { w: 1, v: makeAsmJSFunction },
+    { w: 1, v: makeRegisterStompFunction }
   ]);
-  makeEvilCallback = function(d, b) {
+  makeEvilCallback = function (d, b) {
     return (Random.index(builderFunctionMakers))(d - 1, b);
   };
 
   var handlerTraps = ["getOwnPropertyDescriptor", "defineProperty", "getOwnPropertyNames", "delete", "fix", "has", "hasOwn", "get", "set", "iterate", "enumerate", "keys"];
 
-  function forwardingHandler(d, b) {
+  function forwardingHandler (d, b) {
     return (
-      "({"+
+      "({" +
         "getOwnPropertyDescriptor: function(name) { Z; var desc = Object.getOwnPropertyDescriptor(X); desc.configurable = true; return desc; }, " +
         "defineProperty: function(name, desc) { Z; Object.defineProperty(X, name, desc); }, " +
         "getOwnPropertyNames: function() { Z; return Object.getOwnPropertyNames(X); }, " +
@@ -152,7 +144,7 @@ var makeEvilCallback;
       "})"
     )
       .replace(/X/g, m())
-      .replace(/Z/g, function() {
+      .replace(/Z/g, function () {
         switch (rnd(20)) {
           /* eslint-disable no-multi-spaces */
           case 0:  return "return " + m();
@@ -163,13 +155,11 @@ var makeEvilCallback;
       });
   }
 
-  function propertyDescriptorPrefix(d, b)
-  {
+  function propertyDescriptorPrefix (d, b) {
     return "configurable: " + makeBoolean(d, b) + ", " + "enumerable: " + makeBoolean(d, b) + ", ";
   }
 
-  function strToEval(d, b)
-  {
+  function strToEval (d, b) {
     switch (rnd(5)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return simpleSource(fdecl(d, b));
@@ -179,8 +169,7 @@ var makeEvilCallback;
     }
   }
 
-  function evaluateFlags(d, b)
-  {
+  function evaluateFlags (d, b) {
     // Options are in js.cpp: Evaluate() and ParseCompileOptions()
     return ("({ global: " + m("g") +
       ", fileName: " + Random.index(["'evaluate.js'", "null"]) +
@@ -200,10 +189,8 @@ var makeEvilCallback;
   }
 
   var initializedEverything = false;
-  function initializeEverything(d, b)
-  {
-    if (initializedEverything)
-      return ";";
+  function initializeEverything (d, b) {
+    if (initializedEverything) { return ";"; }
     initializedEverything = true;
 
     var s = "";
@@ -228,15 +215,12 @@ var makeEvilCallback;
   //   Array.prototype.push.apply(a1, [x])
   //   Array.prototype.push.call(a1, x)
   //   a1.push(x)
-  function method(d, b, clazz, obj, meth, arglist)
-  {
+  function method (d, b, clazz, obj, meth, arglist) {
     // Sometimes ignore our arguments
-    if (rnd(10) == 0)
-      arglist = [];
+    if (rnd(10) == 0) { arglist = []; }
 
     // Stuff in extra arguments
-    while (rnd(2))
-      arglist.push(val(d, b));
+    while (rnd(2)) { arglist.push(val(d, b)); }
 
     // Emit a method call expression
     switch (rnd(4)) {
@@ -248,8 +232,7 @@ var makeEvilCallback;
     }
   }
 
-  function severalargs(f)
-  {
+  function severalargs (f) {
     var arglist = [];
     arglist.push(f());
     while (rnd(2)) {
@@ -260,46 +243,46 @@ var makeEvilCallback;
 
   var builderStatementMakers = Random.weighted([
     // a: Array
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", "[]"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", "new Array"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", makeIterable(d, b)); } },
-    { w: 1,  v: function(d, b) { return m("a") + ".length = " + arrayIndex(d, b) + ";"; } },
-    { w: 8,  v: function(d, b) { return assign(d, b, "v", m("at") + ".length"); } },
-    { w: 4,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + " = " + val(d, b) + ";"; } },
-    { w: 4,  v: function(d, b) { return val(d, b) + " = " + m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", makeFunOnCallChain(d, b) + ".arguments"); } }, // a read-only arguments object
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", "arguments"); } }, // a read-write arguments object
+    { w: 1, v: function (d, b) { return assign(d, b, "a", "[]"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "a", "new Array"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "a", makeIterable(d, b)); } },
+    { w: 1, v: function (d, b) { return m("a") + ".length = " + arrayIndex(d, b) + ";"; } },
+    { w: 8, v: function (d, b) { return assign(d, b, "v", m("at") + ".length"); } },
+    { w: 4, v: function (d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + " = " + val(d, b) + ";"; } },
+    { w: 4, v: function (d, b) { return val(d, b) + " = " + m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "a", makeFunOnCallChain(d, b) + ".arguments"); } }, // a read-only arguments object
+    { w: 1, v: function (d, b) { return assign(d, b, "a", "arguments"); } }, // a read-write arguments object
 
     // Array indexing
-    { w: 3,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
-    { w: 3,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "] = " + makeExpr(d, b) + ";"; } },
-    { w: 1,  v: function(d, b) { return "/*ADP-1*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
-    { w: 1,  v: function(d, b) { return "/*ADP-2*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
-    { w: 1,  v: function(d, b) { return "/*ADP-3*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
+    { w: 3, v: function (d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
+    { w: 3, v: function (d, b) { return m("at") + "[" + arrayIndex(d, b) + "] = " + makeExpr(d, b) + ";"; } },
+    { w: 1, v: function (d, b) { return "/*ADP-1*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return "/*ADP-2*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
+    { w: 1, v: function (d, b) { return "/*ADP-3*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
 
     // Array mutators
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "push", severalargs(function() { return val(d, b); })) + ";"; } },
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "pop", []) + ";"; } },
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "unshift", severalargs(function() { return val(d, b); })) + ";"; } },
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "shift", []) + ";"; } },
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "reverse", []) + ";"; } },
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "sort", [makeEvilCallback(d, b)]) + ";"; } },
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "splice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b)]) + ";"; } },
+    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "push", severalargs(function () { return val(d, b); })) + ";"; } },
+    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "pop", []) + ";"; } },
+    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "unshift", severalargs(function () { return val(d, b); })) + ";"; } },
+    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "shift", []) + ";"; } },
+    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "reverse", []) + ";"; } },
+    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "sort", [makeEvilCallback(d, b)]) + ";"; } },
+    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "splice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b)]) + ";"; } },
     // Array accessors
-    { w: 1,  v: function(d, b) { return assign(d, b, "s", method(d, b, "Array", m("a"), "join", [m("s")])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "concat", severalargs(function() { return m("at"); }))); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "slice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b) - arrayIndex(d, b)])); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "s", method(d, b, "Array", m("a"), "join", [m("s")])); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "concat", severalargs(function () { return m("at"); }))); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "slice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b) - arrayIndex(d, b)])); } },
 
     // Array iterators
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "forEach", [makeEvilCallback(d, b)]) + ";"; } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "map", [makeEvilCallback(d, b)])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "filter", [makeEvilCallback(d, b)])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "some", [makeEvilCallback(d, b)])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "every", [makeEvilCallback(d, b)])); } },
+    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "forEach", [makeEvilCallback(d, b)]) + ";"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "map", [makeEvilCallback(d, b)])); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "filter", [makeEvilCallback(d, b)])); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "some", [makeEvilCallback(d, b)])); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "every", [makeEvilCallback(d, b)])); } },
 
     // Array reduction, either with a starting value or with the default of starting with the first two elements.
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b)])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b), val(d, b)])); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b)])); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b), val(d, b)])); } },
 
     // Typed Objects (aka Binary Data)
     // http://wiki.ecmascript.org/doku.php?id=harmony:typed_objects (does not match what's in spidermonkey as of 2014-02-11)
@@ -308,140 +291,138 @@ var makeEvilCallback;
     // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".partition(" + (rnd(2)?m("v"):rnd(10)) + ")"); } },
 
     // o: Object
-    { w: 1,  v: function(d, b) { return assign(d, b, "o", "{}"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "o", "new Object"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "o", "Object.create(" + val(d, b) + ")"); } },
-    { w: 3,  v: function(d, b) { return "selectforgc(" + m("o") + ");"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "o", "{}"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "o", "new Object"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "o", "Object.create(" + val(d, b) + ")"); } },
+    { w: 3, v: function (d, b) { return "selectforgc(" + m("o") + ");"; } },
 
     // s: String
-    { w: 1,  v: function(d, b) { return assign(d, b, "s", "''"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "s", "new String"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "s", "new String(" + m() + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "s", m("s") + ".charAt(" + arrayIndex(d, b) + ")"); } },
-    { w: 5,  v: function(d, b) { return m("s") + " += 'x';"; } },
-    { w: 5,  v: function(d, b) { return m("s") + " += " + m("s") + ";"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "s", "''"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "s", "new String"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "s", "new String(" + m() + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "s", m("s") + ".charAt(" + arrayIndex(d, b) + ")"); } },
+    { w: 5, v: function (d, b) { return m("s") + " += 'x';"; } },
+    { w: 5, v: function (d, b) { return m("s") + " += " + m("s") + ";"; } },
     // Should add substr, substring, replace
 
     // m: Map, WeakMap
-    { w: 1,  v: function(d, b) { return assign(d, b, "m", "new Map"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "m", "new Map(" + m() + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "m", "new WeakMap"); } },
-    { w: 5,  v: function(d, b) { return m("m") + ".has(" + val(d, b) + ");"; } },
-    { w: 4,  v: function(d, b) { return m("m") + ".get(" + val(d, b) + ");"; } },
-    { w: 1,  v: function(d, b) { return assign(d, b, null, m("m") + ".get(" + val(d, b) + ")"); } },
-    { w: 5,  v: function(d, b) { return m("m") + ".set(" + val(d, b) + ", " + val(d, b) + ");"; } },
-    { w: 3,  v: function(d, b) { return m("m") + ".delete(" + val(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "m", "new Map"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "m", "new Map(" + m() + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "m", "new WeakMap"); } },
+    { w: 5, v: function (d, b) { return m("m") + ".has(" + val(d, b) + ");"; } },
+    { w: 4, v: function (d, b) { return m("m") + ".get(" + val(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, null, m("m") + ".get(" + val(d, b) + ")"); } },
+    { w: 5, v: function (d, b) { return m("m") + ".set(" + val(d, b) + ", " + val(d, b) + ");"; } },
+    { w: 3, v: function (d, b) { return m("m") + ".delete(" + val(d, b) + ");"; } },
 
     // e: Set
-    { w: 1,  v: function(d, b) { return assign(d, b, "e", "new Set"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "e", "new Set(" + m() + ")"); } },
-    { w: 5,  v: function(d, b) { return m("e") + ".has(" + val(d, b) + ");"; } },
-    { w: 5,  v: function(d, b) { return m("e") + ".add(" + val(d, b) + ");"; } },
-    { w: 3,  v: function(d, b) { return m("e") + ".delete(" + val(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "e", "new Set"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "e", "new Set(" + m() + ")"); } },
+    { w: 5, v: function (d, b) { return m("e") + ".has(" + val(d, b) + ");"; } },
+    { w: 5, v: function (d, b) { return m("e") + ".add(" + val(d, b) + ");"; } },
+    { w: 3, v: function (d, b) { return m("e") + ".delete(" + val(d, b) + ");"; } },
 
     // b: Buffer
-    { w: 1,  v: function(d, b) { return assign(d, b, "b", "new " + arrayBufferType() + "(" + bufsize() + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "b", m("t") + ".buffer"); } },
-    { w: 1,  v: function(d, b) { return "neuter(" + m("b") + ", " + (rnd(2) ? '"same-data"' : '"change-data"') + ");"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "b", "new " + arrayBufferType() + "(" + bufsize() + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "b", m("t") + ".buffer"); } },
+    { w: 1, v: function (d, b) { return "neuter(" + m("b") + ", " + (rnd(2) ? '"same-data"' : '"change-data"') + ");"; } },
 
     // t: Typed arrays, aka ArrayBufferViews
     // Can be constructed using a length, typed array, sequence (e.g. array), or buffer with optional offsets!
-    { w: 1,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + arrayIndex(d, b) + ")"); } },
-    { w: 3,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + m("abt") + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + m("b") + ", " + bufsize() + ", " + arrayIndex(d, b) + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ", " + arrayIndex(d, b) + ")"); } },
-    { w: 3,  v: function(d, b) { return m("t") + ".set(" + m("at") + ", " + arrayIndex(d, b) + ");"; } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", m("tb") + ".byteLength"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", m("t") + ".byteOffset"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", m("t") + ".BYTES_PER_ELEMENT"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + arrayIndex(d, b) + ")"); } },
+    { w: 3, v: function (d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + m("abt") + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + m("b") + ", " + bufsize() + ", " + arrayIndex(d, b) + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ", " + arrayIndex(d, b) + ")"); } },
+    { w: 3, v: function (d, b) { return m("t") + ".set(" + m("at") + ", " + arrayIndex(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", m("tb") + ".byteLength"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", m("t") + ".byteOffset"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", m("t") + ".BYTES_PER_ELEMENT"); } },
 
     // h: proxy handler
-    { w: 1,  v: function(d, b) { return assign(d, b, "h", "{}"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "h", forwardingHandler(d, b)); } },
-    { w: 1,  v: function(d, b) { return "delete " + m("h") + "." + Random.index(handlerTraps) + ";"; } },
-    { w: 4,  v: function(d, b) { return m("h") + "." + Random.index(handlerTraps) + " = " + makeEvilCallback(d, b) + ";"; } },
-    { w: 4,  v: function(d, b) { return m("h") + "." + Random.index(handlerTraps) + " = " + m("f") + ";"; } },
-    { w: 1,  v: function(d, b) { return assign(d, b, null, "Proxy.create(" + m("h") + ", " + m() + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "f", "Proxy.createFunction(" + m("h") + ", " + m("f") + ", " + m("f") + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "h", "{}"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "h", forwardingHandler(d, b)); } },
+    { w: 1, v: function (d, b) { return "delete " + m("h") + "." + Random.index(handlerTraps) + ";"; } },
+    { w: 4, v: function (d, b) { return m("h") + "." + Random.index(handlerTraps) + " = " + makeEvilCallback(d, b) + ";"; } },
+    { w: 4, v: function (d, b) { return m("h") + "." + Random.index(handlerTraps) + " = " + m("f") + ";"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, null, "Proxy.create(" + m("h") + ", " + m() + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "f", "Proxy.createFunction(" + m("h") + ", " + m("f") + ", " + m("f") + ")"); } },
 
     // r: regexp
     // The separate regex code is better at matching strings with regexps, but this is better at reusing the objects.
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=808245 for why it is important to reuse regexp objects.
-    { w: 1,  v: function(d, b) { return assign(d, b, "r", makeRegex(d, b)); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", m("r") + ".exec(" + m("s") + ")"); } },
-    { w: 3,  v: function(d, b) { return makeRegexUseBlock(d, b, m("r")); } },
-    { w: 3,  v: function(d, b) { return makeRegexUseBlock(d, b, m("r"), m("s")); } },
-    { w: 3,  v: function(d, b) { return assign(d, b, "v", m("r") + "." + Random.index(builtinObjects["RegExp.prototype"])); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "r", makeRegex(d, b)); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "a", m("r") + ".exec(" + m("s") + ")"); } },
+    { w: 3, v: function (d, b) { return makeRegexUseBlock(d, b, m("r")); } },
+    { w: 3, v: function (d, b) { return makeRegexUseBlock(d, b, m("r"), m("s")); } },
+    { w: 3, v: function (d, b) { return assign(d, b, "v", m("r") + "." + Random.index(builtinObjects["RegExp.prototype"])); } },
 
     // g: global or sandbox
-    { w: 1,  v: function(d, b) { return assign(d, b, "g", makeGlobal(d, b)); } },
-    { w: 5,  v: function(d, b) { return assign(d, b, "v", m("g") + ".eval(" + strToEval(d, b) + ")"); } },
-    { w: 5,  v: function(d, b) { return assign(d, b, "v", "evalcx(" + strToEval(d, b) + ", " + m("g") + ")"); } },
-    { w: 5,  v: function(d, b) { return assign(d, b, "v", "evaluate(" + strToEval(d, b) + ", " + evaluateFlags(d, b) + ")"); } },
-    { w: 2,  v: function(d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ");"; } },
-    { w: 3,  v: function(d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ", " + evaluateFlags(d, b) + ");"; } },
-    { w: 5,  v: function(d, b) { return assign(d, b, "v", m("g") + ".runOffThreadScript()"); } },
-    { w: 3,  v: function(d, b) { return "(void schedulegc(" + m("g") + "));"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "g", makeGlobal(d, b)); } },
+    { w: 5, v: function (d, b) { return assign(d, b, "v", m("g") + ".eval(" + strToEval(d, b) + ")"); } },
+    { w: 5, v: function (d, b) { return assign(d, b, "v", "evalcx(" + strToEval(d, b) + ", " + m("g") + ")"); } },
+    { w: 5, v: function (d, b) { return assign(d, b, "v", "evaluate(" + strToEval(d, b) + ", " + evaluateFlags(d, b) + ")"); } },
+    { w: 2, v: function (d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ");"; } },
+    { w: 3, v: function (d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ", " + evaluateFlags(d, b) + ");"; } },
+    { w: 5, v: function (d, b) { return assign(d, b, "v", m("g") + ".runOffThreadScript()"); } },
+    { w: 3, v: function (d, b) { return "(void schedulegc(" + m("g") + "));"; } },
 
     // Mix builtins between globals
-    { w: 3,  v: function(d, b) { return "/*MXX1*/" + assign(d, b, "o", m("g") + "." + Random.index(builtinProperties)); } },
-    { w: 3,  v: function(d, b) { return "/*MXX2*/" + m("g") + "." + Random.index(builtinProperties) + " = " + m() + ";"; } },
-    { w: 3,  v: function(d, b) { var prop = Random.index(builtinProperties); return "/*MXX3*/" + m("g") + "." + prop + " = " + m("g") + "." + prop + ";"; } },
+    { w: 3, v: function (d, b) { return "/*MXX1*/" + assign(d, b, "o", m("g") + "." + Random.index(builtinProperties)); } },
+    { w: 3, v: function (d, b) { return "/*MXX2*/" + m("g") + "." + Random.index(builtinProperties) + " = " + m() + ";"; } },
+    { w: 3, v: function (d, b) { var prop = Random.index(builtinProperties); return "/*MXX3*/" + m("g") + "." + prop + " = " + m("g") + "." + prop + ";"; } },
 
     // f: function (?)
     // Could probably do better with args / b
-    { w: 1,  v: function(d, b) { return assign(d, b, "f", makeEvilCallback(d, b)); } },
-    { w: 1,  v: fdecl },
-    { w: 2,  v: function(d, b) { return m("f") + "(" + m() + ");"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "f", makeEvilCallback(d, b)); } },
+    { w: 1, v: fdecl },
+    { w: 2, v: function (d, b) { return m("f") + "(" + m() + ");"; } },
 
     // v: Primitive
-    { w: 2,  v: function(d, b) { return assign(d, b, "v", Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", "new Number(" + Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"]) + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", "new Number(" + m() + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", makeBoolean(d, b)); } },
-    { w: 2,  v: function(d, b) { return assign(d, b, "v", Random.index(["undefined", "null", "true", "false"])); } },
+    { w: 2, v: function (d, b) { return assign(d, b, "v", Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"])); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", "new Number(" + Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"]) + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", "new Number(" + m() + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", makeBoolean(d, b)); } },
+    { w: 2, v: function (d, b) { return assign(d, b, "v", Random.index(["undefined", "null", "true", "false"])); } },
 
     // evil things we can do to any object property
-    { w: 1,  v: function(d, b) { return "/*ODP-1*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
-    { w: 1,  v: function(d, b) { return "/*ODP-2*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
-    { w: 1,  v: function(d, b) { return "/*ODP-3*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
-    { w: 1,  v: function(d, b) { return "delete " + m() + "[" + makePropertyName(d, b) + "];"; } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", m() + "[" + makePropertyName(d, b) + "]"); } },
-    { w: 1,  v: function(d, b) { return m() + "[" + makePropertyName(d, b) + "] = " + val(d, b) + ";"; } },
+    { w: 1, v: function (d, b) { return "/*ODP-1*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return "/*ODP-2*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
+    { w: 1, v: function (d, b) { return "/*ODP-3*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
+    { w: 1, v: function (d, b) { return "delete " + m() + "[" + makePropertyName(d, b) + "];"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", m() + "[" + makePropertyName(d, b) + "]"); } },
+    { w: 1, v: function (d, b) { return m() + "[" + makePropertyName(d, b) + "] = " + val(d, b) + ";"; } },
 
     // evil things we can do to any object
-    { w: 5,  v: function(d, b) { return "print(" + m() + ");"; } },
-    { w: 5,  v: function(d, b) { return "print(uneval(" + m() + "));"; } },
-    { w: 5,  v: function(d, b) { return m() + ".toString = " + makeEvilCallback(d, b) + ";"; } },
-    { w: 5,  v: function(d, b) { return m() + ".valueOf = " + makeEvilCallback(d, b) + ";"; } },
-    { w: 1,  v: function(d, b) { return m() + " = " + m() + ";"; } },
-    { w: 1,  v: function(d, b) { return m() + " = " + m("g") + ".createIsHTMLDDA();"; } },
-    { w: 1,  v: function(d, b) { return m("o") + " = " + m() + ".__proto__;"; } },
-    { w: 5,  v: function(d, b) { return m() + ".__proto__ = " + m() + ";"; } },
-    { w: 10, v: function(d, b) { return "for (var p in " + m() + ") { " + makeBuilderStatements(d, b) + " }"; } },
-    { w: 10, v: function(d, b) { return "for (var v of " + m() + ") { " + makeBuilderStatements(d, b) + " }"; } },
-    { w: 10, v: function(d, b) { return m() + " + " + m() + ";"; } }, // valueOf
-    { w: 10, v: function(d, b) { return m() + " + '';"; } }, // toString
-    { w: 10, v: function(d, b) { return m("v") + " = (" + m() + " instanceof " + m() + ");"; } },
-    { w: 10, v: function(d, b) { return m("v") + " = Object.prototype.isPrototypeOf.call(" + m() + ", " + m() + ");"; } },
-    { w: 2,  v: function(d, b) { return "Object." + Random.index(["preventExtensions", "seal", "freeze"]) + "(" + m() + ");"; } },
+    { w: 5, v: function (d, b) { return "print(" + m() + ");"; } },
+    { w: 5, v: function (d, b) { return "print(uneval(" + m() + "));"; } },
+    { w: 5, v: function (d, b) { return m() + ".toString = " + makeEvilCallback(d, b) + ";"; } },
+    { w: 5, v: function (d, b) { return m() + ".valueOf = " + makeEvilCallback(d, b) + ";"; } },
+    { w: 1, v: function (d, b) { return m() + " = " + m() + ";"; } },
+    { w: 1, v: function (d, b) { return m() + " = " + m("g") + ".createIsHTMLDDA();"; } },
+    { w: 1, v: function (d, b) { return m("o") + " = " + m() + ".__proto__;"; } },
+    { w: 5, v: function (d, b) { return m() + ".__proto__ = " + m() + ";"; } },
+    { w: 10, v: function (d, b) { return "for (var p in " + m() + ") { " + makeBuilderStatements(d, b) + " }"; } },
+    { w: 10, v: function (d, b) { return "for (var v of " + m() + ") { " + makeBuilderStatements(d, b) + " }"; } },
+    { w: 10, v: function (d, b) { return m() + " + " + m() + ";"; } }, // valueOf
+    { w: 10, v: function (d, b) { return m() + " + '';"; } }, // toString
+    { w: 10, v: function (d, b) { return m("v") + " = (" + m() + " instanceof " + m() + ");"; } },
+    { w: 10, v: function (d, b) { return m("v") + " = Object.prototype.isPrototypeOf.call(" + m() + ", " + m() + ");"; } },
+    { w: 2, v: function (d, b) { return "Object." + Random.index(["preventExtensions", "seal", "freeze"]) + "(" + m() + ");"; } },
 
     // Be promiscuous with the rest of jsfunfuzz
-    { w: 1,  v: function(d, b) { return m() + " = x;"; } },
-    { w: 1,  v: function(d, b) { return "x = " + m() + ";"; } },
-    { w: 5,  v: makeStatement },
+    { w: 1, v: function (d, b) { return m() + " = x;"; } },
+    { w: 1, v: function (d, b) { return "x = " + m() + ";"; } },
+    { w: 5, v: makeStatement },
 
-    { w: 5,  v: initializeEverything },
+    { w: 5, v: initializeEverything }
   ]);
-  makeBuilderStatement = function(d, b) {
+  makeBuilderStatement = function (d, b) {
     return (Random.index(builderStatementMakers))(d - 1, b);
   };
 })();
 
-
-function infrequentCondition(v, n)
-{
+function infrequentCondition (v, n) {
   switch (rnd(20)) {
     case 0: return true;
     case 1: return false;
@@ -451,5 +432,5 @@ function infrequentCondition(v, n)
 }
 
 var arrayBufferType = "SharedArrayBuffer" in this ?
-  function() { return rnd(2) ? "SharedArrayBuffer" : "ArrayBuffer"; } :
-  function() { return "ArrayBuffer"; };
+  function () { return rnd(2) ? "SharedArrayBuffer" : "ArrayBuffer"; } :
+  function () { return "ArrayBuffer"; };

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -179,10 +179,10 @@ var makeEvilCallback;
       ", saveIncrementalBytecode: " + makeBoolean(d, b) +
       ", sourceIsLazy: " + makeBoolean(d, b) +
       ", catchTermination: " + makeBoolean(d, b) +
-      ((rnd(5) === 0) ? (
-        ((rnd(2) === 0) ? (", element: " + m("o")) : "") +
-        ((rnd(2) === 0) ? (", elementAttributeName: " + m("s")) : "") +
-        ((rnd(2) === 0) ? (", sourceMapURL: " + m("s")) : "")
+      ((rnd(5) == 0) ? (
+        ((rnd(2) == 0) ? (", element: " + m("o")) : "") +
+        ((rnd(2) == 0) ? (", elementAttributeName: " + m("s")) : "") +
+        ((rnd(2) == 0) ? (", sourceMapURL: " + m("s")) : "")
       ) : ""
       ) +
     " })");
@@ -217,7 +217,7 @@ var makeEvilCallback;
   //   a1.push(x)
   function method (d, b, clazz, obj, meth, arglist) { // eslint-disable-line require-jsdoc
     // Sometimes ignore our arguments
-    if (rnd(10) === 0) { arglist = []; }
+    if (rnd(10) == 0) { arglist = []; }
 
     // Stuff in extra arguments
     while (rnd(2)) { arglist.push(val(d, b)); }

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -67,7 +67,8 @@ var makeEvilCallback;
         "Object.defineProperty(" +
         (rnd(8)?"this":m("og")) + ", " +
         simpleSource(m(t)) + ", " +
-        "{ " + propertyDescriptorPrefix(d-1, b) + " get: function() { " + (rnd(8)?"":makeBuilderStatement(d-1, b)) + " return " + rhs + "; } }" +
+        "{ " + propertyDescriptorPrefix(d-1, b) + " get: function() { " +
+        (rnd(8)?"":makeBuilderStatement(d-1, b)) + " return " + rhs + "; } }" +
       ");"
       );
       case 1:  return Random.index(varBinder) + m(t) + " = " + rhs + ";";
@@ -114,12 +115,19 @@ var makeEvilCallback;
   }
 
   var builderFunctionMakers = Random.weighted([
-    { w: 9,  v: function(d, b) { return "(function() { " + makeBuilderStatements(d, b) + " return " + m() + "; })"; } },
+    { w: 9,  v: function(d, b) { return "(function() { " + makeBuilderStatements(d, b) +
+      " return " + m() + "; })";
+    } },
     { w: 1,  v: function(d, b) { return "(function() { " + makeBuilderStatements(d, b) + " throw " + m() + "; })"; } },
-    { w: 1,  v: function(d, b) { return "(function(j) { " + m("f") + "(j); })"; } }, // a function that just makes one call is begging to be inlined
+    // a function that just makes one call is begging to be inlined
+    { w: 1,  v: function(d, b) { return "(function(j) { " + m("f") + "(j); })"; } },
     // The following pair create and use boolean-using functions.
-    { w: 4,  v: function(d, b) { return "(function(j) { if (j) { " + makeBuilderStatements(d, b) + " } else { " + makeBuilderStatements(d, b) + " } })"; } },
-    { w: 4,  v: function(d, b) { return "(function() { for (var j=0;j<" + loopCount() + ";++j) { " + m("f") + "(j%"+(2+rnd(4))+"=="+rnd(2)+"); } })"; } },
+    { w: 4,  v: function(d, b) { return "(function(j) { if (j) { " + makeBuilderStatements(d, b)
+      + " } else { " + makeBuilderStatements(d, b) + " } })";
+    } },
+    { w: 4,  v: function(d, b) { return "(function() { for (var j=0;j<" + loopCount() + ";++j) { "
+      + m("f") + "(j%"+(2+rnd(4))+"=="+rnd(2)+"); } })";
+    } },
     { w: 1,  v: function(d, b) { return Random.index(builtinFunctions) + ".bind(" + m() + ")"; } },
     { w: 5,  v: function(d, b) { return m("f"); } },
     { w: 3,  v: makeCounterClosure },
@@ -132,12 +140,15 @@ var makeEvilCallback;
     return (Random.index(builderFunctionMakers))(d - 1, b);
   };
 
-  var handlerTraps = ["getOwnPropertyDescriptor", "defineProperty", "getOwnPropertyNames", "delete", "fix", "has", "hasOwn", "get", "set", "iterate", "enumerate", "keys"];
+  var handlerTraps = ["getOwnPropertyDescriptor", "defineProperty", "getOwnPropertyNames", "delete", "fix",
+    "has", "hasOwn", "get", "set", "iterate", "enumerate", "keys"
+  ];
 
   function forwardingHandler(d, b) {
     return (
       "({"+
-        "getOwnPropertyDescriptor: function(name) { Z; var desc = Object.getOwnPropertyDescriptor(X); desc.configurable = true; return desc; }, " +
+        "getOwnPropertyDescriptor: function(name) { Z; var desc = Object.getOwnPropertyDescriptor(X); " +
+        "desc.configurable = true; return desc; }, " +
         "defineProperty: function(name, desc) { Z; Object.defineProperty(X, name, desc); }, " +
         "getOwnPropertyNames: function() { Z; return Object.getOwnPropertyNames(X); }, " +
         "delete: function(name) { Z; return delete X[name]; }, " +
@@ -267,45 +278,78 @@ var makeEvilCallback;
     { w: 8,  v: function(d, b) { return assign(d, b, "v", m("at") + ".length"); } },
     { w: 4,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + " = " + val(d, b) + ";"; } },
     { w: 4,  v: function(d, b) { return val(d, b) + " = " + m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", makeFunOnCallChain(d, b) + ".arguments"); } }, // a read-only arguments object
+    // a read-only arguments object
+    { w: 1,  v: function(d, b) { return assign(d, b, "a", makeFunOnCallChain(d, b) + ".arguments"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "a", "arguments"); } }, // a read-write arguments object
 
     // Array indexing
     { w: 3,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
     { w: 3,  v: function(d, b) { return m("at") + "[" + arrayIndex(d, b) + "] = " + makeExpr(d, b) + ";"; } },
-    { w: 1,  v: function(d, b) { return "/*ADP-1*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
-    { w: 1,  v: function(d, b) { return "/*ADP-2*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
-    { w: 1,  v: function(d, b) { return "/*ADP-3*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
+    { w: 1,  v: function(d, b) { return "/*ADP-1*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", "
+      + makePropertyDescriptor(d, b) + ");";
+    } },
+    { w: 1,  v: function(d, b) { return "/*ADP-2*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { "
+      + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });";
+    } },
+    { w: 1,  v: function(d, b) { return "/*ADP-3*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { "
+      + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; }
+    },
 
     // Array mutators
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "push", severalargs(function() { return val(d, b); })) + ";"; } },
+    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "push",
+      severalargs(function() { return val(d, b); })) + ";";
+    } },
     { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "pop", []) + ";"; } },
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "unshift", severalargs(function() { return val(d, b); })) + ";"; } },
+    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "unshift",
+      severalargs(function() { return val(d, b); })) + ";";
+    } },
     { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "shift", []) + ";"; } },
     { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "reverse", []) + ";"; } },
     { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "sort", [makeEvilCallback(d, b)]) + ";"; } },
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "splice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b)]) + ";"; } },
+    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "splice", [
+      arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b)
+    ]) + ";"; } },
     // Array accessors
     { w: 1,  v: function(d, b) { return assign(d, b, "s", method(d, b, "Array", m("a"), "join", [m("s")])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "concat", severalargs(function() { return m("at"); }))); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "slice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b) - arrayIndex(d, b)])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b,
+      "Array", m("a"), "concat", severalargs(function() { return m("at"); })
+    )); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "slice",[
+      arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b) - arrayIndex(d, b)
+    ])); } },
 
     // Array iterators
-    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "forEach", [makeEvilCallback(d, b)]) + ";"; } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "map", [makeEvilCallback(d, b)])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "filter", [makeEvilCallback(d, b)])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "some", [makeEvilCallback(d, b)])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "every", [makeEvilCallback(d, b)])); } },
+    { w: 5,  v: function(d, b) { return method(d, b, "Array", m("a"), "forEach", [
+      makeEvilCallback(d, b)
+    ]) + ";"; } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "map", [
+      makeEvilCallback(d, b)
+    ])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "filter", [
+      makeEvilCallback(d, b)
+    ])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "some", [
+      makeEvilCallback(d, b)
+    ])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "every", [
+      makeEvilCallback(d, b)
+    ])); } },
 
     // Array reduction, either with a starting value or with the default of starting with the first two elements.
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b)])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b), val(d, b)])); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"),
+      Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b)]
+    )); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"),
+      Random.index(["reduce, reduceRight"]), [makeEvilCallback(d, b), val(d, b)]
+    )); } },
 
     // Typed Objects (aka Binary Data)
-    // http://wiki.ecmascript.org/doku.php?id=harmony:typed_objects (does not match what's in spidermonkey as of 2014-02-11)
+    // http://wiki.ecmascript.org/doku.php?id=harmony:typed_objects
+    // (does not match what's in spidermonkey as of 2014-02-11)
     // Do I need to keep track of 'types', 'objects of those types', and 'arrays of objects of those types'?
     // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".flatten()"); } },
-    // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".partition(" + (rnd(2)?m("v"):rnd(10)) + ")"); } },
+    // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d")
+    //   + ".partition(" + (rnd(2)?m("v"):rnd(10)) + ")"); } },
 
     // o: Object
     { w: 1,  v: function(d, b) { return assign(d, b, "o", "{}"); } },
@@ -342,15 +386,20 @@ var makeEvilCallback;
     // b: Buffer
     { w: 1,  v: function(d, b) { return assign(d, b, "b", "new " + arrayBufferType() + "(" + bufsize() + ")"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "b", m("t") + ".buffer"); } },
-    { w: 1,  v: function(d, b) { return "neuter(" + m("b") + ", " + (rnd(2) ? '"same-data"' : '"change-data"') + ");"; } },
+    { w: 1,  v: function(d, b) { return "neuter(" + m("b") + ", "
+      + (rnd(2) ? '"same-data"' : '"change-data"') + ");"; } },
 
     // t: Typed arrays, aka ArrayBufferViews
     // Can be constructed using a length, typed array, sequence (e.g. array), or buffer with optional offsets!
-    { w: 1,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + arrayIndex(d, b) + ")"); } },
-    { w: 3,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + m("abt") + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + m("b") + ", " + bufsize() + ", " + arrayIndex(d, b) + ")"); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors)
+      + "(" + arrayIndex(d, b) + ")"); } },
+    { w: 3,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors)
+      + "(" + m("abt") + ")"); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors)
+      + "(" + m("b") + ", " + bufsize() + ", " + arrayIndex(d, b) + ")"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ", " + arrayIndex(d, b) + ")"); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ", "
+      + arrayIndex(d, b) + ")"); } },
     { w: 3,  v: function(d, b) { return m("t") + ".set(" + m("at") + ", " + arrayIndex(d, b) + ");"; } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", m("tb") + ".byteLength"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", m("t") + ".byteOffset"); } },
@@ -360,10 +409,12 @@ var makeEvilCallback;
     { w: 1,  v: function(d, b) { return assign(d, b, "h", "{}"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "h", forwardingHandler(d, b)); } },
     { w: 1,  v: function(d, b) { return "delete " + m("h") + "." + Random.index(handlerTraps) + ";"; } },
-    { w: 4,  v: function(d, b) { return m("h") + "." + Random.index(handlerTraps) + " = " + makeEvilCallback(d, b) + ";"; } },
+    { w: 4,  v: function(d, b) { return m("h") + "." + Random.index(handlerTraps) + " = "
+      + makeEvilCallback(d, b) + ";"; } },
     { w: 4,  v: function(d, b) { return m("h") + "." + Random.index(handlerTraps) + " = " + m("f") + ";"; } },
     { w: 1,  v: function(d, b) { return assign(d, b, null, "Proxy.create(" + m("h") + ", " + m() + ")"); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "f", "Proxy.createFunction(" + m("h") + ", " + m("f") + ", " + m("f") + ")"); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "f", "Proxy.createFunction(" + m("h") + ", "
+      + m("f") + ", " + m("f") + ")"); } },
 
     // r: regexp
     // The separate regex code is better at matching strings with regexps, but this is better at reusing the objects.
@@ -372,22 +423,34 @@ var makeEvilCallback;
     { w: 1,  v: function(d, b) { return assign(d, b, "a", m("r") + ".exec(" + m("s") + ")"); } },
     { w: 3,  v: function(d, b) { return makeRegexUseBlock(d, b, m("r")); } },
     { w: 3,  v: function(d, b) { return makeRegexUseBlock(d, b, m("r"), m("s")); } },
-    { w: 3,  v: function(d, b) { return assign(d, b, "v", m("r") + "." + Random.index(builtinObjects["RegExp.prototype"])); } },
+    { w: 3,  v: function(d, b) { return assign(d, b, "v", m("r") + "."
+      + Random.index(builtinObjects["RegExp.prototype"])
+    ); } },
 
     // g: global or sandbox
     { w: 1,  v: function(d, b) { return assign(d, b, "g", makeGlobal(d, b)); } },
     { w: 5,  v: function(d, b) { return assign(d, b, "v", m("g") + ".eval(" + strToEval(d, b) + ")"); } },
     { w: 5,  v: function(d, b) { return assign(d, b, "v", "evalcx(" + strToEval(d, b) + ", " + m("g") + ")"); } },
-    { w: 5,  v: function(d, b) { return assign(d, b, "v", "evaluate(" + strToEval(d, b) + ", " + evaluateFlags(d, b) + ")"); } },
+    { w: 5,  v: function(d, b) { return assign(d, b, "v", "evaluate(" + strToEval(d, b) + ", "
+      + evaluateFlags(d, b) + ")"
+    ); } },
     { w: 2,  v: function(d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ");"; } },
-    { w: 3,  v: function(d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ", " + evaluateFlags(d, b) + ");"; } },
+    { w: 3,  v: function(d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ", "
+      + evaluateFlags(d, b) + ");";
+    } },
     { w: 5,  v: function(d, b) { return assign(d, b, "v", m("g") + ".runOffThreadScript()"); } },
     { w: 3,  v: function(d, b) { return "(void schedulegc(" + m("g") + "));"; } },
 
     // Mix builtins between globals
-    { w: 3,  v: function(d, b) { return "/*MXX1*/" + assign(d, b, "o", m("g") + "." + Random.index(builtinProperties)); } },
-    { w: 3,  v: function(d, b) { return "/*MXX2*/" + m("g") + "." + Random.index(builtinProperties) + " = " + m() + ";"; } },
-    { w: 3,  v: function(d, b) { var prop = Random.index(builtinProperties); return "/*MXX3*/" + m("g") + "." + prop + " = " + m("g") + "." + prop + ";"; } },
+    { w: 3,  v: function(d, b) { return "/*MXX1*/" + assign(d, b, "o", m("g") + "."
+      + Random.index(builtinProperties)
+    ); } },
+    { w: 3,  v: function(d, b) { return "/*MXX2*/" + m("g") + "." + Random.index(builtinProperties) + " = "
+      + m() + ";";
+    } },
+    { w: 3,  v: function(d, b) { var prop = Random.index(builtinProperties);
+      return "/*MXX3*/" + m("g") + "." + prop + " = " + m("g") + "." + prop + ";";
+    } },
 
     // f: function (?)
     // Could probably do better with args / b
@@ -396,16 +459,27 @@ var makeEvilCallback;
     { w: 2,  v: function(d, b) { return m("f") + "(" + m() + ");"; } },
 
     // v: Primitive
-    { w: 2,  v: function(d, b) { return assign(d, b, "v", Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"])); } },
-    { w: 1,  v: function(d, b) { return assign(d, b, "v", "new Number(" + Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"]) + ")"); } },
+    { w: 2,  v: function(d, b) { return assign(d, b, "v",
+      Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"])
+    ); } },
+    { w: 1,  v: function(d, b) { return assign(d, b, "v", "new Number("
+      + Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"]) + ")"
+    ); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", "new Number(" + m() + ")"); } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", makeBoolean(d, b)); } },
     { w: 2,  v: function(d, b) { return assign(d, b, "v", Random.index(["undefined", "null", "true", "false"])); } },
 
     // evil things we can do to any object property
-    { w: 1,  v: function(d, b) { return "/*ODP-1*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
-    { w: 1,  v: function(d, b) { return "/*ODP-2*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
-    { w: 1,  v: function(d, b) { return "/*ODP-3*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
+    { w: 1,  v: function(d, b) { return "/*ODP-1*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b)
+      + ", " + makePropertyDescriptor(d, b) + ");";
+    } },
+    { w: 1,  v: function(d, b) { return "/*ODP-2*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { "
+      + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b)
+      + " });";
+    } },
+    { w: 1,  v: function(d, b) { return "/*ODP-3*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { "
+      + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });";
+    } },
     { w: 1,  v: function(d, b) { return "delete " + m() + "[" + makePropertyName(d, b) + "];"; } },
     { w: 1,  v: function(d, b) { return assign(d, b, "v", m() + "[" + makePropertyName(d, b) + "]"); } },
     { w: 1,  v: function(d, b) { return m() + "[" + makePropertyName(d, b) + "] = " + val(d, b) + ";"; } },
@@ -424,8 +498,12 @@ var makeEvilCallback;
     { w: 10, v: function(d, b) { return m() + " + " + m() + ";"; } }, // valueOf
     { w: 10, v: function(d, b) { return m() + " + '';"; } }, // toString
     { w: 10, v: function(d, b) { return m("v") + " = (" + m() + " instanceof " + m() + ");"; } },
-    { w: 10, v: function(d, b) { return m("v") + " = Object.prototype.isPrototypeOf.call(" + m() + ", " + m() + ");"; } },
-    { w: 2,  v: function(d, b) { return "Object." + Random.index(["preventExtensions", "seal", "freeze"]) + "(" + m() + ");"; } },
+    { w: 10, v: function(d, b) { return m("v") + " = Object.prototype.isPrototypeOf.call(" + m() + ", "
+      + m() + ");";
+    } },
+    { w: 2,  v: function(d, b) { return "Object." + Random.index(["preventExtensions", "seal", "freeze"])
+      + "(" + m() + ");";
+    } },
 
     // Be promiscuous with the rest of jsfunfuzz
     { w: 1,  v: function(d, b) { return m() + " = x;"; } },
@@ -446,7 +524,8 @@ function infrequentCondition(v, n)
     case 0: return true;
     case 1: return false;
     case 2: return v + " > " + rnd(n);
-    default: var mod = rnd(n) + 2; var target = rnd(mod); return "/*ICCD*/" + v + " % " + mod + (rnd(8) ? " == " : " != ") + target;
+    default: var mod = rnd(n) + 2; var target = rnd(mod); return "/*ICCD*/" +
+      v + " % " + mod + (rnd(8) ? " == " : " != ") + target;
   }
 }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -179,10 +179,10 @@ var makeEvilCallback;
       ", saveIncrementalBytecode: " + makeBoolean(d, b) +
       ", sourceIsLazy: " + makeBoolean(d, b) +
       ", catchTermination: " + makeBoolean(d, b) +
-      ((rnd(5) == 0) ? (
-        ((rnd(2) == 0) ? (", element: " + m("o")) : "") +
-        ((rnd(2) == 0) ? (", elementAttributeName: " + m("s")) : "") +
-        ((rnd(2) == 0) ? (", sourceMapURL: " + m("s")) : "")
+      ((rnd(5) === 0) ? (
+        ((rnd(2) === 0) ? (", element: " + m("o")) : "") +
+        ((rnd(2) === 0) ? (", elementAttributeName: " + m("s")) : "") +
+        ((rnd(2) === 0) ? (", sourceMapURL: " + m("s")) : "")
       ) : ""
       ) +
     " })");
@@ -217,7 +217,7 @@ var makeEvilCallback;
   //   a1.push(x)
   function method (d, b, clazz, obj, meth, arglist) { // eslint-disable-line require-jsdoc
     // Sometimes ignore our arguments
-    if (rnd(10) == 0) { arglist = []; }
+    if (rnd(10) === 0) { arglist = []; }
 
     // Stuff in extra arguments
     while (rnd(2)) { arglist.push(val(d, b)); }

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -27,7 +27,7 @@ function totallyRandom (d, b) { // eslint-disable-line require-jsdoc
 function getListOfMakers (glob) { // eslint-disable-line require-jsdoc
   var r = [];
   for (var f in glob) {
-    if (f.indexOf("make") === 0 && typeof glob[f] === "function" && f !== "makeFinalizeObserver" && f !== "makeFakePromise") {
+    if (f.indexOf("make") == 0 && typeof glob[f] === "function" && f != "makeFinalizeObserver" && f != "makeFakePromise") {
       r.push(glob[f]);
     }
   }

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -27,11 +27,7 @@ function getListOfMakers(glob)
 {
   var r = [];
   for (var f in glob) {
-    if (f.indexOf("make") == 0 &&
-      typeof glob[f] == "function" &&
-      f != "makeFinalizeObserver" &&
-      f != "makeFakePromise"
-    ) {
+    if (f.indexOf("make") == 0 && typeof glob[f] == "function" && f != "makeFinalizeObserver" && f != "makeFakePromise") {
       r.push(glob[f]);
     }
   }

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global print, Random, rnd */
+
 // Randomly ignore the grammar 1 in TOTALLY_RANDOM times we generate any grammar node.
 var TOTALLY_RANDOM = 1000;
 

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -26,15 +26,15 @@ function totallyRandom(d, b) {
 function getListOfMakers(glob)
 {
   var r = [];
-  for (var f in glob) 
+  for (var f in glob) {
     if (f.indexOf("make") == 0 &&
       typeof glob[f] == "function" &&
       f != "makeFinalizeObserver" &&
       f != "makeFakePromise"
-    ) 
+    ) {
       r.push(glob[f]);
-    
-  
+    }
+  }
   return r;
 }
 

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -27,7 +27,7 @@ function totallyRandom (d, b) { // eslint-disable-line require-jsdoc
 function getListOfMakers (glob) { // eslint-disable-line require-jsdoc
   var r = [];
   for (var f in glob) {
-    if (f.indexOf("make") == 0 && typeof glob[f] === "function" && f != "makeFinalizeObserver" && f != "makeFakePromise") {
+    if (f.indexOf("make") === 0 && typeof glob[f] === "function" && f !== "makeFinalizeObserver" && f !== "makeFakePromise") {
       r.push(glob[f]);
     }
   }

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -19,7 +19,7 @@ function totallyRandom (d, b) { // eslint-disable-line require-jsdoc
   if (typeof val !== "string") {
     print(maker.name);
     print(maker);
-    throw "We generated something that isn't a string!";
+    throw new Error("We generated something that isn't a string!");
   }
   return val;
 }

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -27,7 +27,11 @@ function getListOfMakers(glob)
 {
   var r = [];
   for (var f in glob) {
-    if (f.indexOf("make") == 0 && typeof glob[f] == "function" && f != "makeFinalizeObserver" && f != "makeFakePromise") {
+    if (f.indexOf("make") == 0 &&
+      typeof glob[f] == "function" &&
+      f != "makeFinalizeObserver" &&
+      f != "makeFakePromise"
+    ) {
       r.push(glob[f]);
     }
   }

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported TOTALLY_RANDOM, totallyRandom */
 /* global print, Random, rnd */
 
 // Randomly ignore the grammar 1 in TOTALLY_RANDOM times we generate any grammar node.

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -11,12 +11,12 @@ var TOTALLY_RANDOM = 1000;
 
 var allMakers = getListOfMakers(this);
 
-function totallyRandom(d, b) {
+function totallyRandom (d, b) {
   d = d + (rnd(5) - 2); // can increase!!
 
   var maker = Random.index(allMakers);
   var val = maker(d, b);
-  if (typeof val != "string") {
+  if (typeof val !== "string") {
     print(maker.name);
     print(maker);
     throw "We generated something that isn't a string!";
@@ -24,17 +24,15 @@ function totallyRandom(d, b) {
   return val;
 }
 
-function getListOfMakers(glob)
-{
+function getListOfMakers (glob) {
   var r = [];
   for (var f in glob) {
-    if (f.indexOf("make") == 0 && typeof glob[f] == "function" && f != "makeFinalizeObserver" && f != "makeFakePromise") {
+    if (f.indexOf("make") == 0 && typeof glob[f] === "function" && f != "makeFinalizeObserver" && f != "makeFakePromise") {
       r.push(glob[f]);
     }
   }
   return r;
 }
-
 
 /*
 function testEachMaker()

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -11,7 +11,7 @@ var TOTALLY_RANDOM = 1000;
 
 var allMakers = getListOfMakers(this);
 
-function totallyRandom (d, b) {
+function totallyRandom (d, b) { // eslint-disable-line require-jsdoc
   d = d + (rnd(5) - 2); // can increase!!
 
   var maker = Random.index(allMakers);
@@ -24,7 +24,7 @@ function totallyRandom (d, b) {
   return val;
 }
 
-function getListOfMakers (glob) {
+function getListOfMakers (glob) { // eslint-disable-line require-jsdoc
   var r = [];
   for (var f in glob) {
     if (f.indexOf("make") == 0 && typeof glob[f] === "function" && f != "makeFinalizeObserver" && f != "makeFakePromise") {

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -26,15 +26,15 @@ function totallyRandom(d, b) {
 function getListOfMakers(glob)
 {
   var r = [];
-  for (var f in glob) {
+  for (var f in glob) 
     if (f.indexOf("make") == 0 &&
       typeof glob[f] == "function" &&
       f != "makeFinalizeObserver" &&
       f != "makeFakePromise"
-    ) {
+    ) 
       r.push(glob[f]);
-    }
-  }
+    
+  
   return r;
 }
 

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -21,64 +21,59 @@
 
 // Why did I decide to toString at every step, instead of making larger and larger arrays (or more and more deeply nested arrays?).  no particular reason.
 
-function cat(toks)
-{
-  if (rnd(1700) === 0)
-    return totallyRandom(2, ["x"]);
+function cat (toks) {
+  if (rnd(1700) === 0) { return totallyRandom(2, ["x"]); }
 
   var torture = (rnd(1700) === 57);
-  if (torture)
-    dumpln("Torture!!!");
+  if (torture) { dumpln("Torture!!!"); }
 
   var s = maybeLineBreak();
   for (var i = 0; i < toks.length; ++i) {
-
     // Catch bugs in the fuzzer.  An easy mistake is
     //   return /*foo*/ + ...
     // instead of
     //   return "/*foo*/" + ...
     // Unary plus in the first one coerces the string that follows to number!
-    if (typeof(toks[i]) != "string") {
-      dumpln("Strange item in the array passed to cat: typeof toks[" + i + "] == " + typeof(toks[i]));
+    if (typeof (toks[i]) !== "string") {
+      dumpln("Strange item in the array passed to cat: typeof toks[" + i + "] == " + typeof (toks[i]));
       dumpln(cat.caller);
       dumpln(cat.caller.caller);
     }
 
-    if (!(torture && rnd(12) === 0))
-      s += toks[i];
+    if (!(torture && rnd(12) === 0)) { s += toks[i]; }
 
     s += maybeLineBreak();
 
-    if (torture) switch (rnd(120)) {
-      case 0:
-      case 1:
-      case 2:
-      case 3:
-      case 4:
-        s += maybeSpace() + totallyRandom(2, ["x"]) + maybeSpace();
-        break;
-      case 5:
-        s = "(" + s + ")"; // randomly parenthesize some *prefix* of it.
-        break;
-      case 6:
-        s = ""; // throw away everything before this point
-        break;
-      case 7:
-        return s; // throw away everything after this point
-      case 8:
-        s += UNTERMINATED_COMMENT;
-        break;
-      case 9:
-        s += UNTERMINATED_STRING_LITERAL;
-        break;
-      case 10:
-        if (rnd(2))
-          s += "(";
-        s += UNTERMINATED_REGEXP_LITERAL;
-        break;
-      default:
+    if (torture) {
+      switch (rnd(120)) {
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+          s += maybeSpace() + totallyRandom(2, ["x"]) + maybeSpace();
+          break;
+        case 5:
+          s = "(" + s + ")"; // randomly parenthesize some *prefix* of it.
+          break;
+        case 6:
+          s = ""; // throw away everything before this point
+          break;
+        case 7:
+          return s; // throw away everything after this point
+        case 8:
+          s += UNTERMINATED_COMMENT;
+          break;
+        case 9:
+          s += UNTERMINATED_STRING_LITERAL;
+          break;
+        case 10:
+          if (rnd(2)) { s += "("; }
+          s += UNTERMINATED_REGEXP_LITERAL;
+          break;
+        default:
+      }
     }
-
   }
 
   return s;
@@ -101,36 +96,21 @@ function catNice(toks)
 }
 */
 
-
 var UNTERMINATED_COMMENT = "/*"; /* this comment is here so my text editor won't get confused */
 var UNTERMINATED_STRING_LITERAL = "'";
 var UNTERMINATED_REGEXP_LITERAL = "/";
 
-function maybeLineBreak()
-{
-  if (rnd(900) === 3)
-    return Random.index(["\r", "\n", "//h\n", "/*\n*/"]); // line break to trigger semicolon insertion and stuff
-  else if (rnd(400) === 3)
-    return rnd(2) ? "\u000C" : "\t"; // weird space-like characters
-  else
-    return "";
+function maybeLineBreak () {
+  if (rnd(900) === 3) { return Random.index(["\r", "\n", "//h\n", "/*\n*/"]); } // line break to trigger semicolon insertion and stuff
+  else if (rnd(400) === 3) { return rnd(2) ? "\u000C" : "\t"; } // weird space-like characters
+  else { return ""; }
 }
 
-function maybeSpace()
-{
-  if (rnd(2) === 0)
-    return " ";
-  else
-    return "";
+function maybeSpace () {
+  if (rnd(2) === 0) { return " "; } else { return ""; }
 }
 
-function stripSemicolon(c)
-{
+function stripSemicolon (c) {
   var len = c.length;
-  if (c.charAt(len - 1) == ";")
-    return c.substr(0, len - 1);
-  else
-    return c;
+  if (c.charAt(len - 1) == ";") { return c.substr(0, len - 1); } else { return c; }
 }
-
-

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -101,9 +101,13 @@ var UNTERMINATED_STRING_LITERAL = "'";
 var UNTERMINATED_REGEXP_LITERAL = "/";
 
 function maybeLineBreak () { // eslint-disable-line require-jsdoc
-  if (rnd(900) === 3) { return Random.index(["\r", "\n", "//h\n", "/*\n*/"]); } // line break to trigger semicolon insertion and stuff
-  else if (rnd(400) === 3) { return rnd(2) ? "\u000C" : "\t"; } // weird space-like characters
-  else { return ""; }
+  if (rnd(900) === 3) { // line break to trigger semicolon insertion and stuff
+    return Random.index(["\r", "\n", "//h\n", "/*\n*/"]);
+  } else if (rnd(400) === 3) { // weird space-like characters
+    return rnd(2) ? "\u000C" : "\t";
+  } else {
+    return "";
+  }
 }
 
 function maybeSpace () { // eslint-disable-line require-jsdoc

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -21,7 +21,7 @@
 
 // Why did I decide to toString at every step, instead of making larger and larger arrays (or more and more deeply nested arrays?).  no particular reason.
 
-function cat (toks) {
+function cat (toks) { // eslint-disable-line require-jsdoc
   if (rnd(1700) === 0) { return totallyRandom(2, ["x"]); }
 
   var torture = (rnd(1700) === 57);
@@ -100,17 +100,17 @@ var UNTERMINATED_COMMENT = "/*"; /* this comment is here so my text editor won't
 var UNTERMINATED_STRING_LITERAL = "'";
 var UNTERMINATED_REGEXP_LITERAL = "/";
 
-function maybeLineBreak () {
+function maybeLineBreak () { // eslint-disable-line require-jsdoc
   if (rnd(900) === 3) { return Random.index(["\r", "\n", "//h\n", "/*\n*/"]); } // line break to trigger semicolon insertion and stuff
   else if (rnd(400) === 3) { return rnd(2) ? "\u000C" : "\t"; } // weird space-like characters
   else { return ""; }
 }
 
-function maybeSpace () {
+function maybeSpace () { // eslint-disable-line require-jsdoc
   if (rnd(2) === 0) { return " "; } else { return ""; }
 }
 
-function stripSemicolon (c) {
+function stripSemicolon (c) { // eslint-disable-line require-jsdoc
   var len = c.length;
   if (c.charAt(len - 1) == ";") { return c.substr(0, len - 1); } else { return c; }
 }

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global dumpln, Random, rnd, totallyRandom */
+
 // Each input to |cat| should be a token or so, OR a bigger logical piece (such as a call to makeExpr).  Smaller than a token is ok too ;)
 
 // When "torture" is true, it may do any of the following:

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -5,8 +5,7 @@
 
 /* global dumpln, Random, rnd, totallyRandom */
 
-// Each input to |cat| should be a token or so, OR a bigger logical piece (such as a call to makeExpr).
-//   Smaller than a token is ok too ;)
+// Each input to |cat| should be a token or so, OR a bigger logical piece (such as a call to makeExpr).  Smaller than a token is ok too ;)
 
 // When "torture" is true, it may do any of the following:
 // * skip a token
@@ -19,8 +18,7 @@
 
 // Even when not in "torture" mode, it may sneak in extra line breaks.
 
-// Why did I decide to toString at every step, instead of making larger and larger arrays
-//   (or more and more deeply nested arrays?).  no particular reason.
+// Why did I decide to toString at every step, instead of making larger and larger arrays (or more and more deeply nested arrays?).  no particular reason.
 
 function cat(toks)
 {

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -48,7 +48,7 @@ function cat(toks)
 
     s += maybeLineBreak();
 
-    if (torture) switch(rnd(120)) {
+    if (torture) switch (rnd(120)) {
       case 0:
       case 1:
       case 2:

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -116,5 +116,5 @@ function maybeSpace () { // eslint-disable-line require-jsdoc
 
 function stripSemicolon (c) { // eslint-disable-line require-jsdoc
   var len = c.length;
-  if (c.charAt(len - 1) == ";") { return c.substr(0, len - 1); } else { return c; }
+  if (c.charAt(len - 1) === ";") { return c.substr(0, len - 1); } else { return c; }
 }

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported cat, stripSemicolon */
 /* global dumpln, Random, rnd, totallyRandom */
 
 // Each input to |cat| should be a token or so, OR a bigger logical piece (such as a call to makeExpr).  Smaller than a token is ok too ;)

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -116,5 +116,5 @@ function maybeSpace () { // eslint-disable-line require-jsdoc
 
 function stripSemicolon (c) { // eslint-disable-line require-jsdoc
   var len = c.length;
-  if (c.charAt(len - 1) === ";") { return c.substr(0, len - 1); } else { return c; }
+  if (c.charAt(len - 1) == ";") { return c.substr(0, len - 1); } else { return c; }
 }

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -5,7 +5,8 @@
 
 /* global dumpln, Random, rnd, totallyRandom */
 
-// Each input to |cat| should be a token or so, OR a bigger logical piece (such as a call to makeExpr).  Smaller than a token is ok too ;)
+// Each input to |cat| should be a token or so, OR a bigger logical piece (such as a call to makeExpr).
+//   Smaller than a token is ok too ;)
 
 // When "torture" is true, it may do any of the following:
 // * skip a token
@@ -18,7 +19,8 @@
 
 // Even when not in "torture" mode, it may sneak in extra line breaks.
 
-// Why did I decide to toString at every step, instead of making larger and larger arrays (or more and more deeply nested arrays?).  no particular reason.
+// Why did I decide to toString at every step, instead of making larger and larger arrays
+//   (or more and more deeply nested arrays?).  no particular reason.
 
 function cat(toks)
 {

--- a/src/funfuzz/js/jsfunfuzz/preamble.js
+++ b/src/funfuzz/js/jsfunfuzz/preamble.js
@@ -2,6 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-/* jshint moz:true, evil:true, sub:true, maxerr:10000 */
 //"use strict";
 var jsStrictMode = false;

--- a/src/funfuzz/js/jsfunfuzz/preamble.js
+++ b/src/funfuzz/js/jsfunfuzz/preamble.js
@@ -2,5 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//"use strict";
+// "use strict";
 var jsStrictMode = false;

--- a/src/funfuzz/js/jsfunfuzz/preamble.js
+++ b/src/funfuzz/js/jsfunfuzz/preamble.js
@@ -2,5 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported jsStrictMode */
+
 // "use strict";
 var jsStrictMode = false;

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported tryRunning, useSpidermonkeyShellSandbox */
 /* global dumpln, errorToString, evalcx, newGlobal, print, tryRunningDirectly, xpcshell */
 
 /* ***************** *

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -70,7 +70,7 @@ function useSpidermonkeyShellSandbox(sandboxType)
   return function(f, code, wtt) {
     try {
       evalcx(code, primarySandbox);
-    } catch(e) {
+    } catch (e) {
       dumpln("Running in sandbox threw " + errorToString(e));
     }
   };
@@ -100,7 +100,7 @@ function useGeckoSandbox() {
   return function(f, code, wtt) {
     try {
       Components.utils.evalInSandbox(code, primarySandbox); // eslint-disable-line no-undef
-    } catch(e) {
+    } catch (e) {
       // It might not be safe to operate on |e|.
     }
   };

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global dumpln, errorToString, evalcx, newGlobal, print, tryRunningDirectly, xpcshell */
+
 /*********************
  * SANDBOXED RUNNING *
  *********************/
@@ -80,12 +82,12 @@ function useSpidermonkeyShellSandbox(sandboxType)
 function newGeckoSandbox(n)
 {
   var t = (typeof n == "number") ? n : 1;
-  var s = Components.utils.Sandbox("http://x" + t + ".example.com/");
+  var s = Components.utils.Sandbox("http://x" + t + ".example.com/"); // eslint-disable-line no-undef
 
   // Allow the sandbox to do a few things
   s.newGeckoSandbox = newGeckoSandbox;
   s.evalInSandbox = function(str, sbx) {
-    return Components.utils.evalInSandbox(str, sbx);
+    return Components.utils.evalInSandbox(str, sbx); // eslint-disable-line no-undef
   };
   s.print = function(str) { print(str); };
 
@@ -97,7 +99,7 @@ function useGeckoSandbox() {
 
   return function(f, code, wtt) {
     try {
-      Components.utils.evalInSandbox(code, primarySandbox);
+      Components.utils.evalInSandbox(code, primarySandbox); // eslint-disable-line no-undef
     } catch(e) {
       // It might not be safe to operate on |e|.
     }

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -58,10 +58,10 @@ function useSpidermonkeyShellSandbox (sandboxType) { // eslint-disable-line requ
 
   switch (sandboxType) {
     /* eslint-disable no-multi-spaces */
-    case 0:  primarySandbox = evalcx("");
-    case 1:  primarySandbox = evalcx("lazy");
-    case 2:  primarySandbox = newGlobal({ sameCompartmentAs: {} });
-    case 3:  primarySandbox = newGlobal({ sameZoneAs: {} }); // same zone
+    case 0:  primarySandbox = evalcx(""); break;
+    case 1:  primarySandbox = evalcx("lazy"); break;
+    case 2:  primarySandbox = newGlobal({ sameCompartmentAs: {} }); break;
+    case 3:  primarySandbox = newGlobal({ sameZoneAs: {} }); break; // same zone
     default: primarySandbox = newGlobal(); // new zone
     /* eslint-enable no-multi-spaces */
   }

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -5,9 +5,9 @@
 
 /* global dumpln, errorToString, evalcx, newGlobal, print, tryRunningDirectly, xpcshell */
 
-/*********************
+/* ***************** *
  * SANDBOXED RUNNING *
- *********************/
+ * ***************** */
 
 // We support three ways to run generated code:
 // * useGeckoSandbox(), which uses Components.utils.Sandbox.
@@ -42,11 +42,11 @@ function fillShellSandbox(sandbox)
   for (var i = 0; i < safeFuns.length; ++i) {
     var fn = safeFuns[i];
     if (sandbox[fn]) {
-      //print("Target already has " + fn);
+      // print("Target already has " + fn);
     } else if (this[fn]) { // FIXME: strict mode compliance requires passing glob around
       sandbox[fn] = this[fn].bind(this);
     } else {
-      //print("Source is missing " + fn);
+      // print("Source is missing " + fn);
     }
   }
 

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -20,11 +20,11 @@
 //   * This creates the most "interesting" testcases.
 
 var tryRunning;
-if (xpcshell) { // Adapted from ternary operator - this longer form helps reducers reduce better
+if (xpcshell)  // Adapted from ternary operator - this longer form helps reducers reduce better
   tryRunning = useGeckoSandbox();
-} else {
+else 
   tryRunning = tryRunningDirectly;
-}
+
 
 function fillShellSandbox(sandbox)
 {

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -20,11 +20,11 @@
 //   * This creates the most "interesting" testcases.
 
 var tryRunning;
-if (xpcshell)  // Adapted from ternary operator - this longer form helps reducers reduce better
+if (xpcshell) { // Adapted from ternary operator - this longer form helps reducers reduce better
   tryRunning = useGeckoSandbox();
-else 
+} else {
   tryRunning = tryRunningDirectly;
-
+}
 
 function fillShellSandbox(sandbox)
 {

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -59,8 +59,8 @@ function useSpidermonkeyShellSandbox(sandboxType)
 
   switch (sandboxType) {
     /* eslint-disable no-multi-spaces */
-    case 0:  primarySandbox = evalcx('');
-    case 1:  primarySandbox = evalcx('lazy');
+    case 0:  primarySandbox = evalcx("");
+    case 1:  primarySandbox = evalcx("lazy");
     case 2:  primarySandbox = newGlobal({sameCompartmentAs: {}});
     case 3:  primarySandbox = newGlobal({sameZoneAs: {}}); // same zone
     default: primarySandbox = newGlobal(); // new zone

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -20,7 +20,7 @@
 //   * This creates the most "interesting" testcases.
 
 var tryRunning;
-if (xpcshell) {  // Adapted from ternary operator - this longer form helps reducers reduce better
+if (xpcshell) { // Adapted from ternary operator - this longer form helps reducers reduce better
   tryRunning = useGeckoSandbox();
 } else {
   tryRunning = tryRunningDirectly;
@@ -58,11 +58,13 @@ function useSpidermonkeyShellSandbox(sandboxType)
   var primarySandbox;
 
   switch (sandboxType) {
+    /* eslint-disable no-multi-spaces */
     case 0:  primarySandbox = evalcx('');
     case 1:  primarySandbox = evalcx('lazy');
     case 2:  primarySandbox = newGlobal({sameCompartmentAs: {}});
     case 3:  primarySandbox = newGlobal({sameZoneAs: {}}); // same zone
     default: primarySandbox = newGlobal(); // new zone
+    /* eslint-enable no-multi-spaces */
   }
 
   fillShellSandbox(primarySandbox);

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -27,8 +27,7 @@ if (xpcshell) { // Adapted from ternary operator - this longer form helps reduce
   tryRunning = tryRunningDirectly;
 }
 
-function fillShellSandbox(sandbox)
-{
+function fillShellSandbox (sandbox) {
   var safeFuns = [
     "print",
     "schedulegc", "selectforgc", "gczeal", "gc", "gcslice",
@@ -37,7 +36,7 @@ function fillShellSandbox(sandbox)
     "evalcx", "newGlobal", "evaluate",
     "dumpln", "fillShellSandbox",
     "testMathyFunction", "hashStr",
-    "isAsmJSCompilationAvailable",
+    "isAsmJSCompilationAvailable"
   ];
 
   for (var i = 0; i < safeFuns.length; ++i) {
@@ -54,23 +53,22 @@ function fillShellSandbox(sandbox)
   return sandbox;
 }
 
-function useSpidermonkeyShellSandbox(sandboxType)
-{
+function useSpidermonkeyShellSandbox (sandboxType) {
   var primarySandbox;
 
   switch (sandboxType) {
     /* eslint-disable no-multi-spaces */
     case 0:  primarySandbox = evalcx("");
     case 1:  primarySandbox = evalcx("lazy");
-    case 2:  primarySandbox = newGlobal({sameCompartmentAs: {}});
-    case 3:  primarySandbox = newGlobal({sameZoneAs: {}}); // same zone
+    case 2:  primarySandbox = newGlobal({ sameCompartmentAs: {} });
+    case 3:  primarySandbox = newGlobal({ sameZoneAs: {} }); // same zone
     default: primarySandbox = newGlobal(); // new zone
     /* eslint-enable no-multi-spaces */
   }
 
   fillShellSandbox(primarySandbox);
 
-  return function(f, code, wtt) {
+  return function (f, code, wtt) {
     try {
       evalcx(code, primarySandbox);
     } catch (e) {
@@ -82,25 +80,24 @@ function useSpidermonkeyShellSandbox(sandboxType)
 // When in xpcshell,
 // * Run all testing in a sandbox so it doesn't accidentally wipe my hard drive.
 // * Test interaction between sandboxes with same or different principals.
-function newGeckoSandbox(n)
-{
-  var t = (typeof n == "number") ? n : 1;
+function newGeckoSandbox (n) {
+  var t = (typeof n === "number") ? n : 1;
   var s = Components.utils.Sandbox("http://x" + t + ".example.com/"); // eslint-disable-line no-undef
 
   // Allow the sandbox to do a few things
   s.newGeckoSandbox = newGeckoSandbox;
-  s.evalInSandbox = function(str, sbx) {
+  s.evalInSandbox = function (str, sbx) {
     return Components.utils.evalInSandbox(str, sbx); // eslint-disable-line no-undef
   };
-  s.print = function(str) { print(str); };
+  s.print = function (str) { print(str); };
 
   return s;
 }
 
-function useGeckoSandbox() {
+function useGeckoSandbox () {
   var primarySandbox = newGeckoSandbox(0);
 
-  return function(f, code, wtt) {
+  return function (f, code, wtt) {
     try {
       Components.utils.evalInSandbox(code, primarySandbox); // eslint-disable-line no-undef
     } catch (e) {

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -27,7 +27,7 @@ if (xpcshell) { // Adapted from ternary operator - this longer form helps reduce
   tryRunning = tryRunningDirectly;
 }
 
-function fillShellSandbox (sandbox) {
+function fillShellSandbox (sandbox) { // eslint-disable-line require-jsdoc
   var safeFuns = [
     "print",
     "schedulegc", "selectforgc", "gczeal", "gc", "gcslice",
@@ -53,7 +53,7 @@ function fillShellSandbox (sandbox) {
   return sandbox;
 }
 
-function useSpidermonkeyShellSandbox (sandboxType) {
+function useSpidermonkeyShellSandbox (sandboxType) { // eslint-disable-line require-jsdoc
   var primarySandbox;
 
   switch (sandboxType) {
@@ -80,7 +80,7 @@ function useSpidermonkeyShellSandbox (sandboxType) {
 // When in xpcshell,
 // * Run all testing in a sandbox so it doesn't accidentally wipe my hard drive.
 // * Test interaction between sandboxes with same or different principals.
-function newGeckoSandbox (n) {
+function newGeckoSandbox (n) { // eslint-disable-line require-jsdoc
   var t = (typeof n === "number") ? n : 1;
   var s = Components.utils.Sandbox("http://x" + t + ".example.com/"); // eslint-disable-line no-undef
 
@@ -94,7 +94,7 @@ function newGeckoSandbox (n) {
   return s;
 }
 
-function useGeckoSandbox () {
+function useGeckoSandbox () { // eslint-disable-line require-jsdoc
   var primarySandbox = newGeckoSandbox(0);
 
   return function (f, code, wtt) {

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -125,7 +125,9 @@ function tryItOut(code)
   if (!wtt.allowParse)
     return;
 
-  code = code.replace(/\/\*DUPTRY\d+\*\//, function(k) { var n = parseInt(k.substr(8), 10); dumpln(n); return strTimes("try{}catch(e){}", n); });
+  code = code.replace(/\/\*DUPTRY\d+\*\//,
+    function(k) { var n = parseInt(k.substr(8), 10); dumpln(n); return strTimes("try{}catch(e){}", n); }
+  );
 
   if (jsStrictMode)
     code = "'use strict'; " + code; // ES5 10.1.1: new Function does not inherit strict mode
@@ -149,7 +151,11 @@ function tryItOut(code)
       // But leave some things out of function(){} because some bugs are only detectable at top-level, and
       // pure jsfunfuzz doesn't test top-level at all.
       // (This is a good reason to use compare_jit even if I'm not interested in finding JIT bugs!)
-      if (nCode.indexOf("return") != -1 || nCode.indexOf("yield") != -1 || nCode.indexOf("const") != -1 || failsToCompileInTry(nCode))
+      if (nCode.indexOf("return") != -1 ||
+        nCode.indexOf("yield") != -1 ||
+        nCode.indexOf("const") != -1 ||
+        failsToCompileInTry(nCode)
+      )
         nCode = "(function(){" + nCode + "})()";
       dumpln(cookie1 + cookie2 + " try { " + nCode + " } catch(e) { }");
     }

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -13,7 +13,7 @@
 
 // Hack to make line numbers be consistent, to make spidermonkey
 // disassemble() comparison testing easier (e.g. for round-trip testing)
-function directEvalC (s) { var c; /* evil closureizer */ return eval(s); } // eslint-disable-line no-eval,require-jsdoc
+function directEvalC (s) { var c; /* evil closureizer */ return eval(s); } // eslint-disable-line no-eval,no-unused-vars,require-jsdoc
 function newFun (s) { return new Function(s); } // eslint-disable-line no-new-func,require-jsdoc
 
 function tryRunningDirectly (f, code, wtt) { // eslint-disable-line require-jsdoc

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -6,9 +6,9 @@
 /* global confused, count, dumpln, errorToString, failsToCompileInTry, gc, gczeal, jsStrictMode, optionalTests */
 /* global resetOOMFailure, strTimes, tryRunning, uneval, verbose, whatToTest */
 
-/***********************
+/* ******************* *
  * UNSANDBOXED RUNNING *
- ***********************/
+ * ******************* */
 
 // Hack to make line numbers be consistent, to make spidermonkey
 // disassemble() comparison testing easier (e.g. for round-trip testing)

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -125,9 +125,7 @@ function tryItOut(code)
   if (!wtt.allowParse)
     return;
 
-  code = code.replace(/\/\*DUPTRY\d+\*\//,
-    function(k) { var n = parseInt(k.substr(8), 10); dumpln(n); return strTimes("try{}catch(e){}", n); }
-  );
+  code = code.replace(/\/\*DUPTRY\d+\*\//, function(k) { var n = parseInt(k.substr(8), 10); dumpln(n); return strTimes("try{}catch(e){}", n); });
 
   if (jsStrictMode)
     code = "'use strict'; " + code; // ES5 10.1.1: new Function does not inherit strict mode
@@ -151,11 +149,7 @@ function tryItOut(code)
       // But leave some things out of function(){} because some bugs are only detectable at top-level, and
       // pure jsfunfuzz doesn't test top-level at all.
       // (This is a good reason to use compare_jit even if I'm not interested in finding JIT bugs!)
-      if (nCode.indexOf("return") != -1 ||
-        nCode.indexOf("yield") != -1 ||
-        nCode.indexOf("const") != -1 ||
-        failsToCompileInTry(nCode)
-      )
+      if (nCode.indexOf("return") != -1 || nCode.indexOf("yield") != -1 || nCode.indexOf("const") != -1 || failsToCompileInTry(nCode))
         nCode = "(function(){" + nCode + "})()";
       dumpln(cookie1 + cookie2 + " try { " + nCode + " } catch(e) { }");
     }

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -18,7 +18,7 @@ function tryRunningDirectly(f, code, wtt)
 {
   if (count % 23 == 3) {
     dumpln("Plain eval!");
-    try { eval(code); } catch(e) { }
+    try { eval(code); } catch (e) { }
     tryEnsureSanity();
     return;
   }
@@ -34,8 +34,8 @@ function tryRunningDirectly(f, code, wtt)
     var rv = f();
     if (verbose)
       dumpln("It ran!");
-  } catch(runError) {
-    if(verbose)
+  } catch (runError) {
+    if (verbose)
       dumpln("Running threw!  About to toString to error.");
     var err = errorToString(runError);
     dumpln("Running threw: " + err);
@@ -61,17 +61,17 @@ function tryEnsureSanity()
   try {
     if (typeof resetOOMFailure == "function")
       resetOOMFailure();
-  } catch(e) { }
+  } catch (e) { }
 
   try {
     // The script might have turned on gczeal.
     // Turn it off to avoid slowness.
     if (typeof gczeal == "function")
       gczeal(0);
-  } catch(e) { }
+  } catch (e) { }
 
   // At least one bug in the past has put exceptions in strange places.  This also catches "eval getter" issues.
-  try { eval(""); } catch(e) { dumpln("That really shouldn't have thrown: " + errorToString(e)); }
+  try { eval(""); } catch (e) { dumpln("That really shouldn't have thrown: " + errorToString(e)); }
 
   if (!this) {
     // Strict mode. Great.
@@ -96,7 +96,7 @@ function tryEnsureSanity()
     this.gc = realGC;
     this.uneval = realUneval;
     this.toString = realToString;
-  } catch(e) {
+  } catch (e) {
     confused("tryEnsureSanity failed: " + errorToString(e));
   }
 
@@ -133,7 +133,7 @@ function tryItOut(code)
   var f;
   try {
     f = new Function(code);
-  } catch(compileError) {
+  } catch (compileError) {
     dumpln("Compiling threw: " + errorToString(compileError));
   }
 

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -73,10 +73,10 @@ function tryEnsureSanity()
   // At least one bug in the past has put exceptions in strange places.  This also catches "eval getter" issues.
   try { eval(""); } catch (e) { dumpln("That really shouldn't have thrown: " + errorToString(e)); }
 
-  if (!this) 
+  if (!this) {
     // Strict mode. Great.
     return;
-  
+  }
 
   try {
     if ("__defineSetter__" in this) {
@@ -139,7 +139,7 @@ function tryItOut(code)
     dumpln("Compiling threw: " + errorToString(compileError));
   }
 
-  if (f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossJITs) 
+  if (f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossJITs) {
     if (code.indexOf("\n") == -1 && code.indexOf("\r") == -1 && code.indexOf("\f") == -1 && code.indexOf("\0") == -1 &&
         code.indexOf("\u2028") == -1 && code.indexOf("\u2029") == -1 &&
         code.indexOf("<--") == -1 && code.indexOf("-->") == -1 && code.indexOf("//") == -1) {
@@ -159,15 +159,15 @@ function tryItOut(code)
         nCode = "(function(){" + nCode + "})()";
       dumpln(cookie1 + cookie2 + " try { " + nCode + " } catch(e) { }");
     }
-  
+  }
 
-  if (tryRunning != tryRunningDirectly) 
+  if (tryRunning != tryRunningDirectly) {
     optionalTests(f, code, wtt);
-  
+  }
 
-  if (wtt.allowExec && f) 
+  if (wtt.allowExec && f) {
     tryRunning(f, code, wtt);
-  
+  }
 
   if (verbose)
     dumpln("Done trying out that function!");

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -13,9 +13,10 @@
 
 // Hack to make line numbers be consistent, to make spidermonkey
 // disassemble() comparison testing easier (e.g. for round-trip testing)
-function directEvalC (s) { var c; /* evil closureizer */ return eval(s); } function newFun (s) { return new Function(s); }
+function directEvalC (s) { var c; /* evil closureizer */ return eval(s); } // eslint-disable-line require-jsdoc
+function newFun (s) { return new Function(s); } // eslint-disable-line require-jsdoc
 
-function tryRunningDirectly (f, code, wtt) {
+function tryRunningDirectly (f, code, wtt) { // eslint-disable-line require-jsdoc
   if (count % 23 == 3) {
     dumpln("Plain eval!");
     try { eval(code); } catch (e) { }
@@ -49,7 +50,7 @@ var realGC = gc;
 var realUneval = uneval;
 var realToString = toString;
 
-function tryEnsureSanity () {
+function tryEnsureSanity () { // eslint-disable-line require-jsdoc
   // The script might have set up oomAfterAllocations or oomAtAllocation.
   // Turn it off so we can test only generated code with it.
   try {
@@ -96,7 +97,7 @@ function tryEnsureSanity () {
   if (Function != realFunction) { confused("Fuzz script replaced |Function|"); }
 }
 
-function tryItOut (code) {
+function tryItOut (code) { // eslint-disable-line require-jsdoc
   // Accidentally leaving gczeal enabled for a long time would make jsfunfuzz really slow.
   if (typeof gczeal === "function") { gczeal(0); }
 

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported newFun, tryItOut */
 /* global confused, count, dumpln, errorToString, failsToCompileInTry, gc, gczeal, jsStrictMode, optionalTests */
 /* global resetOOMFailure, strTimes, tryRunning, uneval, verbose, whatToTest */
 

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -13,13 +13,13 @@
 
 // Hack to make line numbers be consistent, to make spidermonkey
 // disassemble() comparison testing easier (e.g. for round-trip testing)
-function directEvalC (s) { var c; /* evil closureizer */ return eval(s); } // eslint-disable-line require-jsdoc
+function directEvalC (s) { var c; /* evil closureizer */ return eval(s); } // eslint-disable-line no-eval,require-jsdoc
 function newFun (s) { return new Function(s); } // eslint-disable-line require-jsdoc
 
 function tryRunningDirectly (f, code, wtt) { // eslint-disable-line require-jsdoc
   if (count % 23 == 3) {
     dumpln("Plain eval!");
-    try { eval(code); } catch (e) { }
+    try { eval(code); } catch (e) { } // eslint-disable-line no-eval
     tryEnsureSanity();
     return;
   }
@@ -43,7 +43,7 @@ function tryRunningDirectly (f, code, wtt) { // eslint-disable-line require-jsdo
 }
 
 // Store things now so we can restore sanity later.
-var realEval = eval;
+var realEval = eval; // eslint-disable-line no-eval
 var realMath = Math;
 var realFunction = Function;
 var realGC = gc;
@@ -64,7 +64,9 @@ function tryEnsureSanity () { // eslint-disable-line require-jsdoc
   } catch (e) { }
 
   // At least one bug in the past has put exceptions in strange places.  This also catches "eval getter" issues.
-  try { eval(""); } catch (e) { dumpln("That really shouldn't have thrown: " + errorToString(e)); }
+  try { eval(""); } catch (e) { // eslint-disable-line no-eval
+    dumpln("That really shouldn't have thrown: " + errorToString(e));
+  }
 
   if (!this) {
     // Strict mode. Great.
@@ -74,7 +76,7 @@ function tryEnsureSanity () { // eslint-disable-line require-jsdoc
   try {
     if ("__defineSetter__" in this) {
       // The only way to get rid of getters/setters is to delete the property.
-      if (!jsStrictMode) { delete this.eval; }
+      if (!jsStrictMode) { delete this.eval; } // eslint-disable-line no-eval
       delete this.Math;
       delete this.Function;
       delete this.gc;
@@ -83,7 +85,7 @@ function tryEnsureSanity () { // eslint-disable-line require-jsdoc
     }
 
     this.Math = realMath;
-    this.eval = realEval;
+    this.eval = realEval; // eslint-disable-line no-eval
     this.Function = realFunction;
     this.gc = realGC;
     this.uneval = realUneval;
@@ -93,7 +95,7 @@ function tryEnsureSanity () { // eslint-disable-line require-jsdoc
   }
 
   // These can fail if the page creates a getter for "eval", for example.
-  if (this.eval != realEval) { confused("Fuzz script replaced |eval|"); }
+  if (this.eval != realEval) { confused("Fuzz script replaced |eval|"); } // eslint-disable-line no-eval
   if (Function != realFunction) { confused("Fuzz script replaced |Function|"); }
 }
 

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -17,14 +17,14 @@ function directEvalC (s) { var c; /* evil closureizer */ return eval(s); } // es
 function newFun (s) { return new Function(s); } // eslint-disable-line no-new-func,require-jsdoc
 
 function tryRunningDirectly (f, code, wtt) { // eslint-disable-line require-jsdoc
-  if (count % 23 == 3) {
+  if (count % 23 === 3) {
     dumpln("Plain eval!");
     try { eval(code); } catch (e) { } // eslint-disable-line no-eval
     tryEnsureSanity();
     return;
   }
 
-  if (count % 23 == 4) {
+  if (count % 23 === 4) {
     dumpln("About to recompile, using eval hack.");
     f = directEvalC("(function(){" + code + "});");
   }
@@ -95,8 +95,8 @@ function tryEnsureSanity () { // eslint-disable-line require-jsdoc
   }
 
   // These can fail if the page creates a getter for "eval", for example.
-  if (this.eval != realEval) { confused("Fuzz script replaced |eval|"); } // eslint-disable-line no-eval
-  if (Function != realFunction) { confused("Fuzz script replaced |Function|"); }
+  if (this.eval !== realEval) { confused("Fuzz script replaced |eval|"); } // eslint-disable-line no-eval
+  if (Function !== realFunction) { confused("Fuzz script replaced |Function|"); }
 }
 
 function tryItOut (code) { // eslint-disable-line require-jsdoc
@@ -104,7 +104,7 @@ function tryItOut (code) { // eslint-disable-line require-jsdoc
   if (typeof gczeal === "function") { gczeal(0); }
 
   // SpiderMonkey shell does not schedule GC on its own.  Help it not use too much memory.
-  if (count % 1000 == 0) {
+  if (count % 1000 === 0) {
     dumpln("Paranoid GC (count=" + count + ")!");
     realGC();
   }
@@ -125,9 +125,9 @@ function tryItOut (code) { // eslint-disable-line require-jsdoc
   }
 
   if (f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossJITs) {
-    if (code.indexOf("\n") == -1 && code.indexOf("\r") == -1 && code.indexOf("\f") == -1 && code.indexOf("\0") == -1 &&
-        code.indexOf("\u2028") == -1 && code.indexOf("\u2029") == -1 &&
-        code.indexOf("<--") == -1 && code.indexOf("-->") == -1 && code.indexOf("//") == -1) {
+    if (code.indexOf("\n") === -1 && code.indexOf("\r") === -1 && code.indexOf("\f") === -1 && code.indexOf("\0") === -1 &&
+        code.indexOf("\u2028") === -1 && code.indexOf("\u2029") === -1 &&
+        code.indexOf("<--") === -1 && code.indexOf("-->") === -1 && code.indexOf("//") === -1) {
       // FCM cookie, lines with this cookie are used for compare_jit
       var cookie1 = "/*F";
       var cookie2 = "CM*/";
@@ -136,12 +136,12 @@ function tryItOut (code) { // eslint-disable-line require-jsdoc
       // But leave some things out of function(){} because some bugs are only detectable at top-level, and
       // pure jsfunfuzz doesn't test top-level at all.
       // (This is a good reason to use compare_jit even if I'm not interested in finding JIT bugs!)
-      if (nCode.indexOf("return") != -1 || nCode.indexOf("yield") != -1 || nCode.indexOf("const") != -1 || failsToCompileInTry(nCode)) { nCode = "(function(){" + nCode + "})()"; }
+      if (nCode.indexOf("return") !== -1 || nCode.indexOf("yield") !== -1 || nCode.indexOf("const") !== -1 || failsToCompileInTry(nCode)) { nCode = "(function(){" + nCode + "})()"; }
       dumpln(cookie1 + cookie2 + " try { " + nCode + " } catch(e) { }");
     }
   }
 
-  if (tryRunning != tryRunningDirectly) {
+  if (tryRunning !== tryRunningDirectly) {
     optionalTests(f, code, wtt);
   }
 

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -17,14 +17,14 @@ function directEvalC (s) { var c; /* evil closureizer */ return eval(s); } // es
 function newFun (s) { return new Function(s); } // eslint-disable-line no-new-func,require-jsdoc
 
 function tryRunningDirectly (f, code, wtt) { // eslint-disable-line require-jsdoc
-  if (count % 23 === 3) {
+  if (count % 23 == 3) {
     dumpln("Plain eval!");
     try { eval(code); } catch (e) { } // eslint-disable-line no-eval
     tryEnsureSanity();
     return;
   }
 
-  if (count % 23 === 4) {
+  if (count % 23 == 4) {
     dumpln("About to recompile, using eval hack.");
     f = directEvalC("(function(){" + code + "});");
   }
@@ -95,8 +95,8 @@ function tryEnsureSanity () { // eslint-disable-line require-jsdoc
   }
 
   // These can fail if the page creates a getter for "eval", for example.
-  if (this.eval !== realEval) { confused("Fuzz script replaced |eval|"); } // eslint-disable-line no-eval
-  if (Function !== realFunction) { confused("Fuzz script replaced |Function|"); }
+  if (this.eval != realEval) { confused("Fuzz script replaced |eval|"); } // eslint-disable-line no-eval
+  if (Function != realFunction) { confused("Fuzz script replaced |Function|"); }
 }
 
 function tryItOut (code) { // eslint-disable-line require-jsdoc
@@ -104,7 +104,7 @@ function tryItOut (code) { // eslint-disable-line require-jsdoc
   if (typeof gczeal === "function") { gczeal(0); }
 
   // SpiderMonkey shell does not schedule GC on its own.  Help it not use too much memory.
-  if (count % 1000 === 0) {
+  if (count % 1000 == 0) {
     dumpln("Paranoid GC (count=" + count + ")!");
     realGC();
   }
@@ -125,9 +125,9 @@ function tryItOut (code) { // eslint-disable-line require-jsdoc
   }
 
   if (f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossJITs) {
-    if (code.indexOf("\n") === -1 && code.indexOf("\r") === -1 && code.indexOf("\f") === -1 && code.indexOf("\0") === -1 &&
-        code.indexOf("\u2028") === -1 && code.indexOf("\u2029") === -1 &&
-        code.indexOf("<--") === -1 && code.indexOf("-->") === -1 && code.indexOf("//") === -1) {
+    if (code.indexOf("\n") == -1 && code.indexOf("\r") == -1 && code.indexOf("\f") == -1 && code.indexOf("\0") == -1 &&
+        code.indexOf("\u2028") == -1 && code.indexOf("\u2029") == -1 &&
+        code.indexOf("<--") == -1 && code.indexOf("-->") == -1 && code.indexOf("//") == -1) {
       // FCM cookie, lines with this cookie are used for compare_jit
       var cookie1 = "/*F";
       var cookie2 = "CM*/";
@@ -136,12 +136,12 @@ function tryItOut (code) { // eslint-disable-line require-jsdoc
       // But leave some things out of function(){} because some bugs are only detectable at top-level, and
       // pure jsfunfuzz doesn't test top-level at all.
       // (This is a good reason to use compare_jit even if I'm not interested in finding JIT bugs!)
-      if (nCode.indexOf("return") !== -1 || nCode.indexOf("yield") !== -1 || nCode.indexOf("const") !== -1 || failsToCompileInTry(nCode)) { nCode = "(function(){" + nCode + "})()"; }
+      if (nCode.indexOf("return") != -1 || nCode.indexOf("yield") != -1 || nCode.indexOf("const") != -1 || failsToCompileInTry(nCode)) { nCode = "(function(){" + nCode + "})()"; }
       dumpln(cookie1 + cookie2 + " try { " + nCode + " } catch(e) { }");
     }
   }
 
-  if (tryRunning !== tryRunningDirectly) {
+  if (tryRunning != tryRunningDirectly) {
     optionalTests(f, code, wtt);
   }
 

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -31,7 +31,7 @@ function tryRunningDirectly (f, code, wtt) { // eslint-disable-line require-jsdo
 
   try {
     if (verbose) { dumpln("About to run it!"); }
-    var rv = f();
+    f();
     if (verbose) { dumpln("It ran!"); }
   } catch (runError) {
     if (verbose) { dumpln("Running threw!  About to toString to error."); }

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -79,7 +79,7 @@ function tryEnsureSanity()
   }
 
   try {
-    if ('__defineSetter__' in this) {
+    if ("__defineSetter__" in this) {
       // The only way to get rid of getters/setters is to delete the property.
       if (!jsStrictMode)
         delete this.eval;

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -73,10 +73,10 @@ function tryEnsureSanity()
   // At least one bug in the past has put exceptions in strange places.  This also catches "eval getter" issues.
   try { eval(""); } catch (e) { dumpln("That really shouldn't have thrown: " + errorToString(e)); }
 
-  if (!this) {
+  if (!this) 
     // Strict mode. Great.
     return;
-  }
+  
 
   try {
     if ("__defineSetter__" in this) {
@@ -139,7 +139,7 @@ function tryItOut(code)
     dumpln("Compiling threw: " + errorToString(compileError));
   }
 
-  if (f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossJITs) {
+  if (f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossJITs) 
     if (code.indexOf("\n") == -1 && code.indexOf("\r") == -1 && code.indexOf("\f") == -1 && code.indexOf("\0") == -1 &&
         code.indexOf("\u2028") == -1 && code.indexOf("\u2029") == -1 &&
         code.indexOf("<--") == -1 && code.indexOf("-->") == -1 && code.indexOf("//") == -1) {
@@ -159,15 +159,15 @@ function tryItOut(code)
         nCode = "(function(){" + nCode + "})()";
       dumpln(cookie1 + cookie2 + " try { " + nCode + " } catch(e) { }");
     }
-  }
+  
 
-  if (tryRunning != tryRunningDirectly) {
+  if (tryRunning != tryRunningDirectly) 
     optionalTests(f, code, wtt);
-  }
+  
 
-  if (wtt.allowExec && f) {
+  if (wtt.allowExec && f) 
     tryRunning(f, code, wtt);
-  }
+  
 
   if (verbose)
     dumpln("Done trying out that function!");

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -3,6 +3,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global confused, count, dumpln, errorToString, failsToCompileInTry, gc, gczeal, jsStrictMode, optionalTests */
+/* global resetOOMFailure, strTimes, tryRunning, uneval, verbose, whatToTest */
+
 /***********************
  * UNSANDBOXED RUNNING *
  ***********************/

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -14,7 +14,7 @@
 // Hack to make line numbers be consistent, to make spidermonkey
 // disassemble() comparison testing easier (e.g. for round-trip testing)
 function directEvalC (s) { var c; /* evil closureizer */ return eval(s); } // eslint-disable-line no-eval,require-jsdoc
-function newFun (s) { return new Function(s); } // eslint-disable-line require-jsdoc
+function newFun (s) { return new Function(s); } // eslint-disable-line no-new-func,require-jsdoc
 
 function tryRunningDirectly (f, code, wtt) { // eslint-disable-line require-jsdoc
   if (count % 23 == 3) {
@@ -119,7 +119,7 @@ function tryItOut (code) { // eslint-disable-line require-jsdoc
 
   var f;
   try {
-    f = new Function(code);
+    f = new Function(code); // eslint-disable-line no-new-func
   } catch (compileError) {
     dumpln("Compiling threw: " + errorToString(compileError));
   }

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -13,10 +13,9 @@
 
 // Hack to make line numbers be consistent, to make spidermonkey
 // disassemble() comparison testing easier (e.g. for round-trip testing)
-function directEvalC(s) { var c; /* evil closureizer */ return eval(s); } function newFun(s) { return new Function(s); }
+function directEvalC (s) { var c; /* evil closureizer */ return eval(s); } function newFun (s) { return new Function(s); }
 
-function tryRunningDirectly(f, code, wtt)
-{
+function tryRunningDirectly (f, code, wtt) {
   if (count % 23 == 3) {
     dumpln("Plain eval!");
     try { eval(code); } catch (e) { }
@@ -30,21 +29,17 @@ function tryRunningDirectly(f, code, wtt)
   }
 
   try {
-    if (verbose)
-      dumpln("About to run it!");
+    if (verbose) { dumpln("About to run it!"); }
     var rv = f();
-    if (verbose)
-      dumpln("It ran!");
+    if (verbose) { dumpln("It ran!"); }
   } catch (runError) {
-    if (verbose)
-      dumpln("Running threw!  About to toString to error.");
+    if (verbose) { dumpln("Running threw!  About to toString to error."); }
     var err = errorToString(runError);
     dumpln("Running threw: " + err);
   }
 
   tryEnsureSanity();
 }
-
 
 // Store things now so we can restore sanity later.
 var realEval = eval;
@@ -54,21 +49,17 @@ var realGC = gc;
 var realUneval = uneval;
 var realToString = toString;
 
-
-function tryEnsureSanity()
-{
+function tryEnsureSanity () {
   // The script might have set up oomAfterAllocations or oomAtAllocation.
   // Turn it off so we can test only generated code with it.
   try {
-    if (typeof resetOOMFailure == "function")
-      resetOOMFailure();
+    if (typeof resetOOMFailure === "function") { resetOOMFailure(); }
   } catch (e) { }
 
   try {
     // The script might have turned on gczeal.
     // Turn it off to avoid slowness.
-    if (typeof gczeal == "function")
-      gczeal(0);
+    if (typeof gczeal === "function") { gczeal(0); }
   } catch (e) { }
 
   // At least one bug in the past has put exceptions in strange places.  This also catches "eval getter" issues.
@@ -82,8 +73,7 @@ function tryEnsureSanity()
   try {
     if ("__defineSetter__" in this) {
       // The only way to get rid of getters/setters is to delete the property.
-      if (!jsStrictMode)
-        delete this.eval;
+      if (!jsStrictMode) { delete this.eval; }
       delete this.Math;
       delete this.Function;
       delete this.gc;
@@ -102,18 +92,13 @@ function tryEnsureSanity()
   }
 
   // These can fail if the page creates a getter for "eval", for example.
-  if (this.eval != realEval)
-    confused("Fuzz script replaced |eval|");
-  if (Function != realFunction)
-    confused("Fuzz script replaced |Function|");
+  if (this.eval != realEval) { confused("Fuzz script replaced |eval|"); }
+  if (Function != realFunction) { confused("Fuzz script replaced |Function|"); }
 }
 
-
-function tryItOut(code)
-{
+function tryItOut (code) {
   // Accidentally leaving gczeal enabled for a long time would make jsfunfuzz really slow.
-  if (typeof gczeal == "function")
-    gczeal(0);
+  if (typeof gczeal === "function") { gczeal(0); }
 
   // SpiderMonkey shell does not schedule GC on its own.  Help it not use too much memory.
   if (count % 1000 == 0) {
@@ -123,13 +108,11 @@ function tryItOut(code)
 
   var wtt = whatToTest(code);
 
-  if (!wtt.allowParse)
-    return;
+  if (!wtt.allowParse) { return; }
 
-  code = code.replace(/\/\*DUPTRY\d+\*\//, function(k) { var n = parseInt(k.substr(8), 10); dumpln(n); return strTimes("try{}catch(e){}", n); });
+  code = code.replace(/\/\*DUPTRY\d+\*\//, function (k) { var n = parseInt(k.substr(8), 10); dumpln(n); return strTimes("try{}catch(e){}", n); });
 
-  if (jsStrictMode)
-    code = "'use strict'; " + code; // ES5 10.1.1: new Function does not inherit strict mode
+  if (jsStrictMode) { code = "'use strict'; " + code; } // ES5 10.1.1: new Function does not inherit strict mode
 
   var f;
   try {
@@ -150,8 +133,7 @@ function tryItOut(code)
       // But leave some things out of function(){} because some bugs are only detectable at top-level, and
       // pure jsfunfuzz doesn't test top-level at all.
       // (This is a good reason to use compare_jit even if I'm not interested in finding JIT bugs!)
-      if (nCode.indexOf("return") != -1 || nCode.indexOf("yield") != -1 || nCode.indexOf("const") != -1 || failsToCompileInTry(nCode))
-        nCode = "(function(){" + nCode + "})()";
+      if (nCode.indexOf("return") != -1 || nCode.indexOf("yield") != -1 || nCode.indexOf("const") != -1 || failsToCompileInTry(nCode)) { nCode = "(function(){" + nCode + "})()"; }
       dumpln(cookie1 + cookie2 + " try { " + nCode + " } catch(e) { }");
     }
   }
@@ -164,8 +146,7 @@ function tryItOut(code)
     tryRunning(f, code, wtt);
   }
 
-  if (verbose)
-    dumpln("Done trying out that function!");
+  if (verbose) { dumpln("Done trying out that function!"); }
 
   dumpln("");
 }

--- a/src/funfuzz/js/jsfunfuzz/tail.js
+++ b/src/funfuzz/js/jsfunfuzz/tail.js
@@ -9,9 +9,9 @@ var count = 0;
 var verbose = false;
 
 
-/**************************************
+/* ********************************** *
  * To reproduce a crash or assertion: *
- **************************************/
+ * ********************************** */
 
 // 1. grep tryIt LOGFILE | grep -v "function tryIt" | pbcopy
 // 2. Paste the result between "ddbegin" and "ddend", replacing "start(this);"

--- a/src/funfuzz/js/jsfunfuzz/tail.js
+++ b/src/funfuzz/js/jsfunfuzz/tail.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported count, verbose */
 /* global jsshell, print, start */
 
 var count = 0;

--- a/src/funfuzz/js/jsfunfuzz/tail.js
+++ b/src/funfuzz/js/jsfunfuzz/tail.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global jsshell, print, start */
+
 var count = 0;
 var verbose = false;
 

--- a/src/funfuzz/js/jsfunfuzz/tail.js
+++ b/src/funfuzz/js/jsfunfuzz/tail.js
@@ -9,7 +9,6 @@
 var count = 0;
 var verbose = false;
 
-
 /* ********************************** *
  * To reproduce a crash or assertion: *
  * ********************************** */
@@ -21,8 +20,6 @@ var verbose = false;
 start(this);
 // SPLICE DDEND
 
-if (jsshell)
-  print("It's looking good!"); // Magic string that js_interesting looks for
-
+if (jsshell) { print("It's looking good!"); } // Magic string that js_interesting looks for
 
 // 3. Run it.

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -105,11 +105,11 @@ var pureForeign = {
   stomp: function () { }
 };
 
-for (var f in unaryMathFunctions) {
+for (let f in unaryMathFunctions) {
   pureForeign["Math_" + unaryMathFunctions[f]] = Math[unaryMathFunctions[f]];
 }
 
-for (var f in binaryMathFunctions) {
+for (let f in binaryMathFunctions) {
   pureForeign["Math_" + binaryMathFunctions[f]] = Math[binaryMathFunctions[f]];
 }
 

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -53,9 +53,9 @@ var compareAsm = (function() {
     // Special float values
     0, -0, 0/0, 1/0, -1/0,
     // Boundaries of int, signed, unsigned (near +/- 2^31, +/- 2^32)
-     0x07fffffff,  0x080000000,  0x080000001,
+    0x07fffffff,  0x080000000,  0x080000001,
     -0x07fffffff, -0x080000000, -0x080000001,
-     0x0ffffffff,  0x100000000,  0x100000001,
+    0x0ffffffff,  0x100000000,  0x100000001,
     -0x0ffffffff, -0x100000000,  0x100000001,
     // Boundaries of double
     Number.MIN_VALUE, -Number.MIN_VALUE,

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -89,7 +89,7 @@ var compareAsm = (function () {
 
 function nanBitsMayBeVisible (s) { // eslint-disable-line require-jsdoc
   // Does the code use more than one of {*int*, float32, or float64} views on the same array buffer?
-  return (s.indexOf("Uint") != -1 || s.indexOf("Int") != -1) + (s.indexOf("Float32Array") != -1) + (s.indexOf("Float64Array") != -1) > 1;
+  return (s.indexOf("Uint") !== -1 || s.indexOf("Int") !== -1) + (s.indexOf("Float32Array") !== -1) + (s.indexOf("Float64Array") !== -1) > 1;
 }
 
 var pureForeign = {

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported startAsmDifferential */
 /* global ArrayBuffer, asmJSInterior, binaryMathFunctions, dumpln, foundABug, gc, Int32Array, isAsmJSModule */
 /* global makeRegisterStompFunction, print, Random, rnd, unaryMathFunctions, uneval */
 

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -89,7 +89,7 @@ var compareAsm = (function () {
 
 function nanBitsMayBeVisible (s) { // eslint-disable-line require-jsdoc
   // Does the code use more than one of {*int*, float32, or float64} views on the same array buffer?
-  return (s.indexOf("Uint") !== -1 || s.indexOf("Int") !== -1) + (s.indexOf("Float32Array") !== -1) + (s.indexOf("Float64Array") !== -1) > 1;
+  return (s.indexOf("Uint") != -1 || s.indexOf("Int") != -1) + (s.indexOf("Float32Array") != -1) + (s.indexOf("Float64Array") != -1) > 1;
 }
 
 var pureForeign = {

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -70,9 +70,9 @@ var compareAsm = (function() {
       var x = asmvals[i];
       var fr = f(x);
       var gr = g(x);
-      if (!isSameNumber(fr, gr)) {
+      if (!isSameNumber(fr, gr)) 
         foundABug("asm mismatch", "(" + uneval(x) + ") -> " + uneval(fr) + " vs " + uneval(gr));
-      }
+      
     }
   }
 
@@ -84,9 +84,9 @@ var compareAsm = (function() {
         var y = asmvals[j];
         var fr = f(x, y);
         var gr = g(x, y);
-        if (!isSameNumber(fr, gr)) {
+        if (!isSameNumber(fr, gr)) 
           foundABug("asm mismatch", "(" + uneval(x) + ", " + uneval(y) + ") -> " + uneval(fr) + " vs " + uneval(gr));
-        }
+        
       }
     }
   }
@@ -114,13 +114,13 @@ var pureForeign = {
   stomp:     function() { },
 };
 
-for (var f in unaryMathFunctions) {
+for (var f in unaryMathFunctions) 
   pureForeign["Math_" + unaryMathFunctions[f]] = Math[unaryMathFunctions[f]];
-}
 
-for (var f in binaryMathFunctions) {
+
+for (var f in binaryMathFunctions) 
   pureForeign["Math_" + binaryMathFunctions[f]] = Math[binaryMathFunctions[f]];
-}
+
 
 var pureMathNames = Object.keys(pureForeign);
 

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -6,9 +6,9 @@
 /* global ArrayBuffer, asmJSInterior, binaryMathFunctions, dumpln, foundABug, gc, Int32Array, isAsmJSModule */
 /* global makeRegisterStompFunction, print, Random, rnd, unaryMathFunctions, uneval */
 
-/***************************
+/* *********************** *
  * TEST ASM.JS CORRECTNESS *
- ***************************/
+ * *********************** */
 
 // asm.js functions should always have the same semantics as JavaScript functions.
 //

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -25,7 +25,8 @@
 // Because we pass the 'sanePlease' flag to asmJSInterior,
 // * We don't expect any parse errors. (testOneAsmJSInterior currently relies on this.)
 // * We expect only the following asm.js type errors:
-//   * "numeric literal out of representable integer range" (https://github.com/dherman/asm.js/issues/67 makes composition hard)
+//   * "numeric literal out of representable integer range"
+//     (https://github.com/dherman/asm.js/issues/67 makes composition hard)
 //   * "no duplicate case labels" (because asmSwitchStatement doesn't avoid this)
 // * And the following, infrequently, due to out-of-range integer literals:
 //   * "one arg to int multiply must be a small (-2^20, 2^20) int literal"
@@ -96,7 +97,8 @@ var compareAsm = (function() {
 function nanBitsMayBeVisible(s)
 {
   // Does the code use more than one of {*int*, float32, or float64} views on the same array buffer?
-  return (s.indexOf("Uint") != -1 || s.indexOf("Int") != -1) + (s.indexOf("Float32Array") != -1) + (s.indexOf("Float64Array") != -1) > 1;
+  return (s.indexOf("Uint") != -1 || s.indexOf("Int") != -1)
+    + (s.indexOf("Float32Array") != -1) + (s.indexOf("Float64Array") != -1) > 1;
 }
 
 var pureForeign = {

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -41,7 +41,7 @@ var compareAsm = (function () {
     if (a === 0 && b === 0) { return 1 / a === 1 / b; }
 
     // Don't differentiate between NaNs
-    return a === b || (a !== a && b !== b);
+    return a === b || (a !== a && b !== b); // eslint-disable-line no-self-compare
   }
 
   var asmvals = [

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -34,7 +34,7 @@
 //   * "unsigned is not a subtype of signed or doublish" [Math.abs]
 
 var compareAsm = (function () {
-  function isSameNumber (a, b) {
+  function isSameNumber (a, b) { // eslint-disable-line require-jsdoc
     if (!(typeof a === "number" && typeof b === "number")) { return false; }
 
     // Differentiate between 0 and -0
@@ -59,7 +59,7 @@ var compareAsm = (function () {
   ];
   var asmvalsLen = asmvals.length;
 
-  function compareUnaryFunctions (f, g) {
+  function compareUnaryFunctions (f, g) { // eslint-disable-line require-jsdoc
     for (var i = 0; i < asmvalsLen; ++i) {
       var x = asmvals[i];
       var fr = f(x);
@@ -70,7 +70,7 @@ var compareAsm = (function () {
     }
   }
 
-  function compareBinaryFunctions (f, g) {
+  function compareBinaryFunctions (f, g) { // eslint-disable-line require-jsdoc
     for (var i = 0; i < asmvalsLen; ++i) {
       var x = asmvals[i];
       for (var j = 0; j < asmvalsLen; ++j) {
@@ -87,7 +87,7 @@ var compareAsm = (function () {
   return { compareUnaryFunctions: compareUnaryFunctions, compareBinaryFunctions: compareBinaryFunctions };
 })();
 
-function nanBitsMayBeVisible (s) {
+function nanBitsMayBeVisible (s) { // eslint-disable-line require-jsdoc
   // Does the code use more than one of {*int*, float32, or float64} views on the same array buffer?
   return (s.indexOf("Uint") != -1 || s.indexOf("Int") != -1) + (s.indexOf("Float32Array") != -1) + (s.indexOf("Float64Array") != -1) > 1;
 }
@@ -115,12 +115,12 @@ for (var f in binaryMathFunctions) {
 
 var pureMathNames = Object.keys(pureForeign);
 
-function generateAsmDifferential () {
+function generateAsmDifferential () { // eslint-disable-line require-jsdoc
   var foreignFunctions = rnd(10) ? [] : pureMathNames;
   return asmJSInterior(foreignFunctions, true);
 }
 
-function testAsmDifferential (stdlib, interior) {
+function testAsmDifferential (stdlib, interior) { // eslint-disable-line require-jsdoc
   if (nanBitsMayBeVisible(interior)) {
     dumpln("Skipping correctness test for asm module that could expose low bits of NaN");
     return;
@@ -145,7 +145,7 @@ function testAsmDifferential (stdlib, interior) {
 }
 
 // Call this instead of start() to run asm-differential tests
-function startAsmDifferential () {
+function startAsmDifferential () { // eslint-disable-line require-jsdoc
   var asmFuzzSeed = Math.floor(Math.random() * Math.pow(2, 28));
   dumpln("asmFuzzSeed: " + asmFuzzSeed);
   Random.init(asmFuzzSeed);

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -25,8 +25,7 @@
 // Because we pass the 'sanePlease' flag to asmJSInterior,
 // * We don't expect any parse errors. (testOneAsmJSInterior currently relies on this.)
 // * We expect only the following asm.js type errors:
-//   * "numeric literal out of representable integer range"
-//     (https://github.com/dherman/asm.js/issues/67 makes composition hard)
+//   * "numeric literal out of representable integer range" (https://github.com/dherman/asm.js/issues/67 makes composition hard)
 //   * "no duplicate case labels" (because asmSwitchStatement doesn't avoid this)
 // * And the following, infrequently, due to out-of-range integer literals:
 //   * "one arg to int multiply must be a small (-2^20, 2^20) int literal"
@@ -97,8 +96,7 @@ var compareAsm = (function() {
 function nanBitsMayBeVisible(s)
 {
   // Does the code use more than one of {*int*, float32, or float64} views on the same array buffer?
-  return (s.indexOf("Uint") != -1 || s.indexOf("Int") != -1)
-    + (s.indexOf("Float32Array") != -1) + (s.indexOf("Float64Array") != -1) > 1;
+  return (s.indexOf("Uint") != -1 || s.indexOf("Int") != -1) + (s.indexOf("Float32Array") != -1) + (s.indexOf("Float64Array") != -1) > 1;
 }
 
 var pureForeign = {

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -156,7 +156,7 @@ function testAsmDifferential(stdlib, interior)
 // Call this instead of start() to run asm-differential tests
 function startAsmDifferential()
 {
-  var asmFuzzSeed = Math.floor(Math.random() * Math.pow(2,28));
+  var asmFuzzSeed = Math.floor(Math.random() * Math.pow(2, 28));
   dumpln("asmFuzzSeed: " + asmFuzzSeed);
   Random.init(asmFuzzSeed);
 

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -127,7 +127,7 @@ function testAsmDifferential (stdlib, interior) { // eslint-disable-line require
   }
 
   var asmJs = "(function(stdlib, foreign, heap) { 'use asm'; " + interior + " })";
-  var asmModule = eval(asmJs);
+  var asmModule = eval(asmJs); // eslint-disable-line no-eval
 
   if (isAsmJSModule(asmModule)) {
     var asmHeap = new ArrayBuffer(4096);
@@ -137,7 +137,7 @@ function testAsmDifferential (stdlib, interior) { // eslint-disable-line require
     var normalHeap = new ArrayBuffer(4096);
     (new Int32Array(normalHeap))[0] = 0x12345678;
     var normalJs = "(function(stdlib, foreign, heap) { " + interior + " })";
-    var normalModule = eval(normalJs);
+    var normalModule = eval(normalJs); // eslint-disable-line no-eval
     var normalFun = normalModule(stdlib, pureForeign, normalHeap);
 
     compareAsm.compareBinaryFunctions(asmFun, normalFun);
@@ -153,7 +153,7 @@ function startAsmDifferential () { // eslint-disable-line require-jsdoc
   while (true) {
     var stompStr = makeRegisterStompFunction(8, [], true);
     print(stompStr);
-    pureForeign.stomp = eval(stompStr);
+    pureForeign.stomp = eval(stompStr); // eslint-disable-line no-eval
 
     for (var i = 0; i < 100; ++i) {
       var interior = generateAsmDifferential();

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -33,17 +33,12 @@
 //   * "arguments to / or % must both be double, signed, or unsigned, unsigned and signed are given"
 //   * "unsigned is not a subtype of signed or doublish" [Math.abs]
 
-
-var compareAsm = (function() {
-
-  function isSameNumber(a, b)
-  {
-    if (!(typeof a == "number" && typeof b == "number"))
-      return false;
+var compareAsm = (function () {
+  function isSameNumber (a, b) {
+    if (!(typeof a === "number" && typeof b === "number")) { return false; }
 
     // Differentiate between 0 and -0
-    if (a === 0 && b === 0)
-      return 1/a === 1/b;
+    if (a === 0 && b === 0) { return 1 / a === 1 / b; }
 
     // Don't differentiate between NaNs
     return a === b || (a !== a && b !== b);
@@ -52,20 +47,19 @@ var compareAsm = (function() {
   var asmvals = [
     1, Math.PI, 42,
     // Special float values
-    0, -0, 0/0, 1/0, -1/0,
+    0, -0, 0 / 0, 1 / 0, -1 / 0,
     // Boundaries of int, signed, unsigned (near +/- 2^31, +/- 2^32)
-    0x07fffffff,  0x080000000,  0x080000001,
+    0x07fffffff, 0x080000000, 0x080000001,
     -0x07fffffff, -0x080000000, -0x080000001,
-    0x0ffffffff,  0x100000000,  0x100000001,
-    -0x0ffffffff, -0x100000000,  0x100000001,
+    0x0ffffffff, 0x100000000, 0x100000001,
+    -0x0ffffffff, -0x100000000, 0x100000001,
     // Boundaries of double
     Number.MIN_VALUE, -Number.MIN_VALUE,
-    Number.MAX_VALUE, -Number.MAX_VALUE,
+    Number.MAX_VALUE, -Number.MAX_VALUE
   ];
   var asmvalsLen = asmvals.length;
 
-  function compareUnaryFunctions(f, g)
-  {
+  function compareUnaryFunctions (f, g) {
     for (var i = 0; i < asmvalsLen; ++i) {
       var x = asmvals[i];
       var fr = f(x);
@@ -76,8 +70,7 @@ var compareAsm = (function() {
     }
   }
 
-  function compareBinaryFunctions(f, g)
-  {
+  function compareBinaryFunctions (f, g) {
     for (var i = 0; i < asmvalsLen; ++i) {
       var x = asmvals[i];
       for (var j = 0; j < asmvalsLen; ++j) {
@@ -91,26 +84,25 @@ var compareAsm = (function() {
     }
   }
 
-  return {compareUnaryFunctions: compareUnaryFunctions, compareBinaryFunctions: compareBinaryFunctions};
+  return { compareUnaryFunctions: compareUnaryFunctions, compareBinaryFunctions: compareBinaryFunctions };
 })();
 
-function nanBitsMayBeVisible(s)
-{
+function nanBitsMayBeVisible (s) {
   // Does the code use more than one of {*int*, float32, or float64} views on the same array buffer?
   return (s.indexOf("Uint") != -1 || s.indexOf("Int") != -1) + (s.indexOf("Float32Array") != -1) + (s.indexOf("Float64Array") != -1) > 1;
 }
 
 var pureForeign = {
-  identity:  function(x) { return x; },
-  quadruple: function(x) { return x * 4; },
-  half:      function(x) { return x / 2; },
+  identity: function (x) { return x; },
+  quadruple: function (x) { return x * 4; },
+  half: function (x) { return x / 2; },
   // Test coercion coming back from FFI.
-  asString:  function(x) { return uneval(x); },
-  asValueOf: function(x) { return { valueOf: function() { return x; } }; },
+  asString: function (x) { return uneval(x); },
+  asValueOf: function (x) { return { valueOf: function () { return x; } }; },
   // Test register arguments vs stack arguments.
-  sum:       function() { var s = 0; for (var i = 0; i < arguments.length; ++i) s += arguments[i]; return s; },
+  sum: function () { var s = 0; for (var i = 0; i < arguments.length; ++i) s += arguments[i]; return s; },
   // Will be replaced by calling makeRegisterStompFunction
-  stomp:     function() { },
+  stomp: function () { }
 };
 
 for (var f in unaryMathFunctions) {
@@ -123,14 +115,12 @@ for (var f in binaryMathFunctions) {
 
 var pureMathNames = Object.keys(pureForeign);
 
-function generateAsmDifferential()
-{
+function generateAsmDifferential () {
   var foreignFunctions = rnd(10) ? [] : pureMathNames;
   return asmJSInterior(foreignFunctions, true);
 }
 
-function testAsmDifferential(stdlib, interior)
-{
+function testAsmDifferential (stdlib, interior) {
   if (nanBitsMayBeVisible(interior)) {
     dumpln("Skipping correctness test for asm module that could expose low bits of NaN");
     return;
@@ -155,14 +145,12 @@ function testAsmDifferential(stdlib, interior)
 }
 
 // Call this instead of start() to run asm-differential tests
-function startAsmDifferential()
-{
+function startAsmDifferential () {
   var asmFuzzSeed = Math.floor(Math.random() * Math.pow(2, 28));
   dumpln("asmFuzzSeed: " + asmFuzzSeed);
   Random.init(asmFuzzSeed);
 
   while (true) {
-
     var stompStr = makeRegisterStompFunction(8, [], true);
     print(stompStr);
     pureForeign.stomp = eval(stompStr);

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -70,9 +70,9 @@ var compareAsm = (function() {
       var x = asmvals[i];
       var fr = f(x);
       var gr = g(x);
-      if (!isSameNumber(fr, gr)) 
+      if (!isSameNumber(fr, gr)) {
         foundABug("asm mismatch", "(" + uneval(x) + ") -> " + uneval(fr) + " vs " + uneval(gr));
-      
+      }
     }
   }
 
@@ -84,9 +84,9 @@ var compareAsm = (function() {
         var y = asmvals[j];
         var fr = f(x, y);
         var gr = g(x, y);
-        if (!isSameNumber(fr, gr)) 
+        if (!isSameNumber(fr, gr)) {
           foundABug("asm mismatch", "(" + uneval(x) + ", " + uneval(y) + ") -> " + uneval(fr) + " vs " + uneval(gr));
-        
+        }
       }
     }
   }
@@ -114,13 +114,13 @@ var pureForeign = {
   stomp:     function() { },
 };
 
-for (var f in unaryMathFunctions) 
+for (var f in unaryMathFunctions) {
   pureForeign["Math_" + unaryMathFunctions[f]] = Math[unaryMathFunctions[f]];
+}
 
-
-for (var f in binaryMathFunctions) 
+for (var f in binaryMathFunctions) {
   pureForeign["Math_" + binaryMathFunctions[f]] = Math[binaryMathFunctions[f]];
-
+}
 
 var pureMathNames = Object.keys(pureForeign);
 

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -70,7 +70,7 @@ var compareAsm = (function() {
       var fr = f(x);
       var gr = g(x);
       if (!isSameNumber(fr, gr)) {
-        foundABug("asm mismatch", "(" + uneval(x) + ") -> " + uneval(fr) + " vs "  + uneval(gr));
+        foundABug("asm mismatch", "(" + uneval(x) + ") -> " + uneval(fr) + " vs " + uneval(gr));
       }
     }
   }
@@ -84,7 +84,7 @@ var compareAsm = (function() {
         var fr = f(x, y);
         var gr = g(x, y);
         if (!isSameNumber(fr, gr)) {
-          foundABug("asm mismatch", "(" + uneval(x) + ", " + uneval(y) + ") -> " + uneval(fr) + " vs "  + uneval(gr));
+          foundABug("asm mismatch", "(" + uneval(x) + ", " + uneval(y) + ") -> " + uneval(fr) + " vs " + uneval(gr));
         }
       }
     }
@@ -107,9 +107,9 @@ var pureForeign = {
   asString:  function(x) { return uneval(x); },
   asValueOf: function(x) { return { valueOf: function() { return x; } }; },
   // Test register arguments vs stack arguments.
-  sum:       function()  { var s = 0; for (var i = 0; i < arguments.length; ++i) s += arguments[i]; return s; },
+  sum:       function() { var s = 0; for (var i = 0; i < arguments.length; ++i) s += arguments[i]; return s; },
   // Will be replaced by calling makeRegisterStompFunction
-  stomp:     function()  { },
+  stomp:     function() { },
 };
 
 for (var f in unaryMathFunctions) {

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -3,6 +3,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global ArrayBuffer, asmJSInterior, binaryMathFunctions, dumpln, foundABug, gc, Int32Array, isAsmJSModule */
+/* global makeRegisterStompFunction, print, Random, rnd, unaryMathFunctions, uneval */
+
 /***************************
  * TEST ASM.JS CORRECTNESS *
  ***************************/

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -5,9 +5,9 @@
 
 /* global count, evalcx, errorToString, foundABug, newGlobal */
 
-/*******************************
+/* *************************** *
  * EXECUTION CONSISTENCY TESTS *
- *******************************/
+ * *************************** */
 
 function sandboxResult(code, zone)
 {
@@ -27,7 +27,7 @@ function sandboxResult(code, zone)
   } catch(e) {
     result = "Error: " + errorToString(e);
   }
-  //print("resultStr: " + resultStr);
+  // print("resultStr: " + resultStr);
   return resultStr;
 }
 
@@ -46,8 +46,8 @@ function nestingConsistencyTest(code)
   // These are on the same line so that line numbers in stack traces will match.
   var resultO = sandboxResult(codeNestedOnce, null); var resultD = sandboxResult(codeNestedDeep, null);
 
-  //if (resultO != "" && resultO != "undefined" && resultO != "use strict")
-  //  print("NestTest: " + resultO);
+  // if (resultO != "" && resultO != "undefined" && resultO != "use strict")
+  //   print("NestTest: " + resultO);
 
   if (resultO != resultD) {
     foundABug("NestTest mismatch",

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -20,10 +20,10 @@ function sandboxResult(code, zone)
     var sandbox = newGlobal({sameZoneAs: zone});
 
     result = evalcx(code, sandbox);
-    if (typeof result != "object") {
+    if (typeof result != "object") 
       // Avoid cross-compartment excitement if it has a toString
       resultStr = "" + result;
-    }
+    
   } catch (e) {
     result = "Error: " + errorToString(e);
   }
@@ -39,9 +39,9 @@ function nestingConsistencyTest(code)
   var codeNestedOnce = nestExpr(code);
   var codeNestedDeep = code;
   var depth = (count % 7) + 14; // 16 might be special
-  for (var i = 0; i < depth; ++i) {
+  for (var i = 0; i < depth; ++i) 
     codeNestedDeep = nestExpr(codeNestedDeep);
-  }
+  
 
   // These are on the same line so that line numbers in stack traces will match.
   var resultO = sandboxResult(codeNestedOnce, null); var resultD = sandboxResult(codeNestedDeep, null);
@@ -49,10 +49,10 @@ function nestingConsistencyTest(code)
   // if (resultO != "" && resultO != "undefined" && resultO != "use strict")
   //   print("NestTest: " + resultO);
 
-  if (resultO != resultD) {
+  if (resultO != resultD) 
     foundABug("NestTest mismatch",
       "resultO: " + resultO + "\n" +
       "resultD: " + resultD);
-  }
+  
 }
 

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -48,7 +48,7 @@ function nestingConsistencyTest (code) { // eslint-disable-line require-jsdoc
   // if (resultO != "" && resultO != "undefined" && resultO != "use strict")
   //   print("NestTest: " + resultO);
 
-  if (resultO !== resultD) {
+  if (resultO != resultD) {
     foundABug("NestTest mismatch",
       "resultO: " + resultO + "\n" +
       "resultD: " + resultD);

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global count, evalcx, errorToString, foundABug, newGlobal */
+
 /*******************************
  * EXECUTION CONSISTENCY TESTS *
  *******************************/

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -20,10 +20,10 @@ function sandboxResult(code, zone)
     var sandbox = newGlobal({sameZoneAs: zone});
 
     result = evalcx(code, sandbox);
-    if (typeof result != "object") 
+    if (typeof result != "object") {
       // Avoid cross-compartment excitement if it has a toString
       resultStr = "" + result;
-    
+    }
   } catch (e) {
     result = "Error: " + errorToString(e);
   }
@@ -39,9 +39,9 @@ function nestingConsistencyTest(code)
   var codeNestedOnce = nestExpr(code);
   var codeNestedDeep = code;
   var depth = (count % 7) + 14; // 16 might be special
-  for (var i = 0; i < depth; ++i) 
+  for (var i = 0; i < depth; ++i) {
     codeNestedDeep = nestExpr(codeNestedDeep);
-  
+  }
 
   // These are on the same line so that line numbers in stack traces will match.
   var resultO = sandboxResult(codeNestedOnce, null); var resultD = sandboxResult(codeNestedDeep, null);
@@ -49,10 +49,10 @@ function nestingConsistencyTest(code)
   // if (resultO != "" && resultO != "undefined" && resultO != "use strict")
   //   print("NestTest: " + resultO);
 
-  if (resultO != resultD) 
+  if (resultO != resultD) {
     foundABug("NestTest mismatch",
       "resultO: " + resultO + "\n" +
       "resultD: " + resultD);
-  
+  }
 }
 

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -10,7 +10,7 @@
  * EXECUTION CONSISTENCY TESTS *
  * *************************** */
 
-function sandboxResult (code, zone) {
+function sandboxResult (code, zone) { // eslint-disable-line require-jsdoc
   // Use sandbox to isolate side-effects.
   var result;
   var resultStr = "";
@@ -31,10 +31,10 @@ function sandboxResult (code, zone) {
   return resultStr;
 }
 
-function nestingConsistencyTest (code) {
+function nestingConsistencyTest (code) { // eslint-disable-line require-jsdoc
   // Inspired by bug 676343
   // This only makes sense if |code| is an expression (or an expression followed by a semicolon). Oh well.
-  function nestExpr (e) { return "(function() { return " + code + "; })()"; }
+  function nestExpr (e) { return "(function() { return " + code + "; })()"; } // eslint-disable-line require-jsdoc
   var codeNestedOnce = nestExpr(code);
   var codeNestedDeep = code;
   var depth = (count % 7) + 14; // 16 might be special

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -24,7 +24,7 @@ function sandboxResult(code, zone)
       // Avoid cross-compartment excitement if it has a toString
       resultStr = "" + result;
     }
-  } catch(e) {
+  } catch (e) {
     result = "Error: " + errorToString(e);
   }
   // print("resultStr: " + resultStr);

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported nestingConsistencyTest */
 /* global count, evalcx, errorToString, foundABug, newGlobal */
 
 /* *************************** *

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -10,18 +10,17 @@
  * EXECUTION CONSISTENCY TESTS *
  * *************************** */
 
-function sandboxResult(code, zone)
-{
+function sandboxResult (code, zone) {
   // Use sandbox to isolate side-effects.
   var result;
   var resultStr = "";
   try {
     // Using newGlobal(), rather than evalcx(''), to get
     // shell functions. (see bug 647412 comment 2)
-    var sandbox = newGlobal({sameZoneAs: zone});
+    var sandbox = newGlobal({ sameZoneAs: zone });
 
     result = evalcx(code, sandbox);
-    if (typeof result != "object") {
+    if (typeof result !== "object") {
       // Avoid cross-compartment excitement if it has a toString
       resultStr = "" + result;
     }
@@ -32,11 +31,10 @@ function sandboxResult(code, zone)
   return resultStr;
 }
 
-function nestingConsistencyTest(code)
-{
+function nestingConsistencyTest (code) {
   // Inspired by bug 676343
   // This only makes sense if |code| is an expression (or an expression followed by a semicolon). Oh well.
-  function nestExpr(e) { return "(function() { return " + code + "; })()"; }
+  function nestExpr (e) { return "(function() { return " + code + "; })()"; }
   var codeNestedOnce = nestExpr(code);
   var codeNestedDeep = code;
   var depth = (count % 7) + 14; // 16 might be special
@@ -56,4 +54,3 @@ function nestingConsistencyTest(code)
       "resultD: " + resultD);
   }
 }
-

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -48,7 +48,7 @@ function nestingConsistencyTest (code) { // eslint-disable-line require-jsdoc
   // if (resultO != "" && resultO != "undefined" && resultO != "use strict")
   //   print("NestTest: " + resultO);
 
-  if (resultO != resultD) {
+  if (resultO !== resultD) {
     foundABug("NestTest mismatch",
       "resultO: " + resultO + "\n" +
       "resultD: " + resultD);

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported makeMathyFunAndTest, makeMathyFunRef, mathInitFCM */
 /* global errorToString, makeAsmJSFunction, makeMathFunction, makeMixedTypeArray, NUM_MATH_FUNCTIONS, print, Random */
 /* global rnd, TOTALLY_RANDOM, totallyRandom, uneval */
 

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -70,17 +70,17 @@ function hashStr(s)
 function testMathyFunction(f, inputs)
 {
   var results = [];
-  if (f) {
-    for (var j = 0; j < inputs.length; ++j) {
-      for (var k = 0; k < inputs.length; ++k) {
+  if (f) 
+    for (var j = 0; j < inputs.length; ++j) 
+      for (var k = 0; k < inputs.length; ++k) 
         try {
           results.push(f(inputs[j], inputs[k]));
         } catch (e) {
           results.push(errorToString(e));
         }
-      }
-    }
-  }
+      
+    
+  
   /* Use uneval to distinguish -0, 0, "0", etc. */
   /* Use hashStr to shorten the output and keep compare_jit files small. */
   print(hashStr(uneval(results)));
@@ -103,13 +103,13 @@ function makeMathyFunAndTest(d, b)
   var i = rnd(NUM_MATH_FUNCTIONS);
   var s = "";
 
-  if (rnd(5)) {
+  if (rnd(5)) 
     if (rnd(8)) {
       s += "mathy" + i + " = " + makeMathFunction(6, b, i) + "; ";
     } else {
       s += "mathy" + i + " = " + makeAsmJSFunction(6, b) + "; ";
     }
-  }
+  
 
   if (rnd(5)) {
     var inputsStr;

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -57,7 +57,7 @@ var confusableVals = [
   "createIsHTMLDDA()"
 ];
 
-function hashStr (s) {
+function hashStr (s) { // eslint-disable-line require-jsdoc
   var hash = 0;
   var L = s.length;
   for (var i = 0; i < L; i++) {
@@ -67,7 +67,7 @@ function hashStr (s) {
   return hash;
 }
 
-function testMathyFunction (f, inputs) {
+function testMathyFunction (f, inputs) { // eslint-disable-line require-jsdoc
   var results = [];
   if (f) {
     for (var j = 0; j < inputs.length; ++j) {
@@ -85,7 +85,7 @@ function testMathyFunction (f, inputs) {
   print(hashStr(uneval(results)));
 }
 
-function mathInitFCM () {
+function mathInitFCM () { // eslint-disable-line require-jsdoc
   // FCM cookie, lines with this cookie are used for compare_jit
   var cookie = "/*F" + "CM*/";
 
@@ -94,7 +94,7 @@ function mathInitFCM () {
   print(cookie + testMathyFunction.toString().replace(/\r/g, "\n").replace(/\n/g, " "));
 }
 
-function makeMathyFunAndTest (d, b) {
+function makeMathyFunAndTest (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var i = rnd(NUM_MATH_FUNCTIONS);
@@ -124,7 +124,7 @@ function makeMathyFunAndTest (d, b) {
   return s;
 }
 
-function makeMathyFunRef (d, b) {
+function makeMathyFunRef (d, b) { // eslint-disable-line require-jsdoc
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return "mathy" + rnd(NUM_MATH_FUNCTIONS);

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -114,9 +114,11 @@ function makeMathyFunAndTest(d, b)
   if (rnd(5)) {
     var inputsStr;
     switch (rnd(8)) {
+      /* eslint-disable no-multi-spaces */
       case 0:  inputsStr = makeMixedTypeArray(d - 1, b); break;
       case 1:  inputsStr = "[" + Random.shuffled(confusableVals).join(", ") + "]"; break;
       default: inputsStr = "[" + Random.shuffled(numericVals).join(", ") + "]"; break;
+      /* eslint-enable no-multi-spaces */
     }
 
     s += "testMathyFunction(mathy" + i + ", " + inputsStr + "); ";

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -95,7 +95,7 @@ function mathInitFCM () { // eslint-disable-line require-jsdoc
 }
 
 function makeMathyFunAndTest (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var i = rnd(NUM_MATH_FUNCTIONS);
   var s = "";
@@ -125,7 +125,7 @@ function makeMathyFunAndTest (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeMathyFunRef (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   return "mathy" + rnd(NUM_MATH_FUNCTIONS);
 }

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -3,6 +3,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global errorToString, makeAsmJSFunction, makeMathFunction, makeMixedTypeArray, NUM_MATH_FUNCTIONS, print, Random */
+/* global rnd, TOTALLY_RANDOM, totallyRandom, uneval */
+
 var numericVals = [
   "1", "Math.PI", "42",
   // Special float values

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -70,17 +70,17 @@ function hashStr(s)
 function testMathyFunction(f, inputs)
 {
   var results = [];
-  if (f) 
-    for (var j = 0; j < inputs.length; ++j) 
-      for (var k = 0; k < inputs.length; ++k) 
+  if (f) {
+    for (var j = 0; j < inputs.length; ++j) {
+      for (var k = 0; k < inputs.length; ++k) {
         try {
           results.push(f(inputs[j], inputs[k]));
         } catch (e) {
           results.push(errorToString(e));
         }
-      
-    
-  
+      }
+    }
+  }
   /* Use uneval to distinguish -0, 0, "0", etc. */
   /* Use hashStr to shorten the output and keep compare_jit files small. */
   print(hashStr(uneval(results)));
@@ -103,13 +103,13 @@ function makeMathyFunAndTest(d, b)
   var i = rnd(NUM_MATH_FUNCTIONS);
   var s = "";
 
-  if (rnd(5)) 
+  if (rnd(5)) {
     if (rnd(8)) {
       s += "mathy" + i + " = " + makeMathFunction(6, b, i) + "; ";
     } else {
       s += "mathy" + i + " = " + makeAsmJSFunction(6, b) + "; ";
     }
-  
+  }
 
   if (rnd(5)) {
     var inputsStr;

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -75,7 +75,7 @@ function testMathyFunction(f, inputs)
       for (var k = 0; k < inputs.length; ++k) {
         try {
           results.push(f(inputs[j], inputs[k]));
-        } catch(e) {
+        } catch (e) {
           results.push(errorToString(e));
         }
       }
@@ -113,7 +113,7 @@ function makeMathyFunAndTest(d, b)
 
   if (rnd(5)) {
     var inputsStr;
-    switch(rnd(8)) {
+    switch (rnd(8)) {
       case 0:  inputsStr = makeMixedTypeArray(d - 1, b); break;
       case 1:  inputsStr = "[" + Random.shuffled(confusableVals).join(", ") + "]"; break;
       default: inputsStr = "[" + Random.shuffled(numericVals).join(", ") + "]"; break;

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -95,7 +95,7 @@ function mathInitFCM () { // eslint-disable-line require-jsdoc
 }
 
 function makeMathyFunAndTest (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var i = rnd(NUM_MATH_FUNCTIONS);
   var s = "";
@@ -125,7 +125,7 @@ function makeMathyFunAndTest (d, b) { // eslint-disable-line require-jsdoc
 }
 
 function makeMathyFunRef (d, b) { // eslint-disable-line require-jsdoc
-  if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
+  if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return "mathy" + rnd(NUM_MATH_FUNCTIONS);
 }

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -12,10 +12,10 @@ var numericVals = [
   // Special float values
   "0", "-0", "0/0", "1/0", "-1/0",
   // Boundaries of int, signed, unsigned (near +/- 2^31, +/- 2^32)
-  "0x07fffffff",  "0x080000000",  "0x080000001",
+  "0x07fffffff", "0x080000000", "0x080000001",
   "-0x07fffffff", "-0x080000000", "-0x080000001",
-  "0x0ffffffff",  "0x100000000",  "0x100000001",
-  "-0x0ffffffff", "-0x100000000",  "-0x100000001",
+  "0x0ffffffff", "0x100000000", "0x100000001",
+  "-0x0ffffffff", "-0x100000000", "-0x100000001",
   // Boundaries of double
   "Number.MIN_VALUE", "-Number.MIN_VALUE",
   "Number.MAX_VALUE", "-Number.MAX_VALUE",
@@ -25,7 +25,7 @@ var numericVals = [
   "Number.MAX_SAFE_INTEGER", "-Number.MAX_SAFE_INTEGER",
   "(2**53)-2", "(2**53)", "(2**53)+2",
   // See bug 1350097 - 1.79...e308 is the largest (by module) finite number
-  "0.000000000000001", "1.7976931348623157e308",
+  "0.000000000000001", "1.7976931348623157e308"
 ];
 
 var confusableVals = [
@@ -54,11 +54,10 @@ var confusableVals = [
   "(new String(''))",
   "(new Number(0))",
   "(new Number(-0))",
-  "createIsHTMLDDA()",
+  "createIsHTMLDDA()"
 ];
 
-function hashStr(s)
-{
+function hashStr (s) {
   var hash = 0;
   var L = s.length;
   for (var i = 0; i < L; i++) {
@@ -68,8 +67,7 @@ function hashStr(s)
   return hash;
 }
 
-function testMathyFunction(f, inputs)
-{
+function testMathyFunction (f, inputs) {
   var results = [];
   if (f) {
     for (var j = 0; j < inputs.length; ++j) {
@@ -87,8 +85,7 @@ function testMathyFunction(f, inputs)
   print(hashStr(uneval(results)));
 }
 
-function mathInitFCM()
-{
+function mathInitFCM () {
   // FCM cookie, lines with this cookie are used for compare_jit
   var cookie = "/*F" + "CM*/";
 
@@ -97,8 +94,7 @@ function mathInitFCM()
   print(cookie + testMathyFunction.toString().replace(/\r/g, "\n").replace(/\n/g, " "));
 }
 
-function makeMathyFunAndTest(d, b)
-{
+function makeMathyFunAndTest (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   var i = rnd(NUM_MATH_FUNCTIONS);
@@ -128,8 +124,7 @@ function makeMathyFunAndTest(d, b)
   return s;
 }
 
-function makeMathyFunRef(d, b)
-{
+function makeMathyFunRef (d, b) {
   if (rnd(TOTALLY_RANDOM) == 2) return totallyRandom(d, b);
 
   return "mathy" + rnd(NUM_MATH_FUNCTIONS);

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -11,9 +11,9 @@ var numericVals = [
   // Special float values
   "0", "-0", "0/0", "1/0", "-1/0",
   // Boundaries of int, signed, unsigned (near +/- 2^31, +/- 2^32)
-   "0x07fffffff",  "0x080000000",  "0x080000001",
+  "0x07fffffff",  "0x080000000",  "0x080000001",
   "-0x07fffffff", "-0x080000000", "-0x080000001",
-   "0x0ffffffff",  "0x100000000",  "0x100000001",
+  "0x0ffffffff",  "0x100000000",  "0x100000001",
   "-0x0ffffffff", "-0x100000000",  "-0x100000001",
   // Boundaries of double
   "Number.MIN_VALUE", "-Number.MIN_VALUE",

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -40,7 +40,7 @@ function testExpressionDecompiler (code) { // eslint-disable-line require-jsdoc
   var fullCode = "(function() { try { \n" + code + "\n; throw 1; } catch(exx) { this.nnn.nnn } })()";
 
   try {
-    eval(fullCode);
+    eval(fullCode); // eslint-disable-line no-eval
   } catch (e) {
     if (e.message != "this.nnn is undefined" && e.message.indexOf("redeclaration of") == -1) {
       // Break up the following string intentionally, to prevent matching when contents of jsfunfuzz is printed.

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -54,7 +54,8 @@ function testExpressionDecompiler(code)
 
 function tryHalves(code)
 {
-  // See if there are any especially horrible bugs that appear when the parser has to start/stop in the middle of something. this is kinda evil.
+  // See if there are any esp. horrible bugs that appear when the parser has to start/stop in the middle of something.
+  // This is kinda evil.
 
   // Stray "}"s are likely in secondHalf, so use new Function rather than eval.  "}" can't escape from new Function :)
 

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -8,22 +8,22 @@
 
 function optionalTests(f, code, wtt)
 {
-  if (count % 100 == 1) 
+  if (count % 100 == 1) {
     tryHalves(code);
-  
+  }
 
-  if (count % 100 == 2 && engine == ENGINE_SPIDERMONKEY_TRUNK) 
+  if (count % 100 == 2 && engine == ENGINE_SPIDERMONKEY_TRUNK) {
     try {
       Reflect.parse(code);
     } catch (e) {
     }
-  
+  }
 
-  if (count % 100 == 3 && f && typeof disassemble == "function") 
+  if (count % 100 == 3 && f && typeof disassemble == "function") {
     // It's hard to use the recursive disassembly in the comparator,
     // but let's at least make sure the disassembler itself doesn't crash.
     disassemble("-r", f);
-  
+  }
 
   if (0 && f && wtt.allowExec && engine == ENGINE_SPIDERMONKEY_TRUNK) {
     testExpressionDecompiler(code);
@@ -31,9 +31,9 @@ function optionalTests(f, code, wtt)
   }
 
   if (count % 100 == 6 && f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossIter
-    && engine == ENGINE_SPIDERMONKEY_TRUNK && getBuildConfiguration()["more-deterministic"]) 
+    && engine == ENGINE_SPIDERMONKEY_TRUNK && getBuildConfiguration()["more-deterministic"]) {
     nestingConsistencyTest(code);
-  
+  }
 }
 
 
@@ -44,10 +44,10 @@ function testExpressionDecompiler(code)
   try {
     eval(fullCode);
   } catch (e) {
-    if (e.message != "this.nnn is undefined" && e.message.indexOf("redeclaration of") == -1) 
+    if (e.message != "this.nnn is undefined" && e.message.indexOf("redeclaration of") == -1) {
       // Break up the following string intentionally, to prevent matching when contents of jsfunfuzz is printed.
       foundABug("Wrong error " + "message", e);
-    
+    }
   }
 }
 

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -58,7 +58,9 @@ function tryHalves(code)
 
   // Stray "}"s are likely in secondHalf, so use new Function rather than eval.  "}" can't escape from new Function :)
 
-  var f, firstHalf, secondHalf;
+  var f;
+  var firstHalf;
+  var secondHalf;
 
   try {
 

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -8,30 +8,30 @@
 /* global nestingConsistencyTest, Reflect, tryEnsureSanity, verbose */
 
 function optionalTests (f, code, wtt) { // eslint-disable-line require-jsdoc
-  if (count % 100 == 1) {
+  if (count % 100 === 1) {
     tryHalves(code);
   }
 
-  if (count % 100 == 2 && engine == ENGINE_SPIDERMONKEY_TRUNK) {
+  if (count % 100 === 2 && engine === ENGINE_SPIDERMONKEY_TRUNK) {
     try {
       Reflect.parse(code);
     } catch (e) {
     }
   }
 
-  if (count % 100 == 3 && f && typeof disassemble === "function") {
+  if (count % 100 === 3 && f && typeof disassemble === "function") {
     // It's hard to use the recursive disassembly in the comparator,
     // but let's at least make sure the disassembler itself doesn't crash.
     disassemble("-r", f);
   }
 
-  if (0 && f && wtt.allowExec && engine == ENGINE_SPIDERMONKEY_TRUNK) {
+  if (0 && f && wtt.allowExec && engine === ENGINE_SPIDERMONKEY_TRUNK) {
     testExpressionDecompiler(code);
     tryEnsureSanity();
   }
 
-  if (count % 100 == 6 && f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossIter
-    && engine == ENGINE_SPIDERMONKEY_TRUNK && getBuildConfiguration()["more-deterministic"]) {
+  if (count % 100 === 6 && f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossIter
+    && engine === ENGINE_SPIDERMONKEY_TRUNK && getBuildConfiguration()["more-deterministic"]) {
     nestingConsistencyTest(code);
   }
 }
@@ -42,7 +42,7 @@ function testExpressionDecompiler (code) { // eslint-disable-line require-jsdoc
   try {
     eval(fullCode); // eslint-disable-line no-eval
   } catch (e) {
-    if (e.message != "this.nnn is undefined" && e.message.indexOf("redeclaration of") == -1) {
+    if (e.message !== "this.nnn is undefined" && e.message.indexOf("redeclaration of") === -1) {
       // Break up the following string intentionally, to prevent matching when contents of jsfunfuzz is printed.
       foundABug("Wrong error " + "message", e);
     }

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -15,7 +15,7 @@ function optionalTests(f, code, wtt)
   if (count % 100 == 2 && engine == ENGINE_SPIDERMONKEY_TRUNK) {
     try {
       Reflect.parse(code);
-    } catch(e) {
+    } catch (e) {
     }
   }
 
@@ -43,7 +43,7 @@ function testExpressionDecompiler(code)
 
   try {
     eval(fullCode);
-  } catch(e) {
+  } catch (e) {
     if (e.message != "this.nnn is undefined" && e.message.indexOf("redeclaration of") == -1) {
       // Break up the following string intentionally, to prevent matching when contents of jsfunfuzz is printed.
       foundABug("Wrong error " + "message", e);
@@ -68,7 +68,7 @@ function tryHalves(code)
     f = new Function(firstHalf);
     void ("" + f);
   }
-  catch(e) {
+  catch (e) {
     if (verbose)
       dumpln("First half compilation error: " + e);
   }
@@ -80,7 +80,7 @@ function tryHalves(code)
     f = new Function(secondHalf);
     void ("" + f);
   }
-  catch(e) {
+  catch (e) {
     if (verbose)
       dumpln("Second half compilation error: " + e);
   }

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -8,22 +8,22 @@
 
 function optionalTests(f, code, wtt)
 {
-  if (count % 100 == 1) {
+  if (count % 100 == 1) 
     tryHalves(code);
-  }
+  
 
-  if (count % 100 == 2 && engine == ENGINE_SPIDERMONKEY_TRUNK) {
+  if (count % 100 == 2 && engine == ENGINE_SPIDERMONKEY_TRUNK) 
     try {
       Reflect.parse(code);
     } catch (e) {
     }
-  }
+  
 
-  if (count % 100 == 3 && f && typeof disassemble == "function") {
+  if (count % 100 == 3 && f && typeof disassemble == "function") 
     // It's hard to use the recursive disassembly in the comparator,
     // but let's at least make sure the disassembler itself doesn't crash.
     disassemble("-r", f);
-  }
+  
 
   if (0 && f && wtt.allowExec && engine == ENGINE_SPIDERMONKEY_TRUNK) {
     testExpressionDecompiler(code);
@@ -31,9 +31,9 @@ function optionalTests(f, code, wtt)
   }
 
   if (count % 100 == 6 && f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossIter
-    && engine == ENGINE_SPIDERMONKEY_TRUNK && getBuildConfiguration()["more-deterministic"]) {
+    && engine == ENGINE_SPIDERMONKEY_TRUNK && getBuildConfiguration()["more-deterministic"]) 
     nestingConsistencyTest(code);
-  }
+  
 }
 
 
@@ -44,10 +44,10 @@ function testExpressionDecompiler(code)
   try {
     eval(fullCode);
   } catch (e) {
-    if (e.message != "this.nnn is undefined" && e.message.indexOf("redeclaration of") == -1) {
+    if (e.message != "this.nnn is undefined" && e.message.indexOf("redeclaration of") == -1) 
       // Break up the following string intentionally, to prevent matching when contents of jsfunfuzz is printed.
       foundABug("Wrong error " + "message", e);
-    }
+    
   }
 }
 

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -7,7 +7,7 @@
 /* global count, disassemble, dumpln, engine, ENGINE_SPIDERMONKEY_TRUNK, foundABug, getBuildConfiguration */
 /* global nestingConsistencyTest, Reflect, tryEnsureSanity, verbose */
 
-function optionalTests (f, code, wtt) {
+function optionalTests (f, code, wtt) { // eslint-disable-line require-jsdoc
   if (count % 100 == 1) {
     tryHalves(code);
   }
@@ -36,7 +36,7 @@ function optionalTests (f, code, wtt) {
   }
 }
 
-function testExpressionDecompiler (code) {
+function testExpressionDecompiler (code) { // eslint-disable-line require-jsdoc
   var fullCode = "(function() { try { \n" + code + "\n; throw 1; } catch(exx) { this.nnn.nnn } })()";
 
   try {
@@ -49,7 +49,7 @@ function testExpressionDecompiler (code) {
   }
 }
 
-function tryHalves (code) {
+function tryHalves (code) { // eslint-disable-line require-jsdoc
   // See if there are any especially horrible bugs that appear when the parser has to start/stop in the middle of something. this is kinda evil.
 
   // Stray "}"s are likely in secondHalf, so use new Function rather than eval.  "}" can't escape from new Function :)

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -31,7 +31,7 @@ function optionalTests(f, code, wtt)
   }
 
   if (count % 100 == 6 && f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossIter
-    && engine == ENGINE_SPIDERMONKEY_TRUNK && getBuildConfiguration()['more-deterministic']) {
+    && engine == ENGINE_SPIDERMONKEY_TRUNK && getBuildConfiguration()["more-deterministic"]) {
     nestingConsistencyTest(code);
   }
 }

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -3,6 +3,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global count, disassemble, dumpln, engine, ENGINE_SPIDERMONKEY_TRUNK, foundABug, getBuildConfiguration */
+/* global nestingConsistencyTest, Reflect, tryEnsureSanity, verbose */
+
 function optionalTests(f, code, wtt)
 {
   if (count % 100 == 1) {

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported optionalTests */
 /* global count, disassemble, dumpln, engine, ENGINE_SPIDERMONKEY_TRUNK, foundABug, getBuildConfiguration */
 /* global nestingConsistencyTest, Reflect, tryEnsureSanity, verbose */
 

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -61,7 +61,7 @@ function tryHalves (code) { // eslint-disable-line require-jsdoc
   try {
     firstHalf = code.substr(0, code.length / 2);
     if (verbose) { dumpln("First half: " + firstHalf); }
-    f = new Function(firstHalf);
+    f = new Function(firstHalf); // eslint-disable-line no-new-func
     void ("" + f);
   } catch (e) {
     if (verbose) { dumpln("First half compilation error: " + e); }
@@ -70,7 +70,7 @@ function tryHalves (code) { // eslint-disable-line require-jsdoc
   try {
     secondHalf = code.substr(code.length / 2, code.length);
     if (verbose) { dumpln("Second half: " + secondHalf); }
-    f = new Function(secondHalf);
+    f = new Function(secondHalf); // eslint-disable-line no-new-func
     void ("" + f);
   } catch (e) {
     if (verbose) { dumpln("Second half compilation error: " + e); }

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -8,30 +8,30 @@
 /* global nestingConsistencyTest, Reflect, tryEnsureSanity, verbose */
 
 function optionalTests (f, code, wtt) { // eslint-disable-line require-jsdoc
-  if (count % 100 === 1) {
+  if (count % 100 == 1) {
     tryHalves(code);
   }
 
-  if (count % 100 === 2 && engine === ENGINE_SPIDERMONKEY_TRUNK) {
+  if (count % 100 == 2 && engine == ENGINE_SPIDERMONKEY_TRUNK) {
     try {
       Reflect.parse(code);
     } catch (e) {
     }
   }
 
-  if (count % 100 === 3 && f && typeof disassemble === "function") {
+  if (count % 100 == 3 && f && typeof disassemble === "function") {
     // It's hard to use the recursive disassembly in the comparator,
     // but let's at least make sure the disassembler itself doesn't crash.
     disassemble("-r", f);
   }
 
-  if (0 && f && wtt.allowExec && engine === ENGINE_SPIDERMONKEY_TRUNK) {
+  if (0 && f && wtt.allowExec && engine == ENGINE_SPIDERMONKEY_TRUNK) {
     testExpressionDecompiler(code);
     tryEnsureSanity();
   }
 
-  if (count % 100 === 6 && f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossIter
-    && engine === ENGINE_SPIDERMONKEY_TRUNK && getBuildConfiguration()["more-deterministic"]) {
+  if (count % 100 == 6 && f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossIter
+    && engine == ENGINE_SPIDERMONKEY_TRUNK && getBuildConfiguration()["more-deterministic"]) {
     nestingConsistencyTest(code);
   }
 }
@@ -42,7 +42,7 @@ function testExpressionDecompiler (code) { // eslint-disable-line require-jsdoc
   try {
     eval(fullCode); // eslint-disable-line no-eval
   } catch (e) {
-    if (e.message !== "this.nnn is undefined" && e.message.indexOf("redeclaration of") === -1) {
+    if (e.message != "this.nnn is undefined" && e.message.indexOf("redeclaration of") == -1) {
       // Break up the following string intentionally, to prevent matching when contents of jsfunfuzz is printed.
       foundABug("Wrong error " + "message", e);
     }

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -54,8 +54,7 @@ function testExpressionDecompiler(code)
 
 function tryHalves(code)
 {
-  // See if there are any esp. horrible bugs that appear when the parser has to start/stop in the middle of something.
-  // This is kinda evil.
+  // See if there are any especially horrible bugs that appear when the parser has to start/stop in the middle of something. this is kinda evil.
 
   // Stray "}"s are likely in secondHalf, so use new Function rather than eval.  "}" can't escape from new Function :)
 

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -7,8 +7,7 @@
 /* global count, disassemble, dumpln, engine, ENGINE_SPIDERMONKEY_TRUNK, foundABug, getBuildConfiguration */
 /* global nestingConsistencyTest, Reflect, tryEnsureSanity, verbose */
 
-function optionalTests(f, code, wtt)
-{
+function optionalTests (f, code, wtt) {
   if (count % 100 == 1) {
     tryHalves(code);
   }
@@ -20,7 +19,7 @@ function optionalTests(f, code, wtt)
     }
   }
 
-  if (count % 100 == 3 && f && typeof disassemble == "function") {
+  if (count % 100 == 3 && f && typeof disassemble === "function") {
     // It's hard to use the recursive disassembly in the comparator,
     // but let's at least make sure the disassembler itself doesn't crash.
     disassemble("-r", f);
@@ -37,9 +36,7 @@ function optionalTests(f, code, wtt)
   }
 }
 
-
-function testExpressionDecompiler(code)
-{
+function testExpressionDecompiler (code) {
   var fullCode = "(function() { try { \n" + code + "\n; throw 1; } catch(exx) { this.nnn.nnn } })()";
 
   try {
@@ -52,9 +49,7 @@ function testExpressionDecompiler(code)
   }
 }
 
-
-function tryHalves(code)
-{
+function tryHalves (code) {
   // See if there are any especially horrible bugs that appear when the parser has to start/stop in the middle of something. this is kinda evil.
 
   // Stray "}"s are likely in secondHalf, so use new Function rather than eval.  "}" can't escape from new Function :)
@@ -64,27 +59,20 @@ function tryHalves(code)
   var secondHalf;
 
   try {
-
     firstHalf = code.substr(0, code.length / 2);
-    if (verbose)
-      dumpln("First half: " + firstHalf);
+    if (verbose) { dumpln("First half: " + firstHalf); }
     f = new Function(firstHalf);
     void ("" + f);
-  }
-  catch (e) {
-    if (verbose)
-      dumpln("First half compilation error: " + e);
+  } catch (e) {
+    if (verbose) { dumpln("First half compilation error: " + e); }
   }
 
   try {
     secondHalf = code.substr(code.length / 2, code.length);
-    if (verbose)
-      dumpln("Second half: " + secondHalf);
+    if (verbose) { dumpln("Second half: " + secondHalf); }
     f = new Function(secondHalf);
     void ("" + f);
-  }
-  catch (e) {
-    if (verbose)
-      dumpln("Second half compilation error: " + e);
+  } catch (e) {
+    if (verbose) { dumpln("Second half compilation error: " + e); }
   }
 }

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported makeRegex, makeRegexUseBlock, makeRegexUseExpr */
 /* global makeExpr, makeFunction, POTENTIAL_MATCHES, Random, regexPattern, rnd, simpleSource */
 
 /* ************* *

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -5,9 +5,9 @@
 
 /* global makeExpr, makeFunction, POTENTIAL_MATCHES, Random, regexPattern, rnd, simpleSource */
 
-/*****************
+/* ************* *
  * USING REGEXPS *
- *****************/
+ * ************* */
 
 function randomRegexFlags() {
   var s = "";

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -20,7 +20,7 @@ function randomRegexFlags () { // eslint-disable-line require-jsdoc
 }
 
 function toRegexSource (rexpat) { // eslint-disable-line require-jsdoc
-  return (rnd(2) === 0 && rexpat.charAt(0) !== "*") ?
+  return (rnd(2) === 0 && rexpat.charAt(0) != "*") ?
     "/" + rexpat + "/" + randomRegexFlags() :
     "new RegExp(" + simpleSource(rexpat) + ", " + simpleSource(randomRegexFlags()) + ")";
 }

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -55,7 +55,7 @@ function makeRegexUseBlock(d, b, rexExpr, strExpr)
             ]) +
           "); " +
           (rnd(3) ? "" : "print(r.lastIndex); ")
-          );
+  );
 }
 
 function makeRegexUseExpr(d, b)

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -51,7 +51,7 @@ function makeRegexUseBlock(d, b, rexExpr, strExpr)
               "uneval(s.match(r))",
               "s.search(r)",
               "s.replace(r, " + makeReplacement(d, bv) + (rnd(3) ? "" : ", " + simpleSource(randomRegexFlags())) + ")",
-              "s.split(r)"
+              "s.split(r)",
             ]) +
           "); " +
           (rnd(3) ? "" : "print(r.lastIndex); ")

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global makeExpr, makeFunction, POTENTIAL_MATCHES, Random, regexPattern, rnd, simpleSource */
+
 /*****************
  * USING REGEXPS *
  *****************/

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -20,7 +20,7 @@ function randomRegexFlags () { // eslint-disable-line require-jsdoc
 }
 
 function toRegexSource (rexpat) { // eslint-disable-line require-jsdoc
-  return (rnd(2) === 0 && rexpat.charAt(0) != "*") ?
+  return (rnd(2) === 0 && rexpat.charAt(0) !== "*") ?
     "/" + rexpat + "/" + randomRegexFlags() :
     "new RegExp(" + simpleSource(rexpat) + ", " + simpleSource(randomRegexFlags()) + ")";
 }

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -80,7 +80,7 @@ function makeRegex(d, b)
 
 function makeReplacement(d, b)
 {
-  switch(rnd(3)) {
+  switch (rnd(3)) {
     case 0:  return Random.index(["''", "'x'", "'\\u0341'"]);
     case 1:  return makeExpr(d, b);
     default: return makeFunction(d, b);

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -81,9 +81,11 @@ function makeRegex(d, b)
 function makeReplacement(d, b)
 {
   switch (rnd(3)) {
+    /* eslint-disable no-multi-spaces */
     case 0:  return Random.index(["''", "'x'", "'\\u0341'"]);
     case 1:  return makeExpr(d, b);
     default: return makeFunction(d, b);
+    /* eslint-enable no-multi-spaces */
   }
 }
 

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -10,28 +10,22 @@
  * USING REGEXPS *
  * ************* */
 
-function randomRegexFlags() {
+function randomRegexFlags () {
   var s = "";
-  if (rnd(2))
-    s += "g";
-  if (rnd(2))
-    s += "y";
-  if (rnd(2))
-    s += "i";
-  if (rnd(2))
-    s += "m";
+  if (rnd(2)) { s += "g"; }
+  if (rnd(2)) { s += "y"; }
+  if (rnd(2)) { s += "i"; }
+  if (rnd(2)) { s += "m"; }
   return s;
 }
 
-function toRegexSource(rexpat)
-{
+function toRegexSource (rexpat) {
   return (rnd(2) === 0 && rexpat.charAt(0) != "*") ?
     "/" + rexpat + "/" + randomRegexFlags() :
     "new RegExp(" + simpleSource(rexpat) + ", " + simpleSource(randomRegexFlags()) + ")";
 }
 
-function makeRegexUseBlock(d, b, rexExpr, strExpr)
-{
+function makeRegexUseBlock (d, b, rexExpr, strExpr) {
   var rexpair = regexPattern(10, false);
   var rexpat = rexpair[0];
   var str = rexpair[1][rnd(POTENTIAL_MATCHES)];
@@ -52,15 +46,14 @@ function makeRegexUseBlock(d, b, rexExpr, strExpr)
               "uneval(s.match(r))",
               "s.search(r)",
               "s.replace(r, " + makeReplacement(d, bv) + (rnd(3) ? "" : ", " + simpleSource(randomRegexFlags())) + ")",
-              "s.split(r)",
+              "s.split(r)"
             ]) +
           "); " +
           (rnd(3) ? "" : "print(r.lastIndex); ")
   );
 }
 
-function makeRegexUseExpr(d, b)
-{
+function makeRegexUseExpr (d, b) {
   var rexpair = regexPattern(8, false);
   var rexpat = rexpair[0];
   var str = rexpair[1][rnd(POTENTIAL_MATCHES)];
@@ -71,16 +64,14 @@ function makeRegexUseExpr(d, b)
   return "/*RXUE*/" + rexExpr + ".exec(" + strExpr + ")";
 }
 
-function makeRegex(d, b)
-{
+function makeRegex (d, b) {
   var rexpair = regexPattern(8, false);
   var rexpat = rexpair[0];
   var rexExpr = toRegexSource(rexpat);
   return rexExpr;
 }
 
-function makeReplacement(d, b)
-{
+function makeReplacement (d, b) {
   switch (rnd(3)) {
     /* eslint-disable no-multi-spaces */
     case 0:  return Random.index(["''", "'x'", "'\\u0341'"]);
@@ -89,4 +80,3 @@ function makeReplacement(d, b)
     /* eslint-enable no-multi-spaces */
   }
 }
-

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -10,7 +10,7 @@
  * USING REGEXPS *
  * ************* */
 
-function randomRegexFlags () {
+function randomRegexFlags () { // eslint-disable-line require-jsdoc
   var s = "";
   if (rnd(2)) { s += "g"; }
   if (rnd(2)) { s += "y"; }
@@ -19,13 +19,13 @@ function randomRegexFlags () {
   return s;
 }
 
-function toRegexSource (rexpat) {
+function toRegexSource (rexpat) { // eslint-disable-line require-jsdoc
   return (rnd(2) === 0 && rexpat.charAt(0) != "*") ?
     "/" + rexpat + "/" + randomRegexFlags() :
     "new RegExp(" + simpleSource(rexpat) + ", " + simpleSource(randomRegexFlags()) + ")";
 }
 
-function makeRegexUseBlock (d, b, rexExpr, strExpr) {
+function makeRegexUseBlock (d, b, rexExpr, strExpr) { // eslint-disable-line require-jsdoc
   var rexpair = regexPattern(10, false);
   var rexpat = rexpair[0];
   var str = rexpair[1][rnd(POTENTIAL_MATCHES)];
@@ -53,7 +53,7 @@ function makeRegexUseBlock (d, b, rexExpr, strExpr) {
   );
 }
 
-function makeRegexUseExpr (d, b) {
+function makeRegexUseExpr (d, b) { // eslint-disable-line require-jsdoc
   var rexpair = regexPattern(8, false);
   var rexpat = rexpair[0];
   var str = rexpair[1][rnd(POTENTIAL_MATCHES)];
@@ -64,14 +64,14 @@ function makeRegexUseExpr (d, b) {
   return "/*RXUE*/" + rexExpr + ".exec(" + strExpr + ")";
 }
 
-function makeRegex (d, b) {
+function makeRegex (d, b) { // eslint-disable-line require-jsdoc
   var rexpair = regexPattern(8, false);
   var rexpat = rexpair[0];
   var rexExpr = toRegexSource(rexpat);
   return rexExpr;
 }
 
-function makeReplacement (d, b) {
+function makeReplacement (d, b) { // eslint-disable-line require-jsdoc
   switch (rnd(3)) {
     /* eslint-disable no-multi-spaces */
     case 0:  return Random.index(["''", "'x'", "'\\u0341'"]);

--- a/src/funfuzz/js/package.json
+++ b/src/funfuzz/js/package.json
@@ -13,7 +13,12 @@
   },
   "homepage": "https://github.com/MozillaSecurity/funfuzz#readme",
   "devDependencies": {
-    "eslint": "^5.13.0"
+    "eslint": "^5.13.0",
+    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-jsdoc": "^4.1.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0"
   },
   "scripts": {
     "lint": "eslint ./",

--- a/src/funfuzz/js/package.json
+++ b/src/funfuzz/js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "jsfunfuzz",
+  "version": "0.6.0a1",
+  "description": "A fuzzer for testing the SpiderMonkey JavaScript engine",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MozillaSecurity/funfuzz.git"
+  },
+  "author": "Gary Kwong",
+  "license": "MPL-2.0",
+  "bugs": {
+    "url": "https://github.com/MozillaSecurity/funfuzz/issues"
+  },
+  "homepage": "https://github.com/MozillaSecurity/funfuzz#readme",
+  "devDependencies": {
+    "eslint": "^5.13.0"
+  },
+  "scripts": {
+    "lint": "eslint ./",
+    "lint:fix": "eslint --fix ./"
+  }
+}

--- a/src/funfuzz/js/package.json
+++ b/src/funfuzz/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsfunfuzz",
-  "version": "0.6.0a1",
+  "version": "0.7.0a1",
   "description": "A fuzzer for testing the SpiderMonkey JavaScript engine",
   "repository": {
     "type": "git",

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -14,6 +14,7 @@
 // lines commented with // are additional comments in this JavaScript version.
 // before using this version, create at least one instance of MersenneTwister19937 class, and initialize the each state, given below in c comments, of all the instances.
 
+/* exported MersenneTwister19937 */
 /* global Int32Array */
 
 /*

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -70,9 +70,9 @@ function MersenneTwister19937()
 
   this.seed = function(s) {
     mt[0] = s | 0;
-    for (mti=1; mti<N; mti++) 
+    for (mti=1; mti<N; mti++) {
       mt[mti] = Math.imul(1812433253, mt[mti-1] ^ (mt[mti-1] >>> 30)) + mti;
-    
+    }
   };
 
   /* eslint-disable camelcase */

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -64,7 +64,7 @@ function MersenneTwister19937()
   var mt = new Int32Array(N);   /* the array for the state vector */
   var mti = 625;
 
-  this.seed = function (s) {
+  this.seed = function(s) {
     mt[0] = s | 0;
     for (mti=1; mti<N; mti++) {
       mt[mti] = Math.imul(1812433253, mt[mti-1] ^ (mt[mti-1] >>> 30)) + mti;
@@ -83,7 +83,7 @@ function MersenneTwister19937()
     return MAG01[y & 0x1];
   }
 
-  this.int32 = function () {
+  this.int32 = function() {
     var y;
     var kk;
 

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -56,7 +56,7 @@
    email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
 */
 
-function MersenneTwister19937 () {
+function MersenneTwister19937 () { // eslint-disable-line require-jsdoc
   const N = 624;
   const M = 397;
   const MAG01 = new Int32Array([0, 0x9908b0df]);
@@ -80,7 +80,7 @@ function MersenneTwister19937 () {
   this.import_mti = function (_mti) { mti = _mti; };
   /* eslint-enable camelcase */
 
-  function mag01 (y) {
+  function mag01 (y) { // eslint-disable-line require-jsdoc
     return MAG01[y & 0x1];
   }
 

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -9,10 +9,12 @@
 //   * Removed parts not needed for fuzzing
 
 // in this program, procedure descriptions and comments of original source code were not removed.
-// lines commented with //c// were originally descriptions of c procedure. and a few following lines are appropriate JavaScript descriptions.
+// lines commented with //c// were originally descriptions of c procedure.
+//   And a few following lines are appropriate JavaScript descriptions.
 // lines commented with /* and */ are original comments.
 // lines commented with // are additional comments in this JavaScript version.
-// before using this version, create at least one instance of MersenneTwister19937 class, and initialize the each state, given below in c comments, of all the instances.
+// before using this version, create at least one instance of MersenneTwister19937 class,
+//   and initialize the each state, given below in c comments, of all the instances.
 
 /* global Int32Array */
 

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -14,6 +14,8 @@
 // lines commented with // are additional comments in this JavaScript version.
 // before using this version, create at least one instance of MersenneTwister19937 class, and initialize the each state, given below in c comments, of all the instances.
 
+/* global Int32Array */
+
 /*
    A C-program for MT19937, with initialization improved 2002/1/26.
    Coded by Takuji Nishimura and Makoto Matsumoto.

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -51,15 +51,12 @@
    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
    Any feedback is very welcome.
    http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
    email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
 */
 
-
-function MersenneTwister19937()
-{
+function MersenneTwister19937 () {
   const N = 624;
   const M = 397;
   const MAG01 = new Int32Array([0, 0x9908b0df]);
@@ -67,42 +64,41 @@ function MersenneTwister19937()
   var mt = new Int32Array(N); /* the array for the state vector */
   var mti = 625;
 
-  this.seed = function(s) {
+  this.seed = function (s) {
     mt[0] = s | 0;
-    for (mti=1; mti<N; mti++) {
-      mt[mti] = Math.imul(1812433253, mt[mti-1] ^ (mt[mti-1] >>> 30)) + mti;
+    for (mti = 1; mti < N; mti++) {
+      mt[mti] = Math.imul(1812433253, mt[mti - 1] ^ (mt[mti - 1] >>> 30)) + mti;
     }
   };
 
   /* eslint-disable camelcase */
-  this.export_state = function() { return [mt, mti]; };
-  this.import_state = function(s) { mt = s[0]; mti = s[1]; };
-  this.export_mta = function() { return mt; };
-  this.import_mta = function(_mta) { mt = _mta; };
-  this.export_mti = function() { return mti; };
-  this.import_mti = function(_mti) { mti = _mti; };
+  this.export_state = function () { return [mt, mti]; };
+  this.import_state = function (s) { mt = s[0]; mti = s[1]; };
+  this.export_mta = function () { return mt; };
+  this.import_mta = function (_mta) { mt = _mta; };
+  this.export_mti = function () { return mti; };
+  this.import_mti = function (_mti) { mti = _mti; };
   /* eslint-enable camelcase */
 
-  function mag01(y)
-  {
+  function mag01 (y) {
     return MAG01[y & 0x1];
   }
 
-  this.int32 = function() {
+  this.int32 = function () {
     var y;
     var kk;
 
     if (mti >= N) { /* generate N words at one time */
-      for (kk=0;kk<N-M;kk++) {
-        y = ((mt[kk]&0x80000000)|(mt[kk+1]&0x7fffffff));
-        mt[kk] = (mt[kk+M] ^ (y >>> 1) ^ mag01(y));
+      for (kk = 0; kk < N - M; kk++) {
+        y = ((mt[kk] & 0x80000000) | (mt[kk + 1] & 0x7fffffff));
+        mt[kk] = (mt[kk + M] ^ (y >>> 1) ^ mag01(y));
       }
-      for (;kk<N-1;kk++) {
-        y = ((mt[kk]&0x80000000)|(mt[kk+1]&0x7fffffff));
-        mt[kk] = (mt[kk+(M-N)] ^ (y >>> 1) ^ mag01(y));
+      for (;kk < N - 1; kk++) {
+        y = ((mt[kk] & 0x80000000) | (mt[kk + 1] & 0x7fffffff));
+        mt[kk] = (mt[kk + (M - N)] ^ (y >>> 1) ^ mag01(y));
       }
-      y = ((mt[N-1]&0x80000000)|(mt[0]&0x7fffffff));
-      mt[N-1] = (mt[M-1] ^ (y >>> 1) ^ mag01(y));
+      y = ((mt[N - 1] & 0x80000000) | (mt[0] & 0x7fffffff));
+      mt[N - 1] = (mt[M - 1] ^ (y >>> 1) ^ mag01(y));
       mti = 0;
     }
 

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -72,14 +72,16 @@ function MersenneTwister19937()
       mt[mti] = Math.imul(1812433253, mt[mti-1] ^ (mt[mti-1] >>> 30)) + mti;
     }
   };
-
+  
+  /* eslint-disable camelcase */
   this.export_state = function() { return [mt, mti]; };
   this.import_state = function(s) { mt = s[0]; mti = s[1]; };
   this.export_mta = function() { return mt; };
   this.import_mta = function(_mta) { mt = _mta; };
   this.export_mti = function() { return mti; };
   this.import_mti = function(_mti) { mti = _mti; };
-
+  /* eslint-enable camelcase */
+  
   function mag01(y)
   {
     return MAG01[y & 0x1];

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -63,7 +63,7 @@ function MersenneTwister19937()
   const M = 397;
   const MAG01 = new Int32Array([0, 0x9908b0df]);
 
-  var mt = new Int32Array(N);   /* the array for the state vector */
+  var mt = new Int32Array(N); /* the array for the state vector */
   var mti = 625;
 
   this.seed = function(s) {
@@ -72,7 +72,7 @@ function MersenneTwister19937()
       mt[mti] = Math.imul(1812433253, mt[mti-1] ^ (mt[mti-1] >>> 30)) + mti;
     }
   };
-  
+
   /* eslint-disable camelcase */
   this.export_state = function() { return [mt, mti]; };
   this.import_state = function(s) { mt = s[0]; mti = s[1]; };
@@ -81,7 +81,7 @@ function MersenneTwister19937()
   this.export_mti = function() { return mti; };
   this.import_mti = function(_mti) { mti = _mti; };
   /* eslint-enable camelcase */
-  
+
   function mag01(y)
   {
     return MAG01[y & 0x1];

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -70,9 +70,9 @@ function MersenneTwister19937()
 
   this.seed = function(s) {
     mt[0] = s | 0;
-    for (mti=1; mti<N; mti++) {
+    for (mti=1; mti<N; mti++) 
       mt[mti] = Math.imul(1812433253, mt[mti-1] ^ (mt[mti-1] >>> 30)) + mti;
-    }
+    
   };
 
   /* eslint-disable camelcase */

--- a/src/funfuzz/js/shared/mersenne-twister.js
+++ b/src/funfuzz/js/shared/mersenne-twister.js
@@ -9,12 +9,10 @@
 //   * Removed parts not needed for fuzzing
 
 // in this program, procedure descriptions and comments of original source code were not removed.
-// lines commented with //c// were originally descriptions of c procedure.
-//   And a few following lines are appropriate JavaScript descriptions.
+// lines commented with //c// were originally descriptions of c procedure. and a few following lines are appropriate JavaScript descriptions.
 // lines commented with /* and */ are original comments.
 // lines commented with // are additional comments in this JavaScript version.
-// before using this version, create at least one instance of MersenneTwister19937 class,
-//   and initialize the each state, given below in c comments, of all the instances.
+// before using this version, create at least one instance of MersenneTwister19937 class, and initialize the each state, given below in c comments, of all the instances.
 
 /* global Int32Array */
 

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -6,14 +6,14 @@
 var Random = {
   twister: null,
 
-  init: function (seed) {
+  init: function(seed) {
     if (seed == null || seed === undefined) {
       seed = new Date().getTime();
     }
     this.twister = new MersenneTwister19937();
     this.twister.seed(seed);
   },
-  number: function (limit) {
+  number: function(limit) {
     // Returns an integer in [0, limit). Uniform distribution.
     if (limit == 0) {
       return limit;
@@ -23,11 +23,11 @@ var Random = {
     }
     return (Random.twister.int32() >>> 0) % limit;
   },
-  float: function () {
+  float: function() {
     // Returns a float in [0, 1]. Uniform distribution.
     return (Random.twister.int32() >>> 0) * (1.0/4294967295.0);
   },
-  range: function (start, limit) {
+  range: function(start, limit) {
     // Returns an integer in [start, limit]. Uniform distribution.
     if (isNaN(start) || isNaN(limit)) {
       Utils.traceback();
@@ -39,7 +39,7 @@ var Random = {
     // Returns a float in [1, limit]. The logarithm has uniform distribution.
     return Math.exp(Random.float() * Math.log(limit));
   },
-  index: function (list, emptyr) {
+  index: function(list, emptyr) {
     if (!(list instanceof Array || (typeof list != "string" && "length" in list))) {
       Utils.traceback();
       throw new TypeError("Random.index() received a non array type: '" + list + "'");
@@ -48,17 +48,17 @@ var Random = {
       return emptyr;
     return list[this.number(list.length)];
   },
-  key: function (obj) {
+  key: function(obj) {
     var list = [];
     for (var i in obj) {
       list.push(i);
     }
     return this.index(list);
   },
-  bool: function () {
+  bool: function() {
     return this.index([true, false]);
   },
-  pick: function (obj) {
+  pick: function(obj) {
     if (typeof obj == "function") {
       return obj();
     }
@@ -67,7 +67,7 @@ var Random = {
     }
     return obj;
   },
-  chance: function (limit) {
+  chance: function(limit) {
     if (limit == null || limit === undefined) {
       limit = 2;
     }
@@ -77,7 +77,7 @@ var Random = {
     }
     return this.number(limit) == 1;
   },
-  choose: function (list, flat) {
+  choose: function(list, flat) {
     if (!(list instanceof Array)) {
       Utils.traceback();
       throw new TypeError("Random.choose() received a non-array type: '" + list + "'");
@@ -102,7 +102,7 @@ var Random = {
     }
     return this.pick([list[0][1]]);
   },
-  weighted: function (wa) {
+  weighted: function(wa) {
     // More memory-hungry but hopefully faster than Random.choose$flat
     var a = [];
     for (var i = 0; i < wa.length; ++i) {
@@ -112,10 +112,10 @@ var Random = {
     }
     return a;
   },
-  use: function (obj) {
+  use: function(obj) {
     return Random.bool() ? obj : "";
   },
-  shuffle: function (arr) {
+  shuffle: function(arr) {
     var len = arr.length;
     var i = len;
     while (i--) {
@@ -125,7 +125,7 @@ var Random = {
       arr[p] = t;
     }
   },
-  shuffled: function (arr) {
+  shuffled: function(arr) {
     var newArray = arr.slice();
     Random.shuffle(newArray);
     return newArray;

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -133,7 +133,7 @@ var Random = {
     return newArray;
   },
   subset: function(a) {
-    // TODO: shuffle, repeat, include bogus things [see also https://github.com/mozilla/rust/blob/d0ddc69298c41df04b0488d91d521eb531d79177/src/fuzzer/ivec_fuzz.rs]
+    // TODO: shuffle, repeat, include bogus things [see also https://git.io/fhQg0]
     // Consider adding a weight argument, or swarming on inclusion/exclusion to make 'all' and 'none' more likely
     var subset = [];
     for (var i = 0; i < a.length; ++i) {

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -17,7 +17,7 @@ var Random = {
   },
   number: function (limit) {
     // Returns an integer in [0, limit). Uniform distribution.
-    if (limit == 0) {
+    if (limit === 0) {
       return limit;
     }
     if (limit == null || limit === undefined) {
@@ -76,7 +76,7 @@ var Random = {
       Utils.traceback();
       throw new TypeError("Random.chance() received a non number type: '" + limit + "'");
     }
-    return this.number(limit) == 1;
+    return this.number(limit) === 1;
   },
   choose: function (list, flat) {
     if (!(list instanceof Array)) {
@@ -90,7 +90,7 @@ var Random = {
     var n = this.number(total);
     for (let j = 0; j < list.length; j++) {
       if (n < list[j][0]) {
-        if (flat == true) {
+        if (flat === true) {
           return list[j][1];
         } else {
           return this.pick([list[j][1]]);
@@ -98,7 +98,7 @@ var Random = {
       }
       n = n - list[j][0];
     }
-    if (flat == true) {
+    if (flat === true) {
       return list[0][1];
     }
     return this.pick([list[0][1]]);

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -8,14 +8,14 @@
 var Random = {
   twister: null,
 
-  init: function(seed) {
+  init: function (seed) {
     if (seed == null || seed === undefined) {
       seed = new Date().getTime();
     }
     this.twister = new MersenneTwister19937();
     this.twister.seed(seed);
   },
-  number: function(limit) {
+  number: function (limit) {
     // Returns an integer in [0, limit). Uniform distribution.
     if (limit == 0) {
       return limit;
@@ -25,11 +25,11 @@ var Random = {
     }
     return (Random.twister.int32() >>> 0) % limit;
   },
-  float: function() {
+  float: function () {
     // Returns a float in [0, 1]. Uniform distribution.
-    return (Random.twister.int32() >>> 0) * (1.0/4294967295.0);
+    return (Random.twister.int32() >>> 0) * (1.0 / 4294967295.0);
   },
-  range: function(start, limit) {
+  range: function (start, limit) {
     // Returns an integer in [start, limit]. Uniform distribution.
     if (isNaN(start) || isNaN(limit)) {
       Utils.traceback();
@@ -37,31 +37,30 @@ var Random = {
     }
     return Random.number(limit - start + 1) + start;
   },
-  ludOneTo: function(limit) {
+  ludOneTo: function (limit) {
     // Returns a float in [1, limit]. The logarithm has uniform distribution.
     return Math.exp(Random.float() * Math.log(limit));
   },
-  index: function(list, emptyr) {
-    if (!(list instanceof Array || (typeof list != "string" && "length" in list))) {
+  index: function (list, emptyr) {
+    if (!(list instanceof Array || (typeof list !== "string" && "length" in list))) {
       Utils.traceback();
       throw new TypeError("Random.index() received a non array type: '" + list + "'");
     }
-    if (!list.length)
-      return emptyr;
+    if (!list.length) { return emptyr; }
     return list[this.number(list.length)];
   },
-  key: function(obj) {
+  key: function (obj) {
     var list = [];
     for (var i in obj) {
       list.push(i);
     }
     return this.index(list);
   },
-  bool: function() {
+  bool: function () {
     return this.index([true, false]);
   },
-  pick: function(obj) {
-    if (typeof obj == "function") {
+  pick: function (obj) {
+    if (typeof obj === "function") {
       return obj();
     }
     if (obj instanceof Array) {
@@ -69,7 +68,7 @@ var Random = {
     }
     return obj;
   },
-  chance: function(limit) {
+  chance: function (limit) {
     if (limit == null || limit === undefined) {
       limit = 2;
     }
@@ -79,7 +78,7 @@ var Random = {
     }
     return this.number(limit) == 1;
   },
-  choose: function(list, flat) {
+  choose: function (list, flat) {
     if (!(list instanceof Array)) {
       Utils.traceback();
       throw new TypeError("Random.choose() received a non-array type: '" + list + "'");
@@ -104,7 +103,7 @@ var Random = {
     }
     return this.pick([list[0][1]]);
   },
-  weighted: function(wa) {
+  weighted: function (wa) {
     // More memory-hungry but hopefully faster than Random.choose$flat
     var a = [];
     for (var i = 0; i < wa.length; ++i) {
@@ -114,10 +113,10 @@ var Random = {
     }
     return a;
   },
-  use: function(obj) {
+  use: function (obj) {
     return Random.bool() ? obj : "";
   },
-  shuffle: function(arr) {
+  shuffle: function (arr) {
     var len = arr.length;
     var i = len;
     while (i--) {
@@ -127,12 +126,12 @@ var Random = {
       arr[p] = t;
     }
   },
-  shuffled: function(arr) {
+  shuffled: function (arr) {
     var newArray = arr.slice();
     Random.shuffle(newArray);
     return newArray;
   },
-  subset: function(a) {
+  subset: function (a) {
     // TODO: shuffle, repeat, include bogus things [see also https://github.com/mozilla/rust/blob/d0ddc69298c41df04b0488d91d521eb531d79177/src/fuzzer/ivec_fuzz.rs]
     // Consider adding a weight argument, or swarming on inclusion/exclusion to make 'all' and 'none' more likely
     var subset = [];
@@ -142,8 +141,8 @@ var Random = {
       }
     }
     return subset;
-  },
+  }
 
 };
 
-function rnd(n) { return Random.number(n); }
+function rnd (n) { return Random.number(n); }

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -9,20 +9,20 @@ var Random = {
   twister: null,
 
   init: function(seed) {
-    if (seed == null || seed === undefined) {
+    if (seed == null || seed === undefined) 
       seed = new Date().getTime();
-    }
+    
     this.twister = new MersenneTwister19937();
     this.twister.seed(seed);
   },
   number: function(limit) {
     // Returns an integer in [0, limit). Uniform distribution.
-    if (limit == 0) {
+    if (limit == 0) 
       return limit;
-    }
-    if (limit == null || limit === undefined) {
+    
+    if (limit == null || limit === undefined) 
       limit = 0xffffffff;
-    }
+    
     return (Random.twister.int32() >>> 0) % limit;
   },
   float: function() {
@@ -52,27 +52,27 @@ var Random = {
   },
   key: function(obj) {
     var list = [];
-    for (var i in obj) {
+    for (var i in obj) 
       list.push(i);
-    }
+    
     return this.index(list);
   },
   bool: function() {
     return this.index([true, false]);
   },
   pick: function(obj) {
-    if (typeof obj == "function") {
+    if (typeof obj == "function") 
       return obj();
-    }
-    if (obj instanceof Array) {
+    
+    if (obj instanceof Array) 
       return this.pick(this.index(obj));
-    }
+    
     return obj;
   },
   chance: function(limit) {
-    if (limit == null || limit === undefined) {
+    if (limit == null || limit === undefined) 
       limit = 2;
-    }
+    
     if (isNaN(limit)) {
       Utils.traceback();
       throw new TypeError("Random.chance() received a non number type: '" + limit + "'");
@@ -85,33 +85,33 @@ var Random = {
       throw new TypeError("Random.choose() received a non-array type: '" + list + "'");
     }
     var total = 0;
-    for (var i = 0; i < list.length; i++) {
+    for (var i = 0; i < list.length; i++) 
       total += list[i][0];
-    }
+    
     var n = this.number(total);
     for (var i = 0; i < list.length; i++) {
-      if (n < list[i][0]) {
+      if (n < list[i][0]) 
         if (flat == true) {
           return list[i][1];
         } else {
           return this.pick([list[i][1]]);
         }
-      }
+      
       n = n - list[i][0];
     }
-    if (flat == true) {
+    if (flat == true) 
       return list[0][1];
-    }
+    
     return this.pick([list[0][1]]);
   },
   weighted: function(wa) {
     // More memory-hungry but hopefully faster than Random.choose$flat
     var a = [];
-    for (var i = 0; i < wa.length; ++i) {
-      for (var j = 0; j < wa[i].w; ++j) {
+    for (var i = 0; i < wa.length; ++i) 
+      for (var j = 0; j < wa[i].w; ++j) 
         a.push(wa[i].v);
-      }
-    }
+      
+    
     return a;
   },
   use: function(obj) {
@@ -136,11 +136,11 @@ var Random = {
     // TODO: shuffle, repeat, include bogus things [see also https://git.io/fhQg0]
     // Consider adding a weight argument, or swarming on inclusion/exclusion to make 'all' and 'none' more likely
     var subset = [];
-    for (var i = 0; i < a.length; ++i) {
-      if (rnd(2)) {
+    for (var i = 0; i < a.length; ++i) 
+      if (rnd(2)) 
         subset.push(a[i]);
-      }
-    }
+      
+    
     return subset;
   },
 

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -88,7 +88,7 @@ var Random = {
       total += list[i][0];
     }
     var n = this.number(total);
-    for (var i = 0; i < list.length; i++) {
+    for (let i = 0; i < list.length; i++) {
       if (n < list[i][0]) {
         if (flat == true) {
           return list[i][1];

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -17,7 +17,7 @@ var Random = {
   },
   number: function (limit) {
     // Returns an integer in [0, limit). Uniform distribution.
-    if (limit === 0) {
+    if (limit == 0) {
       return limit;
     }
     if (limit == null || limit === undefined) {
@@ -76,7 +76,7 @@ var Random = {
       Utils.traceback();
       throw new TypeError("Random.chance() received a non number type: '" + limit + "'");
     }
-    return this.number(limit) === 1;
+    return this.number(limit) == 1;
   },
   choose: function (list, flat) {
     if (!(list instanceof Array)) {
@@ -90,7 +90,7 @@ var Random = {
     var n = this.number(total);
     for (let j = 0; j < list.length; j++) {
       if (n < list[j][0]) {
-        if (flat === true) {
+        if (flat == true) {
           return list[j][1];
         } else {
           return this.pick([list[j][1]]);
@@ -98,7 +98,7 @@ var Random = {
       }
       n = n - list[j][0];
     }
-    if (flat === true) {
+    if (flat == true) {
       return list[0][1];
     }
     return this.pick([list[0][1]]);

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -88,15 +88,15 @@ var Random = {
       total += list[i][0];
     }
     var n = this.number(total);
-    for (let i = 0; i < list.length; i++) {
-      if (n < list[i][0]) {
+    for (let j = 0; j < list.length; j++) {
+      if (n < list[j][0]) {
         if (flat == true) {
-          return list[i][1];
+          return list[j][1];
         } else {
-          return this.pick([list[i][1]]);
+          return this.pick([list[j][1]]);
         }
       }
-      n = n - list[i][0];
+      n = n - list[j][0];
     }
     if (flat == true) {
       return list[0][1];

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -133,7 +133,7 @@ var Random = {
     return newArray;
   },
   subset: function(a) {
-    // TODO: shuffle, repeat, include bogus things [see also https://git.io/fhQg0]
+    // TODO: shuffle, repeat, include bogus things [see also https://github.com/mozilla/rust/blob/d0ddc69298c41df04b0488d91d521eb531d79177/src/fuzzer/ivec_fuzz.rs]
     // Consider adding a weight argument, or swarming on inclusion/exclusion to make 'all' and 'none' more likely
     var subset = [];
     for (var i = 0; i < a.length; ++i) {

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global MersenneTwister19937, Utils */
+
 var Random = {
   twister: null,
 

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -9,20 +9,20 @@ var Random = {
   twister: null,
 
   init: function(seed) {
-    if (seed == null || seed === undefined) 
+    if (seed == null || seed === undefined) {
       seed = new Date().getTime();
-    
+    }
     this.twister = new MersenneTwister19937();
     this.twister.seed(seed);
   },
   number: function(limit) {
     // Returns an integer in [0, limit). Uniform distribution.
-    if (limit == 0) 
+    if (limit == 0) {
       return limit;
-    
-    if (limit == null || limit === undefined) 
+    }
+    if (limit == null || limit === undefined) {
       limit = 0xffffffff;
-    
+    }
     return (Random.twister.int32() >>> 0) % limit;
   },
   float: function() {
@@ -52,27 +52,27 @@ var Random = {
   },
   key: function(obj) {
     var list = [];
-    for (var i in obj) 
+    for (var i in obj) {
       list.push(i);
-    
+    }
     return this.index(list);
   },
   bool: function() {
     return this.index([true, false]);
   },
   pick: function(obj) {
-    if (typeof obj == "function") 
+    if (typeof obj == "function") {
       return obj();
-    
-    if (obj instanceof Array) 
+    }
+    if (obj instanceof Array) {
       return this.pick(this.index(obj));
-    
+    }
     return obj;
   },
   chance: function(limit) {
-    if (limit == null || limit === undefined) 
+    if (limit == null || limit === undefined) {
       limit = 2;
-    
+    }
     if (isNaN(limit)) {
       Utils.traceback();
       throw new TypeError("Random.chance() received a non number type: '" + limit + "'");
@@ -85,33 +85,33 @@ var Random = {
       throw new TypeError("Random.choose() received a non-array type: '" + list + "'");
     }
     var total = 0;
-    for (var i = 0; i < list.length; i++) 
+    for (var i = 0; i < list.length; i++) {
       total += list[i][0];
-    
+    }
     var n = this.number(total);
     for (var i = 0; i < list.length; i++) {
-      if (n < list[i][0]) 
+      if (n < list[i][0]) {
         if (flat == true) {
           return list[i][1];
         } else {
           return this.pick([list[i][1]]);
         }
-      
+      }
       n = n - list[i][0];
     }
-    if (flat == true) 
+    if (flat == true) {
       return list[0][1];
-    
+    }
     return this.pick([list[0][1]]);
   },
   weighted: function(wa) {
     // More memory-hungry but hopefully faster than Random.choose$flat
     var a = [];
-    for (var i = 0; i < wa.length; ++i) 
-      for (var j = 0; j < wa[i].w; ++j) 
+    for (var i = 0; i < wa.length; ++i) {
+      for (var j = 0; j < wa[i].w; ++j) {
         a.push(wa[i].v);
-      
-    
+      }
+    }
     return a;
   },
   use: function(obj) {
@@ -136,11 +136,11 @@ var Random = {
     // TODO: shuffle, repeat, include bogus things [see also https://git.io/fhQg0]
     // Consider adding a weight argument, or swarming on inclusion/exclusion to make 'all' and 'none' more likely
     var subset = [];
-    for (var i = 0; i < a.length; ++i) 
-      if (rnd(2)) 
+    for (var i = 0; i < a.length; ++i) {
+      if (rnd(2)) {
         subset.push(a[i]);
-      
-    
+      }
+    }
     return subset;
   },
 

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -145,4 +145,4 @@ var Random = {
 
 };
 
-function rnd (n) { return Random.number(n); }
+function rnd (n) { return Random.number(n); } // eslint-disable-line require-jsdoc

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -125,7 +125,7 @@ function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) { // eslint-disabl
     { w: 10, v: function (d, b) { return prefix + "baselineCompile" + "();"; } },
 
     // Force inline cache.
-    { w: 1, v: function (d, b) { return prefix + "setJitCompilerOption" + "('ion.forceinlineCaches\', " + rnd(2) + ");"; } },
+    { w: 1, v: function (d, b) { return prefix + "setJitCompilerOption" + "('ion.forceinlineCaches', " + rnd(2) + ");"; } },
 
     // Run-time equivalents to --no-ion, --no-baseline
     // These can throw: "Can't turn off JITs with JIT code on the stack."

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -10,15 +10,15 @@
 // * testing that they do not cause assertions/crashes
 // * testing that they do not alter visible results (compare_jit with and without the call)
 
-function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) {
+function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) { // eslint-disable-line require-jsdoc
   var prefix = browser ? "fuzzPriv." : "";
 
-  function numberOfInstructions () { return Math.floor(Random.ludOneTo(10000)); }
-  function numberOfAllocs () { return Math.floor(Random.ludOneTo(500)); }
-  function gcSliceSize () { return Math.floor(Random.ludOneTo(0x100000000)); }
-  function maybeCommaShrinking () { return rnd(5) ? "" : ", 'shrinking'"; }
+  function numberOfInstructions () { return Math.floor(Random.ludOneTo(10000)); } // eslint-disable-line require-jsdoc
+  function numberOfAllocs () { return Math.floor(Random.ludOneTo(500)); } // eslint-disable-line require-jsdoc
+  function gcSliceSize () { return Math.floor(Random.ludOneTo(0x100000000)); } // eslint-disable-line require-jsdoc
+  function maybeCommaShrinking () { return rnd(5) ? "" : ", 'shrinking'"; } // eslint-disable-line require-jsdoc
 
-  function enableGCZeal () {
+  function enableGCZeal () { // eslint-disable-line require-jsdoc
     // As of m-c 451466:79cf24341024 2018-12-19
     // https://hg.mozilla.org/mozilla-central/file/79cf24341024/js/src/gc/GC.cpp#l1000
     maxLevel = 25;
@@ -40,7 +40,7 @@ function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) {
     return prefix + "gczeal" + "(" + finalLevel + ", " + period + ");";
   }
 
-  function callSetGCCallback () {
+  function callSetGCCallback () { // eslint-disable-line require-jsdoc
     // https://dxr.mozilla.org/mozilla-central/source/js/src/shell/js.cpp - SetGCCallback
     var phases = Random.index(["both", "begin", "end"]);
     var actionAndOptions = rnd(2) ? 'action: "majorGC", depth: ' + rnd(17) : 'action: "minorGC"';
@@ -48,11 +48,11 @@ function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) {
     return prefix + "setGCCallback(" + arg + ");";
   }
 
-  function tryCatch (statement) {
+  function tryCatch (statement) { // eslint-disable-line require-jsdoc
     return "try { " + statement + " } catch(e) { }";
   }
 
-  function setGcparam () {
+  function setGcparam () { // eslint-disable-line require-jsdoc
     switch (rnd(2)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return _set("sliceTimeBudget", rnd(100));
@@ -60,7 +60,7 @@ function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) {
       /* eslint-enable no-multi-spaces */
     }
 
-    function _set (name, value) {
+    function _set (name, value) { // eslint-disable-line require-jsdoc
       // try..catch because gcparam sets may throw, depending on GC state (see bug 973571)
       return tryCatch(prefix + "gcparam" + "('" + name + "', " + value + ");");
     }

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -58,8 +58,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     switch (rnd(2)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return _set("sliceTimeBudget", rnd(100));
-      // Artificially trigger delayed marking
-      default: return _set("markStackLimit", rnd(2) ? (1 + rnd(30)) : 4294967295);
+      default: return _set("markStackLimit", rnd(2) ? (1 + rnd(30)) : 4294967295); // Artificially trigger delayed marking
       /* eslint-enable no-multi-spaces */
     }
 
@@ -74,15 +73,9 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
   var sharedTestingFunctions = [
     /* eslint-disable no-multi-spaces */
     // Force garbage collection (global or specific compartment)
-    { w: 10, v: function(d, b) { return "void "
-      + prefix + "gc" + "("                                           + ");";
-    } },
-    { w: 10, v: function(d, b) { return "void "
-      + prefix + "gc" + "(" + "'compartment'" + maybeCommaShrinking() + ");";
-    } },
-    { w: 5,  v: function(d, b) { return "void "
-      + prefix + "gc" + "(" + fGlobal(d, b)   + maybeCommaShrinking() + ");";
-    } },
+    { w: 10, v: function(d, b) { return "void " + prefix + "gc" + "("                                            + ");"; } },
+    { w: 10, v: function(d, b) { return "void " + prefix + "gc" + "(" + "'compartment'" + maybeCommaShrinking() + ");"; } },
+    { w: 5,  v: function(d, b) { return "void " + prefix + "gc" + "(" + fGlobal(d, b)   + maybeCommaShrinking() + ");"; } },
     /* eslint-enable no-multi-spaces */
 
     // Run a minor garbage collection on the nursery.
@@ -91,9 +84,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
 
     // Start, continue, or abort incremental garbage collection.
     // startgc can throw: "Incremental GC already in progress"
-    { w: 20, v: function(d, b) { return tryCatch(prefix
-      + "startgc" + "(" + gcSliceSize() + maybeCommaShrinking() + ");");
-    } },
+    { w: 20, v: function(d, b) { return tryCatch(prefix + "startgc" + "(" + gcSliceSize() + maybeCommaShrinking() + ");"); } },
     { w: 20, v: function(d, b) { return prefix + "gcslice" + "(" + gcSliceSize() + ");"; } },
     { w: 10, v: function(d, b) { return prefix + "abortgc" + "(" + ");"; } },
 
@@ -114,12 +105,9 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     // Nothing happens when there is only one call.
     { w: 10, v: function(d, b) { return prefix + "verifyprebarriers" + "();"; } },
 
-    // hasChild(parent, child): Return true if |child| is a child of |parent|,
-    // as determined by a call to TraceChildren.
+    // hasChild(parent, child): Return true if |child| is a child of |parent|, as determined by a call to TraceChildren.
     // We ignore the return value because hasChild can be used to see which WeakMap entries have been GCed.
-    { w: 1,  v: function(d, b) { return "void "
-      + prefix + "hasChild(" + fObject(d, b) + ", " + fObject(d, b) + ");";
-    } },
+    { w: 1,  v: function(d, b) { return "void " + prefix + "hasChild(" + fObject(d, b) + ", " + fObject(d, b) + ");"; } },
 
     // Various validation functions (toggles)
     { w: 5,  v: function(d, b) { return prefix + "fullcompartmentchecks" + "(false);"; } },
@@ -132,29 +120,19 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     { w: 1,  v: function(d, b) { return prefix + "assertJitStackInvariants" + "();"; } },
 
     // Run-time equivalents to --baseline-eager, --baseline-warmup-threshold, --ion-eager, --ion-warmup-threshold
-    { w: 1,  v: function(d, b) { return prefix
-      + "setJitCompilerOption" + "('baseline.warmup.trigger', " + rnd(20) + ");";
-    } },
-    { w: 1,  v: function(d, b) { return prefix
-      + "setJitCompilerOption" + "('ion.warmup.trigger', " + rnd(40) + ");";
-    } },
+    { w: 1,  v: function(d, b) { return prefix + "setJitCompilerOption" + "('baseline.warmup.trigger', " + rnd(20) + ");"; } },
+    { w: 1,  v: function(d, b) { return prefix + "setJitCompilerOption" + "('ion.warmup.trigger', " + rnd(40) + ");"; } },
 
     // Test the baseline compiler
     { w: 10,  v: function(d, b) { return prefix + "baselineCompile" + "();"; } },
 
     // Force inline cache.
-    { w: 1,  v: function(d, b) { return prefix
-      + "setJitCompilerOption" + "('ion.forceinlineCaches\', " + rnd(2) + ");";
-    } },
+    { w: 1,  v: function(d, b) { return prefix + "setJitCompilerOption" + "('ion.forceinlineCaches\', " + rnd(2) + ");"; } },
 
     // Run-time equivalents to --no-ion, --no-baseline
     // These can throw: "Can't turn off JITs with JIT code on the stack."
-    { w: 1,  v: function(d, b) { return tryCatch(prefix
-      + "setJitCompilerOption" + "('ion.enable', " + rnd(2) + ");");
-    } },
-    { w: 1,  v: function(d, b) { return tryCatch(prefix
-      + "setJitCompilerOption" + "('baseline.enable', " + rnd(2) + ");");
-    } },
+    { w: 1,  v: function(d, b) { return tryCatch(prefix + "setJitCompilerOption" + "('ion.enable', " + rnd(2) + ");"); } },
+    { w: 1,  v: function(d, b) { return tryCatch(prefix + "setJitCompilerOption" + "('baseline.enable', " + rnd(2) + ");"); } },
 
     // Test the built-in profiler.
     { w: 1,  v: function(d, b) { return prefix + "enableGeckoProfiling" + "();"; } },
@@ -166,7 +144,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     { w: 5,  v: function(d, b) { return prefix + "deterministicgc" + "(false);"; } },
     { w: 1,  v: function(d, b) { return prefix + "deterministicgc" + "(true);"; } },
 
-    // Causes JIT code to always be preserved by GCs afterwards (see https://bugzil.la/750834)
+    // Causes JIT code to always be preserved by GCs afterwards (see https://bugzilla.mozilla.org/show_bug.cgi?id=750834)
     { w: 5,  v: function(d, b) { return prefix + "gcPreserveCode" + "();"; } },
 
     // Generate an LCOV trace (but throw away the returned string)
@@ -189,9 +167,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
   var shellOnlyTestingFunctions = [
     // ARM simulator settings
     // These throw when not in the ARM simulator.
-    { w: 1,  v: function(d, b) { return tryCatch("(void" + prefix
-      + "disableSingleStepProfiling" + "()" + ")");
-    } },
+    { w: 1,  v: function(d, b) { return tryCatch("(void" + prefix + "disableSingleStepProfiling" + "()" + ")"); } },
     { w: 1,  v: function(d, b) { return tryCatch("(" + prefix + "enableSingleStepProfiling" + "()" + ")"); } },
 
     // Force garbage collection with function relazification
@@ -205,14 +181,11 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
 
     // [TestingFunctions.cpp, but debug-only and CRASHY]
     // After N js_malloc memory allocations, fail every following allocation
-    { w: 1,  v: function(d, b) { return (typeof oomAfterAllocations == "function"
-      && rnd(1000) === 0) ? prefix + "oomAfterAllocations" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
+    { w: 1,  v: function(d, b) { return (typeof oomAfterAllocations == "function" && rnd(1000) === 0) ? prefix + "oomAfterAllocations" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
     // After N js_malloc memory allocations, fail one allocation
-    { w: 1,  v: function(d, b) { return (typeof oomAtAllocation == "function"
-      && rnd(100) === 0) ? prefix + "oomAtAllocation" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
+    { w: 1,  v: function(d, b) { return (typeof oomAtAllocation == "function" && rnd(100) === 0) ? prefix + "oomAtAllocation" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
     // Reset either of the above
-    { w: 1,  v: function(d, b) { return (typeof resetOOMFailure == "function") ? "void " + prefix
-      + "resetOOMFailure" + "(" + ");" : "void 0;"; } },
+    { w: 1,  v: function(d, b) { return (typeof resetOOMFailure == "function") ? "void " + prefix + "resetOOMFailure" + "(" + ");" : "void 0;"; } },
 
     // [TestingFunctions.cpp, but SLOW]
     // Make garbage collection extremely frequent
@@ -221,8 +194,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     { w: 10, v: callSetGCCallback },
   ];
 
-  var testingFunctions = Random.weighted(browser ? sharedTestingFunctions :
-    sharedTestingFunctions.concat(shellOnlyTestingFunctions));
+  var testingFunctions = Random.weighted(browser ? sharedTestingFunctions : sharedTestingFunctions.concat(shellOnlyTestingFunctions));
 
   return { testingFunctions: testingFunctions, enableGCZeal: enableGCZeal };
 }

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -23,7 +23,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     // As of m-c 451466:79cf24341024 2018-12-19
     // https://hg.mozilla.org/mozilla-central/file/79cf24341024/js/src/gc/GC.cpp#l1000
     maxLevel = 25;
-    maxLevel++;  // rnd function starts from zero
+    maxLevel++; // rnd function starts from zero
     var level = finalLevel = rnd(maxLevel - 3); // 3 levels disabled below
 
     // Generate the second level.
@@ -56,8 +56,10 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
 
   function setGcparam() {
     switch (rnd(2)) {
+      /* eslint-disable no-multi-spaces */
       case 0:  return _set("sliceTimeBudget", rnd(100));
       default: return _set("markStackLimit", rnd(2) ? (1 + rnd(30)) : 4294967295); // Artificially trigger delayed marking
+      /* eslint-enable no-multi-spaces */
     }
 
     function _set(name, value) {
@@ -69,10 +71,12 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
   // Functions shared between the SpiderMonkey shell and Firefox browser
   // https://mxr.mozilla.org/mozilla-central/source/js/src/builtin/TestingFunctions.cpp
   var sharedTestingFunctions = [
+    /* eslint-disable no-multi-spaces */
     // Force garbage collection (global or specific compartment)
     { w: 10, v: function(d, b) { return "void " + prefix + "gc" + "("                                            + ");"; } },
     { w: 10, v: function(d, b) { return "void " + prefix + "gc" + "(" + "'compartment'" + maybeCommaShrinking() + ");"; } },
     { w: 5,  v: function(d, b) { return "void " + prefix + "gc" + "(" + fGlobal(d, b)   + maybeCommaShrinking() + ");"; } },
+    /* eslint-enable no-multi-spaces */
 
     // Run a minor garbage collection on the nursery.
     { w: 20, v: function(d, b) { return prefix + "minorgc" + "(false);"; } },

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* exported fuzzTestingFunctionsCtor */
 /* global finalLevel:writable, maxLevel:writable, oomAfterAllocations, oomAtAllocation, Random, resetOOMFailure, rnd */
 
 // Generate calls to SpiderMonkey "testing functions" for:

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* global final_level:writable, max_level:writable, oomAfterAllocations, oomAtAllocation, Random, resetOOMFailure, rnd */
+
 // Generate calls to SpiderMonkey "testing functions" for:
 // * testing that they do not cause assertions/crashes
 // * testing that they do not alter visible results (compare_jit with and without the call)

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-/* global final_level:writable, max_level:writable, oomAfterAllocations, oomAtAllocation, Random, resetOOMFailure, rnd */
+/* global finalLevel:writable, maxLevel:writable, oomAfterAllocations, oomAtAllocation, Random, resetOOMFailure, rnd */
 
 // Generate calls to SpiderMonkey "testing functions" for:
 // * testing that they do not cause assertions/crashes
@@ -22,23 +22,23 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
   {
     // As of m-c 451466:79cf24341024 2018-12-19
     // https://hg.mozilla.org/mozilla-central/file/79cf24341024/js/src/gc/GC.cpp#l1000
-    max_level = 25;
-    max_level++;  // rnd function starts from zero
-    var level = final_level = rnd(max_level - 3); // 3 levels disabled below
+    maxLevel = 25;
+    maxLevel++;  // rnd function starts from zero
+    var level = finalLevel = rnd(maxLevel - 3); // 3 levels disabled below
 
     // Generate the second level.
     // ref https://hg.mozilla.org/mozilla-central/file/02aa9c921aed/js/src/gc/GC.cpp#l1001
-    var level_two = rnd(max_level - 3); // 3 levels disabled below
-    if (level_two >= 3) ++level_two; // gczeal 3 does not exist, so repurpose it
-    if (level_two >= 5) ++level_two; // gczeal 5 does not exist, so repurpose it
-    if (level_two >= 6) ++level_two; // gczeal 6 does not exist, so repurpose it
+    var levelTwo = rnd(maxLevel - 3); // 3 levels disabled below
+    if (levelTwo >= 3) ++levelTwo; // gczeal 3 does not exist, so repurpose it
+    if (levelTwo >= 5) ++levelTwo; // gczeal 5 does not exist, so repurpose it
+    if (levelTwo >= 6) ++levelTwo; // gczeal 6 does not exist, so repurpose it
 
-    if (level >= 3) final_level = '"' + (++level) + ";" + level_two + '"'; // gczeal 3 does not exist, so repurpose it
-    if (level >= 5) final_level = '"' + (++level) + ";" + level_two + '"'; // gczeal 5 does not exist, so repurpose it
-    if (level >= 6) final_level = '"' + (++level) + ";" + level_two + '"'; // gczeal 6 does not exist, so repurpose it
+    if (level >= 3) finalLevel = '"' + (++level) + ";" + levelTwo + '"'; // gczeal 3 does not exist, so repurpose it
+    if (level >= 5) finalLevel = '"' + (++level) + ";" + levelTwo + '"'; // gczeal 5 does not exist, so repurpose it
+    if (level >= 6) finalLevel = '"' + (++level) + ";" + levelTwo + '"'; // gczeal 6 does not exist, so repurpose it
 
     var period = numberOfAllocs();
-    return prefix + "gczeal" + "(" + final_level + ", " + period + ");";
+    return prefix + "gczeal" + "(" + finalLevel + ", " + period + ");";
   }
 
   function callSetGCCallback() {

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -10,17 +10,15 @@
 // * testing that they do not cause assertions/crashes
 // * testing that they do not alter visible results (compare_jit with and without the call)
 
-function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
-{
+function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) {
   var prefix = browser ? "fuzzPriv." : "";
 
-  function numberOfInstructions() { return Math.floor(Random.ludOneTo(10000)); }
-  function numberOfAllocs() { return Math.floor(Random.ludOneTo(500)); }
-  function gcSliceSize() { return Math.floor(Random.ludOneTo(0x100000000)); }
-  function maybeCommaShrinking() { return rnd(5) ? "" : ", 'shrinking'"; }
+  function numberOfInstructions () { return Math.floor(Random.ludOneTo(10000)); }
+  function numberOfAllocs () { return Math.floor(Random.ludOneTo(500)); }
+  function gcSliceSize () { return Math.floor(Random.ludOneTo(0x100000000)); }
+  function maybeCommaShrinking () { return rnd(5) ? "" : ", 'shrinking'"; }
 
-  function enableGCZeal()
-  {
+  function enableGCZeal () {
     // As of m-c 451466:79cf24341024 2018-12-19
     // https://hg.mozilla.org/mozilla-central/file/79cf24341024/js/src/gc/GC.cpp#l1000
     maxLevel = 25;
@@ -42,7 +40,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     return prefix + "gczeal" + "(" + finalLevel + ", " + period + ");";
   }
 
-  function callSetGCCallback() {
+  function callSetGCCallback () {
     // https://dxr.mozilla.org/mozilla-central/source/js/src/shell/js.cpp - SetGCCallback
     var phases = Random.index(["both", "begin", "end"]);
     var actionAndOptions = rnd(2) ? 'action: "majorGC", depth: ' + rnd(17) : 'action: "minorGC"';
@@ -50,12 +48,11 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     return prefix + "setGCCallback(" + arg + ");";
   }
 
-  function tryCatch(statement)
-  {
+  function tryCatch (statement) {
     return "try { " + statement + " } catch(e) { }";
   }
 
-  function setGcparam() {
+  function setGcparam () {
     switch (rnd(2)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return _set("sliceTimeBudget", rnd(100));
@@ -63,7 +60,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
       /* eslint-enable no-multi-spaces */
     }
 
-    function _set(name, value) {
+    function _set (name, value) {
       // try..catch because gcparam sets may throw, depending on GC state (see bug 973571)
       return tryCatch(prefix + "gcparam" + "('" + name + "', " + value + ");");
     }
@@ -74,29 +71,29 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
   var sharedTestingFunctions = [
     /* eslint-disable no-multi-spaces */
     // Force garbage collection (global or specific compartment)
-    { w: 10, v: function(d, b) { return "void " + prefix + "gc" + "("                                            + ");"; } },
-    { w: 10, v: function(d, b) { return "void " + prefix + "gc" + "(" + "'compartment'" + maybeCommaShrinking() + ");"; } },
-    { w: 5,  v: function(d, b) { return "void " + prefix + "gc" + "(" + fGlobal(d, b)   + maybeCommaShrinking() + ");"; } },
+    { w: 10, v: function (d, b) { return "void " + prefix + "gc" + "("                                            + ");"; } },
+    { w: 10, v: function (d, b) { return "void " + prefix + "gc" + "(" + "'compartment'" + maybeCommaShrinking() + ");"; } },
+    { w: 5,  v: function (d, b) { return "void " + prefix + "gc" + "(" + fGlobal(d, b)   + maybeCommaShrinking() + ");"; } },
     /* eslint-enable no-multi-spaces */
 
     // Run a minor garbage collection on the nursery.
-    { w: 20, v: function(d, b) { return prefix + "minorgc" + "(false);"; } },
-    { w: 20, v: function(d, b) { return prefix + "minorgc" + "(true);"; } },
+    { w: 20, v: function (d, b) { return prefix + "minorgc" + "(false);"; } },
+    { w: 20, v: function (d, b) { return prefix + "minorgc" + "(true);"; } },
 
     // Start, continue, or abort incremental garbage collection.
     // startgc can throw: "Incremental GC already in progress"
-    { w: 20, v: function(d, b) { return tryCatch(prefix + "startgc" + "(" + gcSliceSize() + maybeCommaShrinking() + ");"); } },
-    { w: 20, v: function(d, b) { return prefix + "gcslice" + "(" + gcSliceSize() + ");"; } },
-    { w: 10, v: function(d, b) { return prefix + "abortgc" + "(" + ");"; } },
+    { w: 20, v: function (d, b) { return tryCatch(prefix + "startgc" + "(" + gcSliceSize() + maybeCommaShrinking() + ");"); } },
+    { w: 20, v: function (d, b) { return prefix + "gcslice" + "(" + gcSliceSize() + ");"; } },
+    { w: 10, v: function (d, b) { return prefix + "abortgc" + "(" + ");"; } },
 
     // Schedule the given objects to be marked in the next GC slice.
-    { w: 10, v: function(d, b) { return prefix + "selectforgc" + "(" + fObject(d, b) + ");"; } },
+    { w: 10, v: function (d, b) { return prefix + "selectforgc" + "(" + fObject(d, b) + ");"; } },
 
     // Add a compartment to the next garbage collection.
-    { w: 10, v: function(d, b) { return "void " + prefix + "schedulegc" + "(" + fGlobal(d, b) + ");"; } },
+    { w: 10, v: function (d, b) { return "void " + prefix + "schedulegc" + "(" + fGlobal(d, b) + ");"; } },
 
     // Schedule a GC for after N allocations.
-    { w: 10, v: function(d, b) { return "void " + prefix + "schedulegc" + "(" + numberOfAllocs() + ");"; } },
+    { w: 10, v: function (d, b) { return "void " + prefix + "schedulegc" + "(" + numberOfAllocs() + ");"; } },
 
     // Change a GC parameter.
     { w: 10, v: setGcparam },
@@ -104,63 +101,63 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     // Verify write barriers. This functions is effective in pairs.
     // The first call sets up the start barrier, the second call sets up the end barrier.
     // Nothing happens when there is only one call.
-    { w: 10, v: function(d, b) { return prefix + "verifyprebarriers" + "();"; } },
+    { w: 10, v: function (d, b) { return prefix + "verifyprebarriers" + "();"; } },
 
     // hasChild(parent, child): Return true if |child| is a child of |parent|, as determined by a call to TraceChildren.
     // We ignore the return value because hasChild can be used to see which WeakMap entries have been GCed.
-    { w: 1,  v: function(d, b) { return "void " + prefix + "hasChild(" + fObject(d, b) + ", " + fObject(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return "void " + prefix + "hasChild(" + fObject(d, b) + ", " + fObject(d, b) + ");"; } },
 
     // Various validation functions (toggles)
-    { w: 5,  v: function(d, b) { return prefix + "fullcompartmentchecks" + "(false);"; } },
-    { w: 1,  v: function(d, b) { return prefix + "fullcompartmentchecks" + "(true);"; } },
-    { w: 5,  v: function(d, b) { return prefix + "setIonCheckGraphCoherency" + "(false);"; } },
-    { w: 1,  v: function(d, b) { return prefix + "setIonCheckGraphCoherency" + "(true);"; } },
-    { w: 1,  v: function(d, b) { return prefix + "enableOsiPointRegisterChecks" + "();"; } },
+    { w: 5, v: function (d, b) { return prefix + "fullcompartmentchecks" + "(false);"; } },
+    { w: 1, v: function (d, b) { return prefix + "fullcompartmentchecks" + "(true);"; } },
+    { w: 5, v: function (d, b) { return prefix + "setIonCheckGraphCoherency" + "(false);"; } },
+    { w: 1, v: function (d, b) { return prefix + "setIonCheckGraphCoherency" + "(true);"; } },
+    { w: 1, v: function (d, b) { return prefix + "enableOsiPointRegisterChecks" + "();"; } },
 
     // Various validation functions (immediate)
-    { w: 1,  v: function(d, b) { return prefix + "assertJitStackInvariants" + "();"; } },
+    { w: 1, v: function (d, b) { return prefix + "assertJitStackInvariants" + "();"; } },
 
     // Run-time equivalents to --baseline-eager, --baseline-warmup-threshold, --ion-eager, --ion-warmup-threshold
-    { w: 1,  v: function(d, b) { return prefix + "setJitCompilerOption" + "('baseline.warmup.trigger', " + rnd(20) + ");"; } },
-    { w: 1,  v: function(d, b) { return prefix + "setJitCompilerOption" + "('ion.warmup.trigger', " + rnd(40) + ");"; } },
+    { w: 1, v: function (d, b) { return prefix + "setJitCompilerOption" + "('baseline.warmup.trigger', " + rnd(20) + ");"; } },
+    { w: 1, v: function (d, b) { return prefix + "setJitCompilerOption" + "('ion.warmup.trigger', " + rnd(40) + ");"; } },
 
     // Test the baseline compiler
-    { w: 10,  v: function(d, b) { return prefix + "baselineCompile" + "();"; } },
+    { w: 10, v: function (d, b) { return prefix + "baselineCompile" + "();"; } },
 
     // Force inline cache.
-    { w: 1,  v: function(d, b) { return prefix + "setJitCompilerOption" + "('ion.forceinlineCaches\', " + rnd(2) + ");"; } },
+    { w: 1, v: function (d, b) { return prefix + "setJitCompilerOption" + "('ion.forceinlineCaches\', " + rnd(2) + ");"; } },
 
     // Run-time equivalents to --no-ion, --no-baseline
     // These can throw: "Can't turn off JITs with JIT code on the stack."
-    { w: 1,  v: function(d, b) { return tryCatch(prefix + "setJitCompilerOption" + "('ion.enable', " + rnd(2) + ");"); } },
-    { w: 1,  v: function(d, b) { return tryCatch(prefix + "setJitCompilerOption" + "('baseline.enable', " + rnd(2) + ");"); } },
+    { w: 1, v: function (d, b) { return tryCatch(prefix + "setJitCompilerOption" + "('ion.enable', " + rnd(2) + ");"); } },
+    { w: 1, v: function (d, b) { return tryCatch(prefix + "setJitCompilerOption" + "('baseline.enable', " + rnd(2) + ");"); } },
 
     // Test the built-in profiler.
-    { w: 1,  v: function(d, b) { return prefix + "enableGeckoProfiling" + "();"; } },
-    { w: 1,  v: function(d, b) { return prefix + "enableGeckoProfilingWithSlowAssertions" + "();"; } },
-    { w: 5,  v: function(d, b) { return prefix + "disableGeckoProfiling" + "();"; } },
-    { w: 1,  v: function(d, b) { return "void " + prefix + "readGeckoProfilingStack" + "();"; } },
+    { w: 1, v: function (d, b) { return prefix + "enableGeckoProfiling" + "();"; } },
+    { w: 1, v: function (d, b) { return prefix + "enableGeckoProfilingWithSlowAssertions" + "();"; } },
+    { w: 5, v: function (d, b) { return prefix + "disableGeckoProfiling" + "();"; } },
+    { w: 1, v: function (d, b) { return "void " + prefix + "readGeckoProfilingStack" + "();"; } },
 
     // I'm not sure what this does in the shell.
-    { w: 5,  v: function(d, b) { return prefix + "deterministicgc" + "(false);"; } },
-    { w: 1,  v: function(d, b) { return prefix + "deterministicgc" + "(true);"; } },
+    { w: 5, v: function (d, b) { return prefix + "deterministicgc" + "(false);"; } },
+    { w: 1, v: function (d, b) { return prefix + "deterministicgc" + "(true);"; } },
 
     // Causes JIT code to always be preserved by GCs afterwards (see https://bugzilla.mozilla.org/show_bug.cgi?id=750834)
-    { w: 5,  v: function(d, b) { return prefix + "gcPreserveCode" + "();"; } },
+    { w: 5, v: function (d, b) { return prefix + "gcPreserveCode" + "();"; } },
 
     // Generate an LCOV trace (but throw away the returned string)
-    { w: 1,  v: function(d, b) { return "void " + prefix + "getLcovInfo" + "();"; } },
-    { w: 1,  v: function(d, b) { return "void " + prefix + "getLcovInfo" + "(" + fGlobal(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return "void " + prefix + "getLcovInfo" + "();"; } },
+    { w: 1, v: function (d, b) { return "void " + prefix + "getLcovInfo" + "(" + fGlobal(d, b) + ");"; } },
 
     // JIT bailout
-    { w: 5,  v: function(d, b) { return prefix + "bailout" + "();"; } },
-    { w: 10, v: function(d, b) { return prefix + "bailAfter" + "(" + numberOfInstructions() + ");"; } },
+    { w: 5, v: function (d, b) { return prefix + "bailout" + "();"; } },
+    { w: 10, v: function (d, b) { return prefix + "bailAfter" + "(" + numberOfInstructions() + ");"; } },
 
     // Enable some slow Shape assertions. See bug 1412289
-    { w: 1,  v: function(d, b) { return prefix + "enableShapeConsistencyChecks" + "();"; } },
+    { w: 1, v: function (d, b) { return prefix + "enableShapeConsistencyChecks" + "();"; } },
 
     // Create gray root Array for the current compartment. See bug 1452602
-    { w: 1,  v: function(d, b) { return prefix + "grayRoot" + "();"; } },
+    { w: 1, v: function (d, b) { return prefix + "grayRoot" + "();"; } }
   ];
 
   // Functions only in the SpiderMonkey shell
@@ -168,31 +165,31 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
   var shellOnlyTestingFunctions = [
     // ARM simulator settings
     // These throw when not in the ARM simulator.
-    { w: 1,  v: function(d, b) { return tryCatch("(void" + prefix + "disableSingleStepProfiling" + "()" + ")"); } },
-    { w: 1,  v: function(d, b) { return tryCatch("(" + prefix + "enableSingleStepProfiling" + "()" + ")"); } },
+    { w: 1, v: function (d, b) { return tryCatch("(void" + prefix + "disableSingleStepProfiling" + "()" + ")"); } },
+    { w: 1, v: function (d, b) { return tryCatch("(" + prefix + "enableSingleStepProfiling" + "()" + ")"); } },
 
     // Force garbage collection with function relazification
-    { w: 10, v: function(d, b) { return "void " + prefix + "relazifyFunctions" + "();"; } },
-    { w: 10, v: function(d, b) { return "void " + prefix + "relazifyFunctions" + "('compartment');"; } },
-    { w: 5,  v: function(d, b) { return "void " + prefix + "relazifyFunctions" + "(" + fGlobal(d, b) + ");"; } },
+    { w: 10, v: function (d, b) { return "void " + prefix + "relazifyFunctions" + "();"; } },
+    { w: 10, v: function (d, b) { return "void " + prefix + "relazifyFunctions" + "('compartment');"; } },
+    { w: 5, v: function (d, b) { return "void " + prefix + "relazifyFunctions" + "(" + fGlobal(d, b) + ");"; } },
 
     // Test recomputeWrappers - see bug 1492406
-    { w: 10,  v: function(d, b) { return prefix + "recomputeWrappers" + "();"; } },
+    { w: 10, v: function (d, b) { return prefix + "recomputeWrappers" + "();"; } },
     // Also test recomputeWrappers calling newGlobal, see the bug
 
     // [TestingFunctions.cpp, but debug-only and CRASHY]
     // After N js_malloc memory allocations, fail every following allocation
-    { w: 1,  v: function(d, b) { return (typeof oomAfterAllocations == "function" && rnd(1000) === 0) ? prefix + "oomAfterAllocations" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
+    { w: 1, v: function (d, b) { return (typeof oomAfterAllocations === "function" && rnd(1000) === 0) ? prefix + "oomAfterAllocations" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
     // After N js_malloc memory allocations, fail one allocation
-    { w: 1,  v: function(d, b) { return (typeof oomAtAllocation == "function" && rnd(100) === 0) ? prefix + "oomAtAllocation" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
+    { w: 1, v: function (d, b) { return (typeof oomAtAllocation === "function" && rnd(100) === 0) ? prefix + "oomAtAllocation" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
     // Reset either of the above
-    { w: 1,  v: function(d, b) { return (typeof resetOOMFailure == "function") ? "void " + prefix + "resetOOMFailure" + "(" + ");" : "void 0;"; } },
+    { w: 1, v: function (d, b) { return (typeof resetOOMFailure === "function") ? "void " + prefix + "resetOOMFailure" + "(" + ");" : "void 0;"; } },
 
     // [TestingFunctions.cpp, but SLOW]
     // Make garbage collection extremely frequent
-    { w: 1,  v: function(d, b) { return (rnd(100) === 0) ? (enableGCZeal()) : "void 0;"; } },
+    { w: 1, v: function (d, b) { return (rnd(100) === 0) ? (enableGCZeal()) : "void 0;"; } },
 
-    { w: 10, v: callSetGCCallback },
+    { w: 10, v: callSetGCCallback }
   ];
 
   var testingFunctions = Random.weighted(browser ? sharedTestingFunctions : sharedTestingFunctions.concat(shellOnlyTestingFunctions));

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -58,7 +58,8 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     switch (rnd(2)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return _set("sliceTimeBudget", rnd(100));
-      default: return _set("markStackLimit", rnd(2) ? (1 + rnd(30)) : 4294967295); // Artificially trigger delayed marking
+      // Artificially trigger delayed marking
+      default: return _set("markStackLimit", rnd(2) ? (1 + rnd(30)) : 4294967295);
       /* eslint-enable no-multi-spaces */
     }
 
@@ -73,9 +74,15 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
   var sharedTestingFunctions = [
     /* eslint-disable no-multi-spaces */
     // Force garbage collection (global or specific compartment)
-    { w: 10, v: function(d, b) { return "void " + prefix + "gc" + "("                                            + ");"; } },
-    { w: 10, v: function(d, b) { return "void " + prefix + "gc" + "(" + "'compartment'" + maybeCommaShrinking() + ");"; } },
-    { w: 5,  v: function(d, b) { return "void " + prefix + "gc" + "(" + fGlobal(d, b)   + maybeCommaShrinking() + ");"; } },
+    { w: 10, v: function(d, b) { return "void "
+      + prefix + "gc" + "("                                           + ");";
+    } },
+    { w: 10, v: function(d, b) { return "void "
+      + prefix + "gc" + "(" + "'compartment'" + maybeCommaShrinking() + ");";
+    } },
+    { w: 5,  v: function(d, b) { return "void "
+      + prefix + "gc" + "(" + fGlobal(d, b)   + maybeCommaShrinking() + ");";
+    } },
     /* eslint-enable no-multi-spaces */
 
     // Run a minor garbage collection on the nursery.
@@ -84,7 +91,9 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
 
     // Start, continue, or abort incremental garbage collection.
     // startgc can throw: "Incremental GC already in progress"
-    { w: 20, v: function(d, b) { return tryCatch(prefix + "startgc" + "(" + gcSliceSize() + maybeCommaShrinking() + ");"); } },
+    { w: 20, v: function(d, b) { return tryCatch(prefix
+      + "startgc" + "(" + gcSliceSize() + maybeCommaShrinking() + ");");
+    } },
     { w: 20, v: function(d, b) { return prefix + "gcslice" + "(" + gcSliceSize() + ");"; } },
     { w: 10, v: function(d, b) { return prefix + "abortgc" + "(" + ");"; } },
 
@@ -105,9 +114,12 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     // Nothing happens when there is only one call.
     { w: 10, v: function(d, b) { return prefix + "verifyprebarriers" + "();"; } },
 
-    // hasChild(parent, child): Return true if |child| is a child of |parent|, as determined by a call to TraceChildren.
+    // hasChild(parent, child): Return true if |child| is a child of |parent|,
+    // as determined by a call to TraceChildren.
     // We ignore the return value because hasChild can be used to see which WeakMap entries have been GCed.
-    { w: 1,  v: function(d, b) { return "void " + prefix + "hasChild(" + fObject(d, b) + ", " + fObject(d, b) + ");"; } },
+    { w: 1,  v: function(d, b) { return "void "
+      + prefix + "hasChild(" + fObject(d, b) + ", " + fObject(d, b) + ");";
+    } },
 
     // Various validation functions (toggles)
     { w: 5,  v: function(d, b) { return prefix + "fullcompartmentchecks" + "(false);"; } },
@@ -120,19 +132,29 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     { w: 1,  v: function(d, b) { return prefix + "assertJitStackInvariants" + "();"; } },
 
     // Run-time equivalents to --baseline-eager, --baseline-warmup-threshold, --ion-eager, --ion-warmup-threshold
-    { w: 1,  v: function(d, b) { return prefix + "setJitCompilerOption" + "('baseline.warmup.trigger', " + rnd(20) + ");"; } },
-    { w: 1,  v: function(d, b) { return prefix + "setJitCompilerOption" + "('ion.warmup.trigger', " + rnd(40) + ");"; } },
+    { w: 1,  v: function(d, b) { return prefix
+      + "setJitCompilerOption" + "('baseline.warmup.trigger', " + rnd(20) + ");";
+    } },
+    { w: 1,  v: function(d, b) { return prefix
+      + "setJitCompilerOption" + "('ion.warmup.trigger', " + rnd(40) + ");";
+    } },
 
     // Test the baseline compiler
     { w: 10,  v: function(d, b) { return prefix + "baselineCompile" + "();"; } },
 
     // Force inline cache.
-    { w: 1,  v: function(d, b) { return prefix + "setJitCompilerOption" + "('ion.forceinlineCaches\', " + rnd(2) + ");"; } },
+    { w: 1,  v: function(d, b) { return prefix
+      + "setJitCompilerOption" + "('ion.forceinlineCaches\', " + rnd(2) + ");";
+    } },
 
     // Run-time equivalents to --no-ion, --no-baseline
     // These can throw: "Can't turn off JITs with JIT code on the stack."
-    { w: 1,  v: function(d, b) { return tryCatch(prefix + "setJitCompilerOption" + "('ion.enable', " + rnd(2) + ");"); } },
-    { w: 1,  v: function(d, b) { return tryCatch(prefix + "setJitCompilerOption" + "('baseline.enable', " + rnd(2) + ");"); } },
+    { w: 1,  v: function(d, b) { return tryCatch(prefix
+      + "setJitCompilerOption" + "('ion.enable', " + rnd(2) + ");");
+    } },
+    { w: 1,  v: function(d, b) { return tryCatch(prefix
+      + "setJitCompilerOption" + "('baseline.enable', " + rnd(2) + ");");
+    } },
 
     // Test the built-in profiler.
     { w: 1,  v: function(d, b) { return prefix + "enableGeckoProfiling" + "();"; } },
@@ -144,7 +166,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     { w: 5,  v: function(d, b) { return prefix + "deterministicgc" + "(false);"; } },
     { w: 1,  v: function(d, b) { return prefix + "deterministicgc" + "(true);"; } },
 
-    // Causes JIT code to always be preserved by GCs afterwards (see https://bugzilla.mozilla.org/show_bug.cgi?id=750834)
+    // Causes JIT code to always be preserved by GCs afterwards (see https://bugzil.la/750834)
     { w: 5,  v: function(d, b) { return prefix + "gcPreserveCode" + "();"; } },
 
     // Generate an LCOV trace (but throw away the returned string)
@@ -167,7 +189,9 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
   var shellOnlyTestingFunctions = [
     // ARM simulator settings
     // These throw when not in the ARM simulator.
-    { w: 1,  v: function(d, b) { return tryCatch("(void" + prefix + "disableSingleStepProfiling" + "()" + ")"); } },
+    { w: 1,  v: function(d, b) { return tryCatch("(void" + prefix
+      + "disableSingleStepProfiling" + "()" + ")");
+    } },
     { w: 1,  v: function(d, b) { return tryCatch("(" + prefix + "enableSingleStepProfiling" + "()" + ")"); } },
 
     // Force garbage collection with function relazification
@@ -181,11 +205,14 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
 
     // [TestingFunctions.cpp, but debug-only and CRASHY]
     // After N js_malloc memory allocations, fail every following allocation
-    { w: 1,  v: function(d, b) { return (typeof oomAfterAllocations == "function" && rnd(1000) === 0) ? prefix + "oomAfterAllocations" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
+    { w: 1,  v: function(d, b) { return (typeof oomAfterAllocations == "function"
+      && rnd(1000) === 0) ? prefix + "oomAfterAllocations" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
     // After N js_malloc memory allocations, fail one allocation
-    { w: 1,  v: function(d, b) { return (typeof oomAtAllocation == "function" && rnd(100) === 0) ? prefix + "oomAtAllocation" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
+    { w: 1,  v: function(d, b) { return (typeof oomAtAllocation == "function"
+      && rnd(100) === 0) ? prefix + "oomAtAllocation" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
     // Reset either of the above
-    { w: 1,  v: function(d, b) { return (typeof resetOOMFailure == "function") ? "void " + prefix + "resetOOMFailure" + "(" + ");" : "void 0;"; } },
+    { w: 1,  v: function(d, b) { return (typeof resetOOMFailure == "function") ? "void " + prefix
+      + "resetOOMFailure" + "(" + ");" : "void 0;"; } },
 
     // [TestingFunctions.cpp, but SLOW]
     // Make garbage collection extremely frequent
@@ -194,7 +221,8 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
     { w: 10, v: callSetGCCallback },
   ];
 
-  var testingFunctions = Random.weighted(browser ? sharedTestingFunctions : sharedTestingFunctions.concat(shellOnlyTestingFunctions));
+  var testingFunctions = Random.weighted(browser ? sharedTestingFunctions :
+    sharedTestingFunctions.concat(shellOnlyTestingFunctions));
 
   return { testingFunctions: testingFunctions, enableGCZeal: enableGCZeal };
 }

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -55,7 +55,7 @@ function fuzzTestingFunctionsCtor(browser, fGlobal, fObject)
   }
 
   function setGcparam() {
-    switch(rnd(2)) {
+    switch (rnd(2)) {
       case 0:  return _set("sliceTimeBudget", rnd(100));
       default: return _set("markStackLimit", rnd(2) ? (1 + rnd(30)) : 4294967295); // Artificially trigger delayed marking
     }


### PR DESCRIPTION
This PR hooks eslint to test the `src/funfuzz/js` directory on Travis.

Let's do this before making large changes to jsfunfuzz. My plan is to land this, fork off a 0.6.x branch, then go about doing the other old code removals, new feature support and making the shift to template literals after releasing 0.6.x.

Also, [let is the new var](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let). We should move entirely to `let`, right?

(moving to npm module style similar to `octo` might also be on the radar in the future, but taking small steps to get there)