### PR TITLE
Move jsfunfuzz to template literals

### DIFF
--- a/src/funfuzz/autobisectjs/known_broken_earliest_working.py
+++ b/src/funfuzz/autobisectjs/known_broken_earliest_working.py
@@ -35,11 +35,6 @@ def known_broken_ranges(options):  # pylint: disable=missing-param-doc,missing-r
     # ANCIENT FIXME: It might make sense to avoid (or note) these in checkBlameParents.
 
     skips = [
-        hgrange("7c25be97325d", "d426154dd31d"),  # Fx38, broken spidermonkey
-        hgrange("da286f0f7a49", "62fecc6ab96e"),  # Fx39, broken spidermonkey
-        hgrange("8a416fedec44", "7f9252925e26"),  # Fx41, broken spidermonkey
-        hgrange("3bcc3881b95d", "c609df6d3895"),  # Fx44, broken spidermonkey
-        hgrange("d3a026933bce", "5fa834fe9b96"),  # Fx52, broken spidermonkey
         hgrange("4c72627cfc6c", "926f80f2c5cc"),  # Fx60, broken spidermonkey
         hgrange("1fb7ddfad86d", "5202cfbf8d60"),  # Fx63, broken spidermonkey
         hgrange("aae4f349fa58", "c5fbbf959e23"),  # Fx64, broken spidermonkey
@@ -53,8 +48,6 @@ def known_broken_ranges(options):  # pylint: disable=missing-param-doc,missing-r
 
     if platform.system() == "Linux":
         skips.extend([
-            # Clang failure - probably recent versions of GCC as well.
-            hgrange("5232dd059c11", "ed98e1b9168d"),  # Fx41, see bug 1140482
             # Failure specific to GCC 5 (and probably earlier) - supposedly works on GCC 6
             hgrange("e94dceac8090", "516c01f62d84"),  # Fx56-57, see bug 1386011
         ])
@@ -68,29 +61,19 @@ def known_broken_ranges(options):  # pylint: disable=missing-param-doc,missing-r
                 hgrange("aa1da5ed8a07", "5a03382283ae"),  # Fx54-55, see bug 1339190
             ])
 
-    if platform.system() == "Windows":
-        skips.extend([
-            hgrange("be8b0845f283", "db3ed1fdbbea"),  # Fx50, see bug 1289679
-        ])
-
     if not options.enableDbg:
         skips.extend([
-            hgrange("a048c55e1906", "ddaa87cfd7fa"),  # Fx46, broken opt builds w/ --enable-gczeal
             hgrange("c5561749c1c6", "f4c15a88c937"),  # Fx58-59, broken opt builds w/ --enable-gczeal
             hgrange("247e265373eb", "e4aa68e2a85b"),  # Fx66, broken opt builds w/ --enable-gczeal
         ])
 
     if options.enableMoreDeterministic:
         skips.extend([
-            hgrange("1d672188b8aa", "ea7dabcd215e"),  # Fx40, see bug 1149739
             hgrange("427b854cdb1c", "4c4e45853808"),  # Fx68, see bug 1542980
         ])
 
     if options.enableSimulatorArm32:
         skips.extend([
-            hgrange("3a580b48d1ad", "20c9570b0734"),  # Fx43, broken 32-bit ARM-simulator builds
-            hgrange("f35d1107fe2e", "bdf975ad2fcd"),  # Fx45, broken 32-bit ARM-simulator builds
-            hgrange("6c37be9cee51", "4548ba932bde"),  # Fx50, broken 32-bit ARM-simulator builds
             hgrange("284002382c21", "05669ce25b03"),  # Fx57-61, broken 32-bit ARM-simulator builds
         ])
 

--- a/src/funfuzz/autobisectjs/known_broken_earliest_working.py
+++ b/src/funfuzz/autobisectjs/known_broken_earliest_working.py
@@ -139,37 +139,7 @@ def earliest_known_working_rev(options, flags, skip_revs):  # pylint: disable=mi
         required.append("1b55231e6628")  # m-c 380023 Fx57, 1st w/--cpu-count=<NUM>, see bug 1206770
     if platform.system() == "Windows" and platform.uname()[2] == "10":
         required.append("530f7bd28399")  # m-c 369571 Fx56, 1st w/ successful MSVC 2017 builds, see bug 1356493
-    if options.disableProfiling:
-        required.append("800a887c705e")  # m-c 324836 Fx53, 1st w/ --disable-profiling, see bug 1321065
-    if "--cache-ir-stubs=on" in flags or "--cache-ir-stubs=off" in flags:
-        required.append("1c5b92144e1e")  # m-c 308931 Fx51, 1st w/--cache-ir-stubs=on, see bug 1292659
-    if platform.machine() == "aarch64":
-        required.append("2f727a828ea0")  # m-c 304669 Fx50, 1st w/ working aarch64 builds, see bug 1286207
-    if options.buildWithAsan:
-        required.append("e1cac03485d9")  # m-c 301874 Fx50, 1st w/ working ASan builds in Ubuntu 18.04, see bug 1264534
-    if "--ion-pgo=on" in flags or "--ion-pgo=off" in flags:
-        required.append("b0a0ff5fa705")  # m-c 272274 Fx45, 1st w/--ion-pgo=on, see bug 1209515
-    if options.enableSimulatorArm64:
-        required.append("80a506f7caa7")  # m-c 264933 Fx44, 1st w/ stable --enable-simulator=arm64, see bug 984018
-    if "--ion-sincos=on" in flags or "--ion-sincos=off" in flags:
-        required.append("3dec2b935295")  # m-c 262544 Fx43, 1st w/--ion-sincos=on, see bug 984018
-    if "--ion-instruction-reordering=on" in flags or "--ion-instruction-reordering=off" in flags:
-        required.append("59d2f2e62420")  # m-c 259672 Fx43, 1st w/--ion-instruction-reordering=on, see bug 1195545
-    if options.enableSimulatorArm32:
-        required.append("25e99bc12482")  # m-c 249239 Fx41, 1st w/--enable-simulator=arm, see bug 1173992
-    if "--ion-regalloc=testbed" in flags:
-        required.append("47e92bae09fd")  # m-c 248962 Fx41, 1st w/--ion-regalloc=testbed, see bug 1170840
-    if '--execute=setJitCompilerOption("ion.forceinlineCaches",1)' in flags:
-        required.append("ea9608e33abe")  # m-c 247709 Fx41, 1st w/ion.forceinlineCaches, see bug 923717
-    if "--no-unboxed-objects" in flags:
-        required.append("322487136b28")  # m-c 244297 Fx41, 1st w/--no-unboxed-objects, see bug 1162199
-    if "--ion-extra-checks" in flags:
-        required.append("cdf93416b39a")  # m-c 234228 Fx39, 1st w/--ion-extra-checks, see bug 1139152
-    if "--no-cgc" in flags:
-        required.append("b63d7e80709a")  # m-c 227705 Fx38, 1st w/--no-cgc, see bug 1126769 and see bug 1129233
-    if "--enable-avx" in flags or "--no-avx" in flags:
-        required.append("5e6e959f0043")  # m-c 223959 Fx38, 1st w/--enable-avx, see bug 1118235
-    required.append("bcacb5692ad9")  # m-c 222786 Fx37, 1st w/ successful GCC 5.2.x builds on Ubuntu 15.10 onwards
+    required.append("bb868860dfc3")  # m-c 330353 Fx53, 1st w/ revised template literals, see bug 1317375
 
     return f"first(({common_descendants(required)}) - ({skip_revs}))"
 

--- a/src/funfuzz/js/compile_shell.py
+++ b/src/funfuzz/js/compile_shell.py
@@ -356,10 +356,6 @@ def cfgBin(shell):  # pylint: disable=invalid-name,missing-param-doc,missing-rai
             cfg_env["CC"] = cfg_env["HOST_CC"] = f"clang {CLANG_PARAMS} {SSE2_FLAGS} {CLANG_X86_FLAG}"
             cfg_env["CXX"] = cfg_env["HOST_CXX"] = f"clang++ {CLANG_PARAMS} {SSE2_FLAGS} {CLANG_X86_FLAG}"
         # apt-get `lib32z1 gcc-multilib g++-multilib` first, if on 64-bit Linux. (no matter Clang or GCC)
-        elif hg_helpers.existsAndIsAncestor(shell.get_repo_dir(), shell.get_hg_hash(), "parents(e1cac03485d9)"):
-            # m-c rev 301874:e1cac03485d9, fx50 is the first rev that works with Clang 6.0 on Ubuntu 18.04
-            cfg_env["CC"] = f"gcc -m32 {SSE2_FLAGS}"
-            cfg_env["CXX"] = f"g++ -m32 {SSE2_FLAGS}"
         else:
             cfg_env["CC"] = f"clang -m32 {SSE2_FLAGS}"
             cfg_env["CXX"] = f"clang++ -m32 {SSE2_FLAGS}"
@@ -688,15 +684,6 @@ def obtainShell(shell, updateToRev=None, updateLatestTxt=False):  # pylint: disa
         if shell.build_opts.patch_file:
             hg_helpers.patch_hg_repo_with_mq(shell.build_opts.patch_file, shell.get_repo_dir())
 
-        if (platform.system() == "Linux" and
-                parse_version(subprocess.run(["sed", "--version"], stdout=subprocess.PIPE)
-                              .stdout.decode("utf-8", errors="replace").split()[3])
-                >= parse_version("4.3") and
-                hg_helpers.existsAndIsAncestor(shell.get_repo_dir(), shell.get_hg_hash(), "parents(ebcbf47a83e7)")):
-            print("Patching for Linux systems with sed >= 4.3 ...", flush=True)
-            sm_compile_helpers.icu_m4_replace(Path(shell.get_repo_dir()))  # Patch the icu.m4 file
-            print("Patching completed.", flush=True)
-
         cfgJsCompile(shell)
         if platform.system() == "Windows":
             sm_compile_helpers.verify_full_win_pageheap(shell.get_shell_cache_js_bin_path())
@@ -717,15 +704,6 @@ def obtainShell(shell, updateToRev=None, updateLatestTxt=False):  # pylint: disa
             s3cache_obj.uploadFileToS3(f"{shell.get_shell_cache_js_bin_path()}.busted")
         raise
     finally:
-        if (platform.system() == "Linux" and
-                parse_version(subprocess.run(["sed", "--version"], stdout=subprocess.PIPE)
-                              .stdout.decode("utf-8", errors="replace").split()[3])
-                >= parse_version("4.3") and
-                hg_helpers.existsAndIsAncestor(shell.get_repo_dir(), shell.get_hg_hash(), "parents(ebcbf47a83e7)")):
-            print("Undo-ing patch for Linux systems with sed >= 4.3 ...", flush=True)
-            sm_compile_helpers.icu_m4_undo(Path(shell.get_repo_dir()))  # Undo the icu.m4 patch
-            print("Undo completed.", flush=True)
-
         if shell.build_opts.patch_file:
             hg_helpers.qpop_qrm_applied_patch(shell.build_opts.patch_file, shell.get_repo_dir())
 

--- a/src/funfuzz/js/inspect_shell.py
+++ b/src/funfuzz/js/inspect_shell.py
@@ -15,7 +15,6 @@ import subprocess
 
 from lithium.interestingness.utils import env_with_path
 
-from ..util import hg_helpers
 from ..util import subprocesses as sps
 
 RUN_MOZGLUE_LIB = ""
@@ -189,13 +188,8 @@ def verifyBinary(sh):  # pylint: disable=invalid-name,missing-param-doc,missing-
 
     assert queryBuildConfiguration(binary, "more-deterministic") == sh.build_opts.enableMoreDeterministic
     assert queryBuildConfiguration(binary, "asan") == sh.build_opts.buildWithAsan
+    assert queryBuildConfiguration(binary, "profiling") != sh.build_opts.disableProfiling
     assert (queryBuildConfiguration(binary, "arm-simulator") and
             sh.build_opts.enable32) == sh.build_opts.enableSimulatorArm32
-
-    # m-c rev 250632:5f9e24957f2d Fx41 added the arm64-simulator entry in getBuildConfiguration.
-    if not hg_helpers.existsAndIsAncestor(sh.get_repo_dir(), sh.get_hg_hash(), "parents(5f9e24957f2d)"):
-        assert (queryBuildConfiguration(binary, "arm64-simulator") and not
-                sh.build_opts.enable32) == sh.build_opts.enableSimulatorArm64
-    # Note that we should test whether a shell has profiling turned on or not.
-    # m-c rev 324836:800a887c705e turned profiling on by default, so once this is beyond the
-    # earliest known working revision, we can probably test it here.
+    assert (queryBuildConfiguration(binary, "arm64-simulator") and not
+            sh.build_opts.enable32) == sh.build_opts.enableSimulatorArm64

--- a/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
+++ b/src/funfuzz/js/jsfunfuzz/built-in-constructors.js
@@ -36,7 +36,7 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
       propertyNames.push(hn);
       allPropertyNames.push(hn);
 
-      var fullName = an + "." + hn;
+      var fullName = `${an}.${hn}`;
       builtinProperties.push(fullName);
 
       var h;
@@ -44,7 +44,7 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
         h = a[hn];
       } catch (e) {
         if (debugMode) {
-          dumpln("Threw: " + fullName);
+          dumpln(`Threw: ${fullName}`);
         }
         h = null;
       }
@@ -71,7 +71,7 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
           builtinProperties.push(gn);
           builtinFunctions.push(gn);
           exploreDeeper(g, gn);
-          exploreDeeper(g.prototype, gn + ".prototype");
+          exploreDeeper(g.prototype, `${gn}.prototype`);
         }
       }
     }
@@ -84,11 +84,11 @@ var builtinObjects = {}; // { "Array.prototype": ["sort", "length", ...], ... }
   exploreDeeper(Proxy, "Proxy");
 
   if (debugMode) {
-    for (let x of constructors) print("^^^^^ " + x);
-    for (let x of builtinProperties) print("***** " + x);
-    for (let x of builtinFunctions) print("===== " + x);
-    for (let x of allMethodNames) print("!!!!! " + x);
-    for (let x of allPropertyNames) print("&&&&& " + x);
+    for (let x of constructors) print(`^^^^^ ${x}`);
+    for (let x of builtinProperties) print(`***** ${x}`);
+    for (let x of builtinFunctions) print(`===== ${x}`);
+    for (let x of allMethodNames) print(`!!!!! ${x}`);
+    for (let x of allPropertyNames) print(`&&&&& ${x}`);
     print(uneval(builtinObjects));
     quit();
   }

--- a/src/funfuzz/js/jsfunfuzz/detect-engine.js
+++ b/src/funfuzz/js/jsfunfuzz/detect-engine.js
@@ -75,8 +75,8 @@ function simpleSource (st) { /* eslint-disable-line require-jsdoc */
   function hexify (c) { /* eslint-disable-line require-jsdoc */
     var code = c.charCodeAt(0);
     var hex = code.toString(16);
-    while (hex.length < 4) { hex = "0" + hex; }
-    return "\\u" + hex;
+    while (hex.length < 4) { hex = `0${hex}`; }
+    return `\\u${hex}`;
   }
 
   if (typeof st === "string") {
@@ -87,7 +87,7 @@ function simpleSource (st) { /* eslint-disable-line require-jsdoc */
         .replace(/\n/g, "\\n")
         .replace(/[^ -~]/g, hexify) + // not space (32) through tilde (126)
       "\"");
-  } else { return "" + st; } // hope this is right ;)  should work for numbers.
+  } else { return `${st}`; } // hope this is right ;)  should work for numbers.
 }
 
 var haveRealUneval = (typeof uneval === "function");

--- a/src/funfuzz/js/jsfunfuzz/driver.js
+++ b/src/funfuzz/js/jsfunfuzz/driver.js
@@ -9,20 +9,20 @@
 
 function start (glob) { /* eslint-disable-line require-jsdoc */
   var fuzzSeed = Math.floor(Math.random() * Math.pow(2, 28));
-  dumpln("fuzzSeed: " + fuzzSeed);
+  dumpln(`fuzzSeed: ${fuzzSeed}`);
   Random.init(fuzzSeed);
 
   // Split this string across two source strings to ensure that if a
   // generated function manages to output the entire jsfunfuzz source,
   // that output won't match the grep command.
   var cookie = "/*F";
-  cookie += "RC-fuzzSeed-" + fuzzSeed + "*/";
+  cookie += `RC-fuzzSeed-${fuzzSeed}*/`;
 
   // Can be set to true if makeStatement has side effects, such as crashing, so you have to reduce "the hard way".
   var dumpEachSeed = false;
 
   if (dumpEachSeed) {
-    dumpln(cookie + "Random.init(0);");
+    dumpln(`${cookie}Random.init(0);`);
   }
 
   mathInitFCM();
@@ -39,7 +39,7 @@ function start (glob) { /* eslint-disable-line require-jsdoc */
       testOne();
       var elapsed1 = new Date() - lastTime;
       if (elapsed1 > 1000) {
-        print("That took " + elapsed1 + "ms!");
+        print(`That took ${elapsed1}ms!`);
       }
       lastTime = new Date();
     } while (lastTime - startTime < MAX_TOTAL_TIME);
@@ -50,7 +50,7 @@ function start (glob) { /* eslint-disable-line require-jsdoc */
   function testStuffForAWhile () { /* eslint-disable-line require-jsdoc */
     for (var j = 0; j < 100; ++j) { testOne(); }
 
-    if (count % 10000 < 100) { printImportant("Iterations: " + count); }
+    if (count % 10000 < 100) { printImportant(`Iterations: ${count}`); }
 
     setTimeout(testStuffForAWhile, 30); /* eslint-disable-line no-undef */
   }
@@ -67,16 +67,16 @@ function start (glob) { /* eslint-disable-line require-jsdoc */
       var MTA = uneval(Random.twister.export_mta());
       var MTI = Random.twister.export_mti();
       if (MTA !== Random.lastDumpedMTA) {
-        dumpln(cookie + "Random.twister.import_mta(" + MTA + ");");
+        dumpln(`${cookie}Random.twister.import_mta(${MTA});`);
         Random.lastDumpedMTA = MTA;
       }
-      dumpln(cookie + "Random.twister.import_mti(" + MTI + "); void (makeScript(" + depth + "));");
+      dumpln(`${cookie}Random.twister.import_mti(${MTI}); void (makeScript(${depth}));`);
     }
 
     var code = makeScript(depth);
 
     if (count === 1 && engine === ENGINE_SPIDERMONKEY_TRUNK && rnd(5)) {
-      code = "tryRunning = useSpidermonkeyShellSandbox(" + rnd(4) + ");";
+      code = `tryRunning = useSpidermonkeyShellSandbox(${rnd(4)});`;
       // print("Sane mode!")
     }
 
@@ -85,7 +85,7 @@ function start (glob) { /* eslint-disable-line require-jsdoc */
     //    if (dp)
     //      code = dp;
     //  }
-    dumpln(cookie + "count=" + count + "; tryItOut(" + uneval(code) + ");");
+    dumpln(`${cookie}count=${count}; tryItOut(${uneval(code)});`);
 
     tryItOut(code);
   }
@@ -94,7 +94,7 @@ function start (glob) { /* eslint-disable-line require-jsdoc */
 function failsToCompileInTry (code) { /* eslint-disable-line require-jsdoc */
   // Why would this happen? One way is "let x, x"
   try {
-    var codeInTry = "try { " + code + " } catch(e) { }";
+    var codeInTry = `try { ${code} } catch(e) { }`;
     void new Function(codeInTry); /* eslint-disable-line no-new-func */
     return false;
   } catch (e) {

--- a/src/funfuzz/js/jsfunfuzz/error-reporting.js
+++ b/src/funfuzz/js/jsfunfuzz/error-reporting.js
@@ -12,7 +12,7 @@ function confused (s) { /* eslint-disable-line require-jsdoc */
     // Currently disabled until its use can be figured out
     // print("jsfunfuzz broke" + " its own scripting environment: " + s);
     // Replaced with the following:
-    print("jsfunfuzz got confused: " + s);
+    print(`jsfunfuzz got confused: ${s}`);
     quit();
   }
 }
@@ -20,7 +20,9 @@ function confused (s) { /* eslint-disable-line require-jsdoc */
 function foundABug (summary, details) { /* eslint-disable-line require-jsdoc */
   // Magic pair of strings that js_interesting looks for
   // Break up the following string so internal js functions do not print it deliberately
-  printImportant("Found" + " a bug: " + summary);
+  let foundMsg = `Found`;
+  foundMsg += ` a bug: ${summary}`;
+  printImportant(foundMsg);
   if (details) {
     printImportant(details);
   }
@@ -32,7 +34,7 @@ function foundABug (summary, details) { /* eslint-disable-line require-jsdoc */
 
 function errorToString (e) { /* eslint-disable-line require-jsdoc */
   try {
-    return ("" + e);
+    return (`${e}`);
   } catch (e2) {
     return "Can't toString the error!!";
   }

--- a/src/funfuzz/js/jsfunfuzz/gen-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-asm.js
@@ -38,7 +38,7 @@ function asmJSInterior (foreignFunctions, sanePlease) { /* eslint-disable-line r
 function importForeign (foreignFunctions) { /* eslint-disable-line require-jsdoc */
   var s = "";
   for (let h of foreignFunctions) {
-    s += "  var " + h + " = foreign." + h + ";\n";
+    s += `  var ${h} = foreign.${h};\n`;
   }
   return s;
 }
@@ -46,7 +46,7 @@ function importForeign (foreignFunctions) { /* eslint-disable-line require-jsdoc
 // ret in ["signed", "double", "void"]
 // args looks like ["i0", "d1", "d2"] -- the first letter indicates int vs double
 function asmJsFunction (globalEnv, name, ret, args) { /* eslint-disable-line require-jsdoc */
-  var s = "  function " + name + "(" + args.join(", ") + ")\n";
+  var s = `  function ${name}(${args.join(", ")})\n`;
   s += "  {\n";
   s += parameterTypeAnnotations(args);
 
@@ -55,7 +55,7 @@ function asmJsFunction (globalEnv, name, ret, args) { /* eslint-disable-line req
   while (rnd(2)) {
     var isDouble = rnd(2);
     var local = (isDouble ? "d" : "i") + locals.length;
-    s += "    var " + local + " = " + (isDouble ? doubleLiteral() : "0") + ";\n";
+    s += `    var ${local} = ${isDouble ? doubleLiteral() : "0"};\n`;
     locals.push(local);
   }
 
@@ -80,7 +80,7 @@ function asmStatement (indent, env, d) { /* eslint-disable-line require-jsdoc */
   if (!env.globalEnv.sanePlease && rnd(100) === 0) { return makeStatement(3, ["x"]); }
 
   if (rnd(5) === 0 && d > 0) {
-    return indent + "{\n" + asmStatement(indent + "  ", env, d - 1) + indent + "}\n";
+    return `${indent}{\n${asmStatement(indent + "  ", env, d - 1)}${indent}}\n`;
   }
   if (rnd(20) === 0 && d > 3) {
     return asmSwitchStatement(indent, env, d);
@@ -96,49 +96,49 @@ function asmStatement (indent, env, d) { /* eslint-disable-line require-jsdoc */
 }
 
 function asmVoidCallStatement (indent, env) { /* eslint-disable-line require-jsdoc */
-  return indent + asmFfiCall(8, env) + ";\n";
+  return `${indent + asmFfiCall(8, env)};\n`;
 }
 
 function asmAssignmentStatement (indent, env) { /* eslint-disable-line require-jsdoc */
   if (rnd(5) === 0 || !env.locals.length) {
     if (rnd(2)) {
-      return indent + intishMemberExpr(8, env) + " = " + intishExpr(10, env) + ";\n";
+      return `${indent + intishMemberExpr(8, env)} = ${intishExpr(10, env)};\n`;
     } else {
-      return indent + doublishMemberExpr(8, env) + " = " + doublishExpr(10, env) + ";\n";
+      return `${indent + doublishMemberExpr(8, env)} = ${doublishExpr(10, env)};\n`;
     }
   }
 
   var local = Random.index(env.locals);
   if (local.charAt(0) === "d") {
-    return indent + local + " = " + doubleExpr(10, env) + ";\n";
+    return `${indent + local} = ${doubleExpr(10, env)};\n`;
   } else {
-    return indent + local + " = " + intExpr(10, env) + ";\n";
+    return `${indent + local} = ${intExpr(10, env)};\n`;
   }
 }
 
 function asmReturnStatement (indent, env) { /* eslint-disable-line require-jsdoc */
   var ret = rnd(2) ? env.ret : Random.index(["double", "signed", "void"]); /* eslint-disable-line no-unused-vars */
   if (env.ret === "double") {
-    return indent + "return +" + doublishExpr(10, env) + ";\n";
+    return `${indent}return +${doublishExpr(10, env)};\n`;
   } else if (env.ret === "signed") {
-    return indent + "return (" + intishExpr(10, env) + ")|0;\n";
+    return `${indent}return (${intishExpr(10, env)})|0;\n`;
   } else { // (env.ret == "void")
-    return indent + "return;\n";
+    return `${indent}return;\n`;
   }
 }
 
 function asmSwitchStatement (indent, env, d) { /* eslint-disable-line require-jsdoc */
-  var s = indent + "switch (" + signedExpr(4, env) + ") {\n";
+  var s = `${indent}switch (${signedExpr(4, env)}) {\n`;
   while (rnd(3)) {
-    s += indent + "  case " + (rnd(5) - 3) + ":\n";
-    s += asmStatement(indent + "    ", env, d - 2);
-    if (rnd(4)) { s += indent + "    break;\n"; }
+    s += `${indent}  case ${rnd(5) - 3}:\n`;
+    s += asmStatement(`${indent}    `, env, d - 2);
+    if (rnd(4)) { s += `${indent}    break;\n`; }
   }
   if (rnd(2)) {
-    s += indent + "  default:\n";
-    s += asmStatement(indent + "    ", env, d - 2);
+    s += `${indent}  default:\n`;
+    s += asmStatement(`${indent}    `, env, d - 2);
   }
-  s += indent + "}\n";
+  s += `${indent}}\n`;
   return s;
 }
 
@@ -146,7 +146,7 @@ function parameterTypeAnnotations (args) { /* eslint-disable-line require-jsdoc 
   var s = "";
   for (var a = 0; a < args.length; ++a) {
     var arg = args[a];
-    if (arg.charAt(0) === "i") { s += "    " + arg + " = " + arg + "|0;\n"; } else { s += "    " + arg + " = " + "+" + arg + ";\n"; }
+    if (arg.charAt(0) === "i") { s += `    ${arg} = ${arg}|0;\n`; } else { s += `    ${arg} = +${arg};\n`; }
   }
   return s;
 }
@@ -160,12 +160,12 @@ var additive = ["+", "-"];
 
 var intExpr = autoExpr(Random.weighted([
   { w: 1, v: function (d, e) { return intLiteralRange(-0x8000000, 0xffffffff); } },
-  { w: 1, v: function (d, e) { return intExpr(d - 3, e) + " ? " + intExpr(d - 3, e) + " : " + intExpr(d - 3, e); } },
-  { w: 1, v: function (d, e) { return "!" + intExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return `${intExpr(d - 3, e)} ? ${intExpr(d - 3, e)} : ${intExpr(d - 3, e)}`; } },
+  { w: 1, v: function (d, e) { return `!${intExpr(d - 1, e)}`; } },
   { w: 1, v: function (d, e) { return signedExpr(d - 1, e); } },
   { w: 1, v: function (d, e) { return unsignedExpr(d - 1, e); } },
   { w: 10, v: function (d, e) { return intVar(e); } }, // + "|0"  ??
-  { w: 1, v: function (d, e) { return e.globalEnv.foreignFunctions.length ? asmFfiCall(d, e) + "|0" : "1"; } },
+  { w: 1, v: function (d, e) { return e.globalEnv.foreignFunctions.length ? `${asmFfiCall(d, e)}|0` : "1"; } },
   { w: 1, v: function (d, e) { return signedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + signedExpr(d - 2, e); } },
   { w: 1, v: function (d, e) { return unsignedExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + unsignedExpr(d - 2, e); } },
   { w: 1, v: function (d, e) { return doubleExpr(d - 2, e) + Random.index([" < ", " <= ", " > ", " >= ", " == ", " != "]) + doubleExpr(d - 2, e); } }
@@ -178,28 +178,28 @@ var intishExpr = autoExpr(Random.weighted([
   { w: 10, v: function (d, e) { return intExpr(d - 1, e) + Random.index(additive) + intExpr(d - 1, e); } },
   { w: 5, v: function (d, e) { return intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e) + Random.index(additive) + intExpr(d - 2, e); } },
   // Multiply by a small int literal
-  { w: 2, v: function (d, e) { return intExpr(d - 1, e) + "*" + intLiteralRange(-0xfffff, 0xfffff); } },
+  { w: 2, v: function (d, e) { return `${intExpr(d - 1, e)}*${intLiteralRange(-0xfffff, 0xfffff)}`; } },
   { w: 2, v: function (d, e) { return intLiteralRange(-0xfffff, 0xfffff) + "*" + intExpr(d - 1, e); } },
-  { w: 1, v: function (d, e) { return "-" + intExpr(d - 1, e); } },
-  { w: 1, v: function (d, e) { return signedExpr(d - 2, e) + " / " + signedExpr(d - 2, e); } },
-  { w: 1, v: function (d, e) { return unsignedExpr(d - 2, e) + " / " + unsignedExpr(d - 2, e); } },
-  { w: 1, v: function (d, e) { return signedExpr(d - 2, e) + " % " + signedExpr(d - 2, e); } },
-  { w: 1, v: function (d, e) { return unsignedExpr(d - 2, e) + " % " + unsignedExpr(d - 2, e); } }
+  { w: 1, v: function (d, e) { return `-${intExpr(d - 1, e)}`; } },
+  { w: 1, v: function (d, e) { return `${signedExpr(d - 2, e)} / ${signedExpr(d - 2, e)}`; } },
+  { w: 1, v: function (d, e) { return `${unsignedExpr(d - 2, e)} / ${unsignedExpr(d - 2, e)}`; } },
+  { w: 1, v: function (d, e) { return `${signedExpr(d - 2, e)} % ${signedExpr(d - 2, e)}`; } },
+  { w: 1, v: function (d, e) { return `${unsignedExpr(d - 2, e)} % ${unsignedExpr(d - 2, e)}`; } }
 ]));
 
 var signedExpr = autoExpr(Random.weighted([
   { w: 1, v: function (d, e) { return intLiteralRange(-0x8000000, 0x7fffffff); } },
-  { w: 1, v: function (d, e) { return "~" + intishExpr(d - 1, e); } },
-  { w: 1, v: function (d, e) { return "~~" + doubleExpr(d - 1, e); } },
-  { w: 1, v: function (d, e) { return intishExpr(d - 1, e) + "|0"; } }, // this isn't a special form, but it's common for a good reason
-  { w: 1, v: function (d, e) { return ensureMathImport(e, "imul") + "(" + intExpr(d - 2, e) + ", " + intExpr(d - 2, e) + ")|0"; } },
-  { w: 1, v: function (d, e) { return ensureMathImport(e, "abs") + "(" + signedExpr(d - 1, e) + ")|0"; } },
+  { w: 1, v: function (d, e) { return `~${intishExpr(d - 1, e)}`; } },
+  { w: 1, v: function (d, e) { return `~~${doubleExpr(d - 1, e)}`; } },
+  { w: 1, v: function (d, e) { return `${intishExpr(d - 1, e)}|0`; } }, // this isn't a special form, but it's common for a good reason
+  { w: 1, v: function (d, e) { return `${ensureMathImport(e, "imul")}(${intExpr(d - 2, e)}, ${intExpr(d - 2, e)})|0`; } },
+  { w: 1, v: function (d, e) { return `${ensureMathImport(e, "abs")}(${signedExpr(d - 1, e)})|0`; } },
   { w: 5, v: function (d, e) { return intishExpr(d - 2, e) + Random.index([" | ", " & ", " ^ ", " << ", " >> "]) + intishExpr(d - 2, e); } }
 ]));
 
 var unsignedExpr = autoExpr(Random.weighted([
   { w: 1, v: function (d, e) { return intLiteralRange(0, 0xffffffff); } },
-  { w: 1, v: function (d, e) { return intishExpr(d - 2, e) + ">>>" + intishExpr(d - 2, e); } }
+  { w: 1, v: function (d, e) { return `${intishExpr(d - 2, e)}>>>${intishExpr(d - 2, e)}`; } }
 ]));
 
 var doublishExpr = autoExpr(Random.weighted([
@@ -211,26 +211,26 @@ var doublishExpr = autoExpr(Random.weighted([
 var doubleExpr = autoExpr(Random.weighted([
   { w: 1, v: function (d, e) { return doubleLiteral(); } },
   { w: 20, v: function (d, e) { return doubleVar(e); } },
-  { w: 1, v: function (d, e) { return e.globalEnv.foreignFunctions.length ? "+" + asmFfiCall(d, e) : "1.0"; } },
+  { w: 1, v: function (d, e) { return e.globalEnv.foreignFunctions.length ? `+${asmFfiCall(d, e)}` : "1.0"; } },
   { w: 1, v: function (d, e) { return "+(1.0/0.0)"; } },
   { w: 1, v: function (d, e) { return "+(0.0/0.0)"; } },
   { w: 1, v: function (d, e) { return "+(-1.0/0.0)"; } },
   // Unary ops that return double
-  { w: 1, v: function (d, e) { return "+" + signedExpr(d - 1, e); } },
-  { w: 1, v: function (d, e) { return "+" + unsignedExpr(d - 1, e); } },
-  { w: 1, v: function (d, e) { return "+" + doublishExpr(d - 1, e); } },
-  { w: 1, v: function (d, e) { return "-" + doublishExpr(d - 1, e); } },
+  { w: 1, v: function (d, e) { return `+${signedExpr(d - 1, e)}`; } },
+  { w: 1, v: function (d, e) { return `+${unsignedExpr(d - 1, e)}`; } },
+  { w: 1, v: function (d, e) { return `+${doublishExpr(d - 1, e)}`; } },
+  { w: 1, v: function (d, e) { return `-${doublishExpr(d - 1, e)}`; } },
   // Binary ops that return double
-  { w: 1, v: function (d, e) { return doubleExpr(d - 2, e) + " + " + doubleExpr(d - 2, e); } },
-  { w: 1, v: function (d, e) { return doublishExpr(d - 2, e) + " - " + doublishExpr(d - 2, e); } },
-  { w: 1, v: function (d, e) { return doublishExpr(d - 2, e) + " * " + doublishExpr(d - 2, e); } },
-  { w: 1, v: function (d, e) { return doublishExpr(d - 2, e) + " / " + doublishExpr(d - 2, e); } },
-  { w: 1, v: function (d, e) { return doublishExpr(d - 2, e) + " % " + doublishExpr(d - 2, e); } },
-  { w: 1, v: function (d, e) { return intExpr(d - 3, e) + " ? " + doubleExpr(d - 3, e) + " : " + doubleExpr(d - 3, e); } },
+  { w: 1, v: function (d, e) { return `${doubleExpr(d - 2, e)} + ${doubleExpr(d - 2, e)}`; } },
+  { w: 1, v: function (d, e) { return `${doublishExpr(d - 2, e)} - ${doublishExpr(d - 2, e)}`; } },
+  { w: 1, v: function (d, e) { return `${doublishExpr(d - 2, e)} * ${doublishExpr(d - 2, e)}`; } },
+  { w: 1, v: function (d, e) { return `${doublishExpr(d - 2, e)} / ${doublishExpr(d - 2, e)}`; } },
+  { w: 1, v: function (d, e) { return `${doublishExpr(d - 2, e)} % ${doublishExpr(d - 2, e)}`; } },
+  { w: 1, v: function (d, e) { return `${intExpr(d - 3, e)} ? ${doubleExpr(d - 3, e)} : ${doubleExpr(d - 3, e)}`; } },
   // with stdlib
-  { w: 1, v: function (d, e) { return "+" + ensureMathImport(e, Random.index(["acos", "asin", "atan", "cos", "sin", "tan", "ceil", "floor", "exp", "log", "sqrt"])) + "(" + doublishExpr(d - 1, e) + ")"; } },
-  { w: 1, v: function (d, e) { return "+" + ensureMathImport(e, "abs") + "(" + doublishExpr(d - 1, e) + ")"; } },
-  { w: 1, v: function (d, e) { return "+" + ensureMathImport(e, Random.index(["atan2", "pow"])) + "(" + doublishExpr(d - 2, e) + ", " + doublishExpr(d - 2, e) + ")"; } },
+  { w: 1, v: function (d, e) { return `+${ensureMathImport(e, Random.index(["acos", "asin", "atan", "cos", "sin", "tan", "ceil", "floor", "exp", "log", "sqrt"]))}(${doublishExpr(d - 1, e)})`; } },
+  { w: 1, v: function (d, e) { return `+${ensureMathImport(e, "abs")}(${doublishExpr(d - 1, e)})`; } },
+  { w: 1, v: function (d, e) { return `+${ensureMathImport(e, Random.index(["atan2", "pow"]))}(${doublishExpr(d - 2, e)}, ${doublishExpr(d - 2, e)})`; } },
   { w: 1, v: function (d, e) { return ensureImport(e, "Infinity"); } },
   { w: 1, v: function (d, e) { return ensureImport(e, "NaN"); } }
 ]));
@@ -241,20 +241,20 @@ var externExpr = autoExpr(Random.weighted([
 ]));
 
 var intishMemberExpr = autoExpr(Random.weighted([
-  { w: 1, v: function (d, e) { return ensureView(e, Random.index(["Int8Array", "Uint8Array"])) + "[" + asmIndex(d, e, 0) + "]"; } },
-  { w: 1, v: function (d, e) { return ensureView(e, Random.index(["Int16Array", "Uint16Array"])) + "[" + asmIndex(d, e, 1) + "]"; } },
-  { w: 1, v: function (d, e) { return ensureView(e, Random.index(["Int32Array", "Uint32Array"])) + "[" + asmIndex(d, e, 2) + "]"; } }
+  { w: 1, v: function (d, e) { return `${ensureView(e, Random.index(["Int8Array", "Uint8Array"]))}[${asmIndex(d, e, 0)}]`; } },
+  { w: 1, v: function (d, e) { return `${ensureView(e, Random.index(["Int16Array", "Uint16Array"]))}[${asmIndex(d, e, 1)}]`; } },
+  { w: 1, v: function (d, e) { return `${ensureView(e, Random.index(["Int32Array", "Uint32Array"]))}[${asmIndex(d, e, 2)}]`; } }
 ]), true);
 
 var doublishMemberExpr = autoExpr(Random.weighted([
-  { w: 1, v: function (d, e) { return ensureView(e, "Float32Array") + "[" + asmIndex(d, e, 2) + "]"; } },
-  { w: 1, v: function (d, e) { return ensureView(e, "Float64Array") + "[" + asmIndex(d, e, 3) + "]"; } }
+  { w: 1, v: function (d, e) { return `${ensureView(e, "Float32Array")}[${asmIndex(d, e, 2)}]`; } },
+  { w: 1, v: function (d, e) { return `${ensureView(e, "Float64Array")}[${asmIndex(d, e, 3)}]`; } }
 ]), true);
 
 function asmIndex (d, e, logSize) { /* eslint-disable-line require-jsdoc */
   if (rnd(2) || d < 2) { return Random.index(["0", "1", "2", "4096"]); }
 
-  return intishExpr(d - 2, e) + " >> " + logSize;
+  return `${intishExpr(d - 2, e)} >> ${logSize}`;
 }
 
 function asmFfiCall (d, e) { /* eslint-disable-line require-jsdoc */
@@ -265,13 +265,13 @@ function asmFfiCall (d, e) { /* eslint-disable-line require-jsdoc */
     argList += externExpr(d, e);
   }
 
-  return "/*FFI*/" + Random.index(e.globalEnv.foreignFunctions) + "(" + argList + ")";
+  return `/*FFI*/${Random.index(e.globalEnv.foreignFunctions)}(${argList})`;
 }
 
 function ensureView (e, t) { /* eslint-disable-line require-jsdoc */
-  var varName = t + "View";
+  var varName = `${t}View`;
   if (!(varName in e.globalEnv.heapImported)) {
-    e.globalEnv.heapImports += "  var " + varName + " = new stdlib." + t + "(heap);\n";
+    e.globalEnv.heapImports += `  var ${varName} = new stdlib.${t}(heap);\n`;
     e.globalEnv.heapImported[varName] = true;
   }
   return varName;
@@ -283,7 +283,7 @@ function ensureMathImport (e, f) { /* eslint-disable-line require-jsdoc */
 
 function ensureImport (e, f, prefix) { /* eslint-disable-line require-jsdoc */
   if (!(f in e.globalEnv.stdlibImported)) {
-    e.globalEnv.stdlibImports += "  var " + f + " = stdlib." + (prefix || "") + f + ";\n";
+    e.globalEnv.stdlibImports += `  var ${f} = stdlib.${prefix || ""}${f};\n`;
     e.globalEnv.stdlibImported[f] = true;
   }
   return f;
@@ -297,7 +297,7 @@ function autoExpr (funs, avoidSubst) { /* eslint-disable-line require-jsdoc */
       rnd(50) === 0 && !e.globalEnv.sanePlease ? function (_d, _e) { return makeExpr(5, ["x"]); } :
         rnd(50) === 0 && !avoidSubst ? Random.index(anyAsmExpr) :
           Random.index(funs);
-    return "(" + f(d, e) + ")";
+    return `(${f(d, e)})`;
   };
 }
 
@@ -336,9 +336,9 @@ function positiveDoubleLiteral () { /* eslint-disable-line require-jsdoc */
     value -= 1;
   }
 
-  var str = value + "";
+  var str = `${value}`;
   if (str.indexOf(".") === -1) {
-    return str + ".0";
+    return `${str}.0`;
   }
   // Numbers with decimal parts, or numbers serialized with exponential notation
   return str;
@@ -358,5 +358,5 @@ function fuzzyRange (min, max) { /* eslint-disable-line require-jsdoc */
 function intLiteralRange (min, max) { /* eslint-disable-line require-jsdoc */
   var val = fuzzyRange(min, max);
   var sign = val < 0 ? "-" : "";
-  return sign + "0x" + Math.abs(val).toString(16);
+  return `${sign}0x${Math.abs(val).toString(16)}`;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -334,16 +334,16 @@ function makeUseRegressionTest (d, b) { /* eslint-disable-line require-jsdoc */
       continue;
     }
 
-    test_type = "regression"
+    let testType = "regression";
 
     switch (rnd(2)) {
       case 0:
       // simply inline the script -- this is the only one that will work in newGlobal()
-        s += `/* ${test_type}-test-inline */ ${inlineTest(file)}`;
+        s += `/* ${testType}-test-inline */ ${inlineTest(file)}`;
         break;
       default:
       // run it using load()
-        s += `/* ${test_type}-test-load */ load(${simpleSource(file)});`;
+        s += `/* ${testType}-test-load */ load(${simpleSource(file)});`;
         break;
       // NB: these scripts will also be run through eval(), evalcx(), evaluate(), evalInWorker()
       //     thanks to other parts of the fuzzer using makeScriptForEval or makeStatement
@@ -1109,7 +1109,7 @@ function makeShapeyConstructorLoop (d, b) { /* eslint-disable-line require-jsdoc
     `/*tLoopC*/for (let ${v} of ${a}) { ` +
      "try{" +
       `let ${v2} = ${Random.index(["new ", ""])}shapeyConstructor(${v}); print('EETT'); ` +
-      // `print(uneval(${v2}));` +
+       // `print(uneval(${v2}));` +
        makeStatement(d - 2, bvv) +
      `}catch(e){print('TTEE ' + e); }` +
   " }";

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -334,14 +334,16 @@ function makeUseRegressionTest (d, b) { /* eslint-disable-line require-jsdoc */
       continue;
     }
 
+    test_type = "regression"
+
     switch (rnd(2)) {
       case 0:
       // simply inline the script -- this is the only one that will work in newGlobal()
-        s += `/* regression-test-inline */ ${inlineTest(file)}`;
+        s += `/* ${test_type}-test-inline */ ${inlineTest(file)}`;
         break;
       default:
       // run it using load()
-        s += `/* regression-test-load */ load(${simpleSource(file)});`;
+        s += `/* ${test_type}-test-load */ load(${simpleSource(file)});`;
         break;
       // NB: these scripts will also be run through eval(), evalcx(), evaluate(), evalInWorker()
       //     thanks to other parts of the fuzzer using makeScriptForEval or makeStatement

--- a/src/funfuzz/js/jsfunfuzz/gen-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-grammar.js
@@ -69,58 +69,58 @@ function forLoopHead (d, b, v, reps) { /* eslint-disable-line require-jsdoc */
 
   switch (rnd(2)) {
     case 0: // Generates constructs like `for (var x = 3; x > 0; x--) { ... }`
-      sInit = Random.index(varBinderFor) + v + " = " + reps;
-      sCond = v + " > 0";
+      sInit = `${Random.index(varBinderFor) + v} = ${reps}`;
+      sCond = `${v} > 0`;
       if (rnd(2)) {
-        sNext = "--" + v;
+        sNext = `--${v}`;
       } else {
-        sNext = v + "--";
+        sNext = `${v}--`;
       }
       break;
     default: // Generates constructs like `for (var x = 0; x < 3; x++) { ... }`
-      sInit = Random.index(varBinderFor) + v + " = 0";
-      sCond = v + " < " + reps;
+      sInit = `${Random.index(varBinderFor) + v} = 0`;
+      sCond = `${v} < ${reps}`;
       if (rnd(2)) {
-        sNext = "++" + v;
+        sNext = `++${v}`;
       } else {
-        sNext = v + "++";
+        sNext = `${v}++`;
       }
   }
 
-  while (rnd(10) === 0) { sInit += ", " + makeLetHeadItem(d - 2, b); }
-  while (rnd(10) === 0) { sInit += ", " + makeExpr(d - 2, b); } // NB: only makes sense if our varBinder is ""
+  while (rnd(10) === 0) { sInit += `, ${makeLetHeadItem(d - 2, b)}`; }
+  while (rnd(10) === 0) { sInit += `, ${makeExpr(d - 2, b)}`; } // NB: only makes sense if our varBinder is ""
   while (rnd(1000) === 0) {
   // never causes the loop to be run, but stuff like register allocation may be happening in the background
     sInit = Random.index(varBinderFor) + v;
   }
   while (rnd(10000) === 0) { sInit = ""; } // mostly throws ReferenceError, so make this rare
 
-  while (rnd(20) === 0) { sCond = sCond + " && (" + makeExpr(d - 2, b) + ")"; }
-  while (rnd(20) === 0) { sCond = "(" + makeExpr(d - 2, b) + ") && " + sCond; }
+  while (rnd(20) === 0) { sCond = `${sCond} && (${makeExpr(d - 2, b)})`; }
+  while (rnd(20) === 0) { sCond = `(${makeExpr(d - 2, b)}) && ${sCond}`; }
 
-  while (rnd(20) === 0) { sNext = sNext + ", " + makeExpr(d - 2, b); }
-  while (rnd(20) === 0) { sNext = makeExpr(d - 2, b) + ", " + sNext; }
+  while (rnd(20) === 0) { sNext = `${sNext}, ${makeExpr(d - 2, b)}`; }
+  while (rnd(20) === 0) { sNext = `${makeExpr(d - 2, b)}, ${sNext}`; }
 
-  return "for (" + sInit + "; " + sCond + "; " + sNext + ")";
+  return `for (${sInit}; ${sCond}; ${sNext})`;
 }
 
 function makeOpaqueIdiomaticLoop (d, b) { /* eslint-disable-line require-jsdoc */
   var reps = loopCount();
   var vHidden = uniqueVarName();
-  return "/*oLoop*/" + forLoopHead(d, b, vHidden, reps) + " { " +
+  return `/*oLoop*/${forLoopHead(d, b, vHidden, reps)} { ` +
       makeStatement(d - 2, b) +
-      " } ";
+      ` } `;
 }
 
 function makeTransparentIdiomaticLoop (d, b) { /* eslint-disable-line require-jsdoc */
   var reps = loopCount();
   var vHidden = uniqueVarName();
   var vVisible = makeNewId(d, b);
-  return "/*vLoop*/" + forLoopHead(d, b, vHidden, reps) +
-    " { " +
-      Random.index(varBinder) + vVisible + " = " + vHidden + "; " +
+  return `/*vLoop*/${forLoopHead(d, b, vHidden, reps)}` +
+    ` { ` +
+      `${Random.index(varBinder) + vVisible} = ${vHidden}; ` +
       makeStatement(d - 2, b.concat([vVisible])) +
-    " } ";
+    ` } `;
 }
 
 function makeBranchUnstableLoop (d, b) { /* eslint-disable-line require-jsdoc */
@@ -128,17 +128,17 @@ function makeBranchUnstableLoop (d, b) { /* eslint-disable-line require-jsdoc */
   var v = uniqueVarName();
   var mod = loopModulo();
   var target = rnd(mod);
-  return "/*bLoop*/" + forLoopHead(d, b, v, reps) + " { " +
-    "if (" + v + " % " + mod + " == " + target + ") { " + makeStatement(d - 2, b) + " } " +
-    "else { " + makeStatement(d - 2, b) + " } " +
-    " } ";
+  return `/*bLoop*/${forLoopHead(d, b, v, reps)} { ` +
+    `if (${v} % ${mod} == ${target}) { ${makeStatement(d - 2, b)} } ` +
+    `else { ${makeStatement(d - 2, b)} } ` +
+    ` } `;
 }
 
 function makeTypeUnstableLoop (d, b) { /* eslint-disable-line require-jsdoc */
   var a = makeMixedTypeArray(d, b);
   var v = makeNewId(d, b);
   var bv = b.concat([v]);
-  return "/*tLoop*/for (let " + v + " of " + a + ") { " + makeStatement(d - 2, bv) + " }";
+  return `/*tLoop*/for (let ${v} of ${a}) { ${makeStatement(d - 2, bv)} }`;
 }
 
 function makeFunOnCallChain (d, b) { /* eslint-disable-line require-jsdoc */
@@ -179,10 +179,10 @@ var statementMakers = Random.weighted([
   // C-style "for" loops
   // Two kinds of "for" loops: one with an expression as the first part, one with a var or let binding 'statement' as the first part.
   // I'm not sure if arbitrary statements are allowed there; I think not.
-  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                                                    "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
-  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v, " = ", makeExpr(d, b),                             "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
-  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeDestructuringLValue(d, b), " = ", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) {                          return `/*infloop*/${cat([maybeLabel(), "for", "(", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)])}`; } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return `/*infloop*/${cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                                                    "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))])}`; } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return `/*infloop*/${cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v, " = ", makeExpr(d, b),                             "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b.concat([v]))])}`; } },
+  { w: 1, v: function (d, b) {                          return `/*infloop*/${cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeDestructuringLValue(d, b), " = ", makeExpr(d, b), "; ", makeExpr(d, b), "; ", makeExpr(d, b), ") ", makeStatementOrBlock(d, b)])}`; } },
   /* eslint-enable no-multi-spaces */
 
   // Various types of "for" loops, specially set up to test tracing, carefully avoiding infinite loops
@@ -195,25 +195,25 @@ var statementMakers = Random.weighted([
   // "for..in" loops
   // arbitrary-LHS marked as infloop because
   // -- for (key in obj)
-  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) {                          return `/*infloop*/${cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)])}`; } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return               cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   // -- for (key in generator())
-  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) {                          return `/*infloop*/${cat([maybeLabel(), "for", "(", Random.index(varBinderFor), makeForInLHS(d, b), " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b)])}`; } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return               cat([maybeLabel(), "for", "(", Random.index(varBinderFor), v,                  " in ", "(", "(", makeFunction(d, b), ")", "(", makeExpr(d, b), ")", ")", ")", makeStatementOrBlock(d, b.concat([v]))]); } },
   // -- for (element of arraylike)
-  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) {                          return `/*infloop*/${cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)])}`; } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return               cat([maybeLabel(), " for ", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // -- for-await-of
-  { w: 1, v: function (d, b) {                          return "/*infloop*/" + cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return                 cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
+  { w: 1, v: function (d, b) {                          return `/*infloop*/${cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), makeLValue(d, b), " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b)])}`; } },
+  { w: 1, v: function (d, b) { var v = makeNewId(d, b); return               cat([maybeLabel(), " for ", "await", "(", Random.index(varBinderFor), v,                " of ", makeExpr(d - 2, b), ") ", makeStatementOrBlock(d, b.concat([v]))]); } },
   /* eslint-enable no-multi-spaces */
 
   // Modify something during a loop -- perhaps the thing being looped over
   // Since we use "let" to bind the for-variables, and only do wacky stuff once, I *think* this is unlikely to hang.
-  //  function(d, b) { return "let forCount = 0; for (let " + makeId(d, b) + " in " + makeExpr(d, b) + ") { if (forCount++ == " + rnd(3) + ") { " + makeStatement(d - 1, b) + " } }"; },
+  //  function(d, b) { return `let forCount = 0; for (let ${makeId(d, b)} in ${makeExpr(d, b)}) { if (forCount++ == ${rnd(3)}) { ${makeStatement(d - 1, b)} } }`; },
 
   /* eslint-disable no-multi-spaces */
   // Hoisty "for..in" loops.  I don't know why this construct exists, but it does, and it hoists the initial-value expression above the loop.
@@ -227,9 +227,9 @@ var statementMakers = Random.weighted([
 
   // do..while
   { w: 1, v: function (d, b) { return cat([maybeLabel(), "while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, makeStatementOrBlock(d, b)]); } },
-  { w: 1, v: function (d, b) { return "/*infloop*/" + cat([maybeLabel(), "while", "(", makeExpr(d, b), ")", makeStatementOrBlock(d, b)]); } },
+  { w: 1, v: function (d, b) { return `/*infloop*/${cat([maybeLabel(), "while", "(", makeExpr(d, b), ")", makeStatementOrBlock(d, b)])}`; } },
   { w: 1, v: function (d, b) { return cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while((", makeExpr(d, b), ") && 0)" /* don't split this, it's needed to avoid marking as infloop */, ";"]); } },
-  { w: 1, v: function (d, b) { return "/*infloop*/" + cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while", "(", makeExpr(d, b), ");"]); } },
+  { w: 1, v: function (d, b) { return `/*infloop*/${cat([maybeLabel(), "do ", makeStatementOrBlock(d, b), " while", "(", makeExpr(d, b), ");"])}`; } },
 
   // Switch statement
   { w: 3, v: function (d, b) { return cat([maybeLabel(), "switch", "(", makeExpr(d, b), ")", " { ", makeSwitchBody(d, b), " }"]); } },
@@ -271,19 +271,19 @@ var statementMakers = Random.weighted([
   // Long script -- can confuse Spidermonkey's short vs long jmp or something like that.
   // Spidermonkey's regexp engine is so slow for long strings that we have to bypass whatToTest :(
   // { w: 1, v: function(d, b) { return strTimes("try{}catch(e){}", rnd(10000)); } },
-  { w: 1, v: function (d, b) { if (rnd(200) === 0) return "/*DUPTRY" + rnd(10000) + "*/" + makeStatement(d - 1, b); return ";"; } },
+  { w: 1, v: function (d, b) { if (rnd(200) === 0) return `/*DUPTRY${rnd(10000)}*/${makeStatement(d - 1, b)}`; return ";"; } },
 
   { w: 1, v: function (d, b) { return makeShapeyConstructorLoop(d, b); } },
 
   // Replace a variable with a long linked list pointing to it.  (Forces SpiderMonkey's GC marker into a stackless mode.)
-  { w: 1, v: function (d, b) { var x = makeId(d, b); return x + " = linkedList(" + x + ", " + (rnd(100) * rnd(100)) + ");"; } },
+  { w: 1, v: function (d, b) { var x = makeId(d, b); return `${x} = linkedList(${x}, ${rnd(100) * rnd(100)});`; } },
 
   // Oddly placed "use strict" or "use asm"
   { w: 1, v: function (d, b) { return directivePrologue() + makeStatement(d - 1, b); } },
 
   // Spidermonkey GC and JIT controls
   { w: 3, v: function (d, b) { return makeTestingFunctionCall(d, b); } },
-  { w: 3, v: function (d, b) { return makeTestingFunctionCall(d - 1, b) + " " + makeStatement(d - 1, b); } },
+  { w: 3, v: function (d, b) { return `${makeTestingFunctionCall(d - 1, b)} ${makeStatement(d - 1, b)}`; } },
 
   // Blocks of statements related to typed arrays
   { w: 8, v: makeTypedArrayStatements },
@@ -298,14 +298,14 @@ var statementMakers = Random.weighted([
   { w: 20, v: makeUseRegressionTest }
 
   // Discover properties to add to the allPropertyNames list
-  // { w: 3, v: function(d, b) { return "for (var p in " + makeId(d, b) + ") { addPropertyName(p); }"; } },
-  // { w: 3, v: function(d, b) { return "var opn = Object.getOwnPropertyNames(" + makeId(d, b) + "); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }"; } },
+  // { w: 3, v: function(d, b) { return `for (var p in ${makeId(d, b)}) { addPropertyName(p); }`; } },
+  // { w: 3, v: function(d, b) { return `var opn = Object.getOwnPropertyNames(${makeId(d, b)}); for (var j = 0; j < opn.length; ++j) { addPropertyName(opn[j]); }`; } },
 ]);
 
 if (typeof oomTest === "function" && engine !== ENGINE_JAVASCRIPTCORE) {
   statementMakers = statementMakers.concat([
-    function (d, b) { return "oomTest(" + makeFunction(d - 1, b) + ")"; },
-    function (d, b) { return "oomTest(" + makeFunction(d - 1, b) + ", { keepFailing: true })"; }
+    function (d, b) { return `oomTest(${makeFunction(d - 1, b)})`; },
+    function (d, b) { return `oomTest(${makeFunction(d - 1, b)}, { keepFailing: true })`; }
   ]);
 }
 
@@ -337,11 +337,11 @@ function makeUseRegressionTest (d, b) { /* eslint-disable-line require-jsdoc */
     switch (rnd(2)) {
       case 0:
       // simply inline the script -- this is the only one that will work in newGlobal()
-        s += "/* regression-test-inline */ " + inlineTest(file);
+        s += `/* regression-test-inline */ ${inlineTest(file)}`;
         break;
       default:
       // run it using load()
-        s += "/* regression-test-load */ " + "load(" + simpleSource(file) + ");";
+        s += `/* regression-test-load */ load(${simpleSource(file)});`;
         break;
       // NB: these scripts will also be run through eval(), evalcx(), evaluate(), evalInWorker()
       //     thanks to other parts of the fuzzer using makeScriptForEval or makeStatement
@@ -365,7 +365,7 @@ function regressionTestIsEvil (contents) { /* eslint-disable-line require-jsdoc 
 function inlineTest (filename) { /* eslint-disable-line require-jsdoc */
   // Inline a regression test, adding NODIFF (to disable differential testing) if it calls a testing function that might throw.
 
-  const s = "/* " + filename + " */ " + read(filename) + "\n";
+  const s = `/* ${filename} */ ${read(filename)}\n`;
 
   const noDiffTestingFunctions = [
     // These can throw
@@ -383,7 +383,7 @@ function inlineTest (filename) { /* eslint-disable-line require-jsdoc */
 
   for (var f of noDiffTestingFunctions) {
     if (s.indexOf(f) !== -1) {
-      return "/*NODIFF*/ " + s;
+      return `/*NODIFF*/ ${s}`;
     }
   }
 
@@ -397,7 +397,7 @@ function regressionTestDependencies (maintest) { /* eslint-disable-line require-
     // Include the chain of 'shell.js' files in their containing directories (starting from regressionTestsRoot)
     for (var i = regressionTestsRoot.length; i < maintest.length; ++i) {
       if (maintest.charAt(i) === "/" || maintest.charAt(i) === "\\") {
-        var shelljs = maintest.substr(0, i + 1) + "shell.js";
+        var shelljs = `${maintest.substr(0, i + 1)}shell.js`;
         if (regressionTestList.indexOf(shelljs) !== -1) {
           files.push(shelljs);
         }
@@ -406,13 +406,13 @@ function regressionTestDependencies (maintest) { /* eslint-disable-line require-
 
     // Include prologue.js for jit-tests
     if (maintest.indexOf("jit-test") !== -1) {
-      files.push(libdir + "prologue.js");
+      files.push(`${libdir}prologue.js`);
     }
 
     // Include web-platform-test-shims.js and testharness.js for streams tests
     if (maintest.indexOf("web-platform") !== -1) {
-      files.push(js_src_tests_dir + "web-platform-test-shims.js"); /* eslint-disable-line camelcase */
-      files.push(w_pltfrm_res_dir + "testharness.js"); /* eslint-disable-line camelcase */
+      files.push(`${js_src_tests_dir}web-platform-test-shims.js`); /* eslint-disable-line camelcase */
+      files.push(`${w_pltfrm_res_dir}testharness.js`); /* eslint-disable-line camelcase */
     }
   }
 
@@ -437,7 +437,7 @@ function makeNamedFunctionAndUse (d, b) { /* eslint-disable-line require-jsdoc *
     useStatement = cat([funcName, "(", makeActualArgList(d, b), ")", ";"]);
   } else {
     // Any statement, allowed to use the name of the function
-    useStatement = "/*iii*/" + makeStatement(d - 1, b.concat([funcName]));
+    useStatement = `/*iii*/${makeStatement(d - 1, b.concat([funcName]))}`;
   }
   if (rnd(2)) {
     return declStatement + useStatement;
@@ -447,7 +447,7 @@ function makeNamedFunctionAndUse (d, b) { /* eslint-disable-line require-jsdoc *
 }
 
 function makePrintStatement (d, b) { /* eslint-disable-line require-jsdoc */
-  if (rnd(2) && b.length) { return "print(" + Random.index(b) + ");"; } else { return "print(" + makeExpr(d, b) + ");"; }
+  if (rnd(2) && b.length) { return `print(${Random.index(b)});`; } else { return `print(${makeExpr(d, b)});`; }
 }
 
 function maybeLabel () { /* eslint-disable-line require-jsdoc */
@@ -478,7 +478,7 @@ function makeSwitchBody (d, b) { /* eslint-disable-line require-jsdoc */
       } else {
         // cases with numbers (integers?) have special optimizations,
         // so be sure to test those well in addition to testing complicated expressions.
-        output += "case " + (rnd(2) ? rnd(10) : makeExpr(d, b)) + ": ";
+        output += `case ${rnd(2) ? rnd(10) : makeExpr(d, b)}: `;
       }
 
       haveSomething = true;
@@ -587,37 +587,37 @@ var exceptionyStatementMakers = [
   function (d, b) { return cat(["await ", makeExpr(d, b), ";"]); },
   function (d, b) { return cat(["throw ", makeId(d, b), ";"]); },
   function (d, b) { return "this.zzz.zzz;"; }, // throws; also tests js_DecompileValueGenerator in various locations
-  function (d, b) { return b[b.length - 1] + "." + Random.index(exceptionProperties) + ";"; },
-  function (d, b) { return makeId(d, b) + "." + Random.index(exceptionProperties) + ";"; },
+  function (d, b) { return `${b[b.length - 1]}.${Random.index(exceptionProperties)};`; },
+  function (d, b) { return `${makeId(d, b)}.${Random.index(exceptionProperties)};`; },
   function (d, b) { return cat([makeId(d, b), " = ", makeId(d, b), ";"]); },
   function (d, b) { return cat([makeLValue(d, b), " = ", makeId(d, b), ";"]); },
 
   // Iteration is also useful to test because it asserts that there is no pending exception.
-  function (d, b) { var v = makeNewId(d, b); return "for(let " + v + " in []);"; },
-  function (d, b) { var v = makeNewId(d, b); return "for(let " + v + " in " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
-  function (d, b) { var v = makeNewId(d, b); return "for(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
-  function (d, b) { var v = makeNewId(d, b); return "for await(let " + v + " of " + makeIterable(d, b) + ") " + makeExceptionyStatement(d, b.concat([v])); },
+  function (d, b) { var v = makeNewId(d, b); return `for(let ${v} in []);`; },
+  function (d, b) { var v = makeNewId(d, b); return `for(let ${v} in ${makeIterable(d, b)}) ${makeExceptionyStatement(d, b.concat([v]))}`; },
+  function (d, b) { var v = makeNewId(d, b); return `for(let ${v} of ${makeIterable(d, b)}) ${makeExceptionyStatement(d, b.concat([v]))}`; },
+  function (d, b) { var v = makeNewId(d, b); return `for await(let ${v} of ${makeIterable(d, b)}) ${makeExceptionyStatement(d, b.concat([v]))}`; },
 
   /* eslint-disable no-multi-spaces */
   // Brendan says these are scary places to throw: with, let block, lambda called immediately in let expr.
   // And I think he was right.
-  function (d, b) { return "with({}) "   + makeExceptionyStatement(d, b);         },
-  function (d, b) { return "with({}) { " + makeExceptionyStatement(d, b) + " } "; },
-  function (d, b) { var v = makeNewId(d, b); return "let(" + v + ") { " + makeExceptionyStatement(d, b.concat([v])) + "}"; },
-  function (d, b) { var v = makeNewId(d, b); return "let(" + v + ") ((function(){" + makeExceptionyStatement(d, b.concat([v])) + "})());"; },
-  function (d, b) { return "let(" + makeLetHead(d, b) + ") { " + makeExceptionyStatement(d, b) + "}"; },
-  function (d, b) { return "let(" + makeLetHead(d, b) + ") ((function(){" + makeExceptionyStatement(d, b) + "})());"; }
+  function (d, b) { return `with({}) ${makeExceptionyStatement(d, b)}`;         },
+  function (d, b) { return `with({}) { ${makeExceptionyStatement(d, b)} } `; },
+  function (d, b) { var v = makeNewId(d, b); return `let(${v}) { ${makeExceptionyStatement(d, b.concat([v]))}}`; },
+  function (d, b) { var v = makeNewId(d, b); return `let(${v}) ((function(){${makeExceptionyStatement(d, b.concat([v]))}})());`; },
+  function (d, b) { return `let(${makeLetHead(d, b)}) { ${makeExceptionyStatement(d, b)}}`; },
+  function (d, b) { return `let(${makeLetHead(d, b)}) ((function(){${makeExceptionyStatement(d, b)}})());`; }
   /* eslint-enable no-multi-spaces */
 
   // Commented out due to causing too much noise on stderr and causing a nonzero exit code :/
 /*
   // Generator close hooks: called during GC in this case!!!
-  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " } finally { " + makeStatement(d, b) + " } })().next()"; },
+  function(d, b) { return `(function () { try { yield ${makeExpr(d, b)} } finally { ${makeStatement(d, b)} } })().next()`; },
 
-  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " } finally { " + makeStatement(d, b) + " } })()"; },
-  function(d, b) { return "(function () { try { yield " + makeExpr(d, b) + " } finally { " + makeStatement(d, b) + " } })"; },
+  function(d, b) { return `(function () { try { yield ${makeExpr(d, b)} } finally { ${makeStatement(d, b)} } })()`; },
+  function(d, b) { return `(function () { try { yield ${makeExpr(d, b)} } finally { ${makeStatement(d, b)} } })`; },
   function(d, b) {
-    return "function gen() { try { yield 1; } finally { " + makeStatement(d, b) + " } } var i = gen(); i.next(); i = null;";
+    return `function gen() { try { yield 1; } finally { ${makeStatement(d, b)} } } var i = gen(); i.next(); i = null;`;
   }
 
 */
@@ -675,7 +675,7 @@ function makeExpr (d, b) { /* eslint-disable-line require-jsdoc */
 
   var expr = (Random.index(exprMakers))(d, b);
 
-  if (rnd(4) === 1) { return "(" + expr + ")"; } else { return expr; }
+  if (rnd(4) === 1) { return `(${expr})`; } else { return expr; }
 }
 
 var binaryOps = [
@@ -712,13 +712,13 @@ var specialProperties = [
 /*
 function addPropertyName(p)
 {
-  p = "" + p;
+  p = `${p}`;
   if (
-      p != "floor" &&
-      p != "random" &&
-      p != "parent" && // unsafe spidermonkey shell function, see bug 619064
+      p !== "floor" &&
+      p !== "random" &&
+      p !== "parent" && // unsafe spidermonkey shell function, see bug 619064
       true) {
-    print("Adding: " + p);
+    print(`Adding: ${p}`);
     allPropertyNames.push(p);
   }
 }
@@ -792,7 +792,7 @@ var exprMakers =
 
   // Functions: called immediately/not
   function (d, b) { return makeFunction(d, b); },
-  function (d, b) { return makeFunction(d, b) + ".prototype"; },
+  function (d, b) { return `${makeFunction(d, b)}.prototype`; },
   function (d, b) { return cat(["(", makeFunction(d, b), ")", "(", makeActualArgList(d, b), ")"]); },
 
   // Try to call things that may or may not be functions.
@@ -868,7 +868,7 @@ var exprMakers =
   function (d, b) { return cat(["(", "{", makeObjLiteralPart(d, b), ", ", makeObjLiteralPart(d, b), " }", ")"]); },
 
   // Test js_ReportIsNotFunction heavily.
-  function (d, b) { return "(p={}, (p.z = " + makeExpr(d, b) + ")())"; },
+  function (d, b) { return `(p={}, (p.z = ${makeExpr(d, b)})())`; },
 
   // Test js_ReportIsNotFunction heavily.
   // Test decompilation for ".keyword" a bit.
@@ -878,37 +878,37 @@ var exprMakers =
 
   // Test eval in various contexts. (but avoid clobbering eval)
   // Test the special "obj.eval" and "eval(..., obj)" forms.
-  function (d, b) { return makeExpr(d, b) + ".eval(" + uneval(makeScriptForEval(d, b)) + ")"; },
-  function (d, b) { return "eval(" + uneval(makeScriptForEval(d, b)) + ")"; },
-  function (d, b) { return "eval(" + uneval(makeScriptForEval(d, b)) + ", " + makeExpr(d, b) + ")"; },
+  function (d, b) { return `${makeExpr(d, b)}.eval(${uneval(makeScriptForEval(d, b))})`; },
+  function (d, b) { return `eval(${uneval(makeScriptForEval(d, b))})`; },
+  function (d, b) { return `eval(${uneval(makeScriptForEval(d, b))}, ${makeExpr(d, b)})`; },
 
   // Uneval needs more testing than it will get accidentally.  No cat() because I don't want uneval clobbered (assigned to) accidentally.
-  function (d, b) { return "(uneval(" + makeExpr(d, b) + "))"; },
+  function (d, b) { return `(uneval(${makeExpr(d, b)}))`; },
 
   /* eslint-disable no-multi-spaces */
   // Constructors.  No cat() because I don't want to screw with the constructors themselves, just call them.
-  function (d, b) { return "new " + Random.index(constructors) + "(" + makeActualArgList(d, b) + ")"; },
-  function (d, b) { return          Random.index(constructors) + "(" + makeActualArgList(d, b) + ")"; },
+  function (d, b) { return `new ${Random.index(constructors)}(${makeActualArgList(d, b)})`; },
+  function (d, b) { return     `${Random.index(constructors)}(${makeActualArgList(d, b)})`; },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // Unary Math functions
-  function (d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeExpr(d, b)   + ")"; },
-  function (d, b) { return "Math." + Random.index(unaryMathFunctions) + "(" + makeNumber(d, b) + ")"; },
+  function (d, b) { return `Math.${Random.index(unaryMathFunctions)}(${makeExpr(d, b)})`; },
+  function (d, b) { return `Math.${Random.index(unaryMathFunctions)}(${makeNumber(d, b)})`; },
   /* eslint-enable no-multi-spaces */
 
   /* eslint-disable no-multi-spaces */
   // Binary Math functions
-  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeExpr(d, b)   + ")"; },
-  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeExpr(d, b)   + ", " + makeNumber(d, b) + ")"; },
-  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeExpr(d, b)   + ")"; },
-  function (d, b) { return "Math." + Random.index(binaryMathFunctions) + "(" + makeNumber(d, b) + ", " + makeNumber(d, b) + ")"; },
+  function (d, b) { return `Math.${Random.index(binaryMathFunctions)}(${makeExpr(d, b)}, ${makeExpr(d, b)})`; },
+  function (d, b) { return `Math.${Random.index(binaryMathFunctions)}(${makeExpr(d, b)}, ${makeNumber(d, b)})`; },
+  function (d, b) { return `Math.${Random.index(binaryMathFunctions)}(${makeNumber(d, b)}, ${makeExpr(d, b)})`; },
+  function (d, b) { return `Math.${Random.index(binaryMathFunctions)}(${makeNumber(d, b)}, ${makeNumber(d, b)})`; },
   /* eslint-enable no-multi-spaces */
 
   // Harmony proxy creation: object, function without constructTrap, function with constructTrap
-  function (d, b) { return makeId(d, b) + " = " + "Proxy.create(" + makeProxyHandler(d, b) + ", " + makeExpr(d, b) + ")"; },
-  function (d, b) { return makeId(d, b) + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ")"; },
-  function (d, b) { return makeId(d, b) + " = " + "Proxy.createFunction(" + makeProxyHandler(d, b) + ", " + makeFunction(d, b) + ", " + makeFunction(d, b) + ")"; },
+  function (d, b) { return `${makeId(d, b)} = Proxy.create(${makeProxyHandler(d, b)}, ${makeExpr(d, b)})`; },
+  function (d, b) { return `${makeId(d, b)} = Proxy.createFunction(${makeProxyHandler(d, b)}, ${makeFunction(d, b)})`; },
+  function (d, b) { return `${makeId(d, b)} = Proxy.createFunction(${makeProxyHandler(d, b)}, ${makeFunction(d, b)}, ${makeFunction(d, b)})`; },
 
   function (d, b) { return cat(["delete", " ", makeId(d, b), ".", makeId(d, b)]); },
 
@@ -920,9 +920,9 @@ var exprMakers =
 
   // More special Spidermonkey shell functions
   // (Note: functions without returned objects or visible side effects go in testing-functions.js, in order to allow presence/absence differential testing.)
-  function(d, b) { return "dumpObject(" + makeExpr(d, b) + ")" } },
-  function (d, b) { return "(void shapeOf(" + makeExpr(d, b) + "))"; },
-  function (d, b) { return "intern(" + makeExpr(d, b) + ")"; },
+  function(d, b) { return `dumpObject(${makeExpr(d, b)})`; },
+  function (d, b) { return `(void shapeOf(${makeExpr(d, b)}))`; },
+  function (d, b) { return `intern(${makeExpr(d, b)})`; },
   function (d, b) { return "allocationMarker()"; },
   function (d, b) { return "timeout(1800)"; }, // see https://bugzilla.mozilla.org/show_bug.cgi?id=840284#c12 -- replace when bug 831046 is fixed
   function (d, b) { return "(makeFinalizeObserver('tenured'))"; },
@@ -948,7 +948,7 @@ function makeTestingFunctionCall (d, b) { /* eslint-disable-line require-jsdoc *
 
   // Set the 'last expression evaluated' to undefined, in case we're in an eval
   // context, and the function throws in one run but not in another.
-  var callBlock = "{ void 0; " + callStatement + " }";
+  var callBlock = `{ void 0; ${callStatement} }`;
 
   if (jsshell && rnd(5) === 0) {
     // Differential testing hack!
@@ -963,8 +963,8 @@ function makeTestingFunctionCall (d, b) { /* eslint-disable-line require-jsdoc *
     // * The extra braces prevent a stray "else" from being associated with this "if".
     // * The 'void 0' at the end ensures the last expression-statement is consistent
     //     (needed because |eval| returns that as its result)
-    var cond = (rnd(2) ? "!" : "") + "isAsmJSCompilationAvailable()";
-    return "{ if (" + cond + ") " + callBlock + " void 0; }";
+    var cond = `${rnd(2) ? "!" : ""}isAsmJSCompilationAvailable()`;
+    return `{ if (${cond}) ${callBlock} void 0; }`;
   }
 
   return callBlock;
@@ -975,8 +975,8 @@ function makeTestingFunctionCall (d, b) { /* eslint-disable-line require-jsdoc *
 if (typeof evalcx === "function") {
   exprMakers = exprMakers.concat([
     function (d, b) { return makeGlobal(d, b); },
-    function (d, b) { return "evalcx(" + uneval(makeScriptForEval(d, b)) + ", " + makeExpr(d, b) + ")"; },
-    function (d, b) { return "evalcx(" + uneval(makeScriptForEval(d, b)) + ", " + makeGlobal(d, b) + ")"; }
+    function (d, b) { return `evalcx(${uneval(makeScriptForEval(d, b))}, ${makeExpr(d, b)})`; },
+    function (d, b) { return `evalcx(${uneval(makeScriptForEval(d, b))}, ${makeGlobal(d, b)})`; }
   ]);
 }
 
@@ -985,16 +985,16 @@ if (typeof evalcx === "function") {
 if (typeof evalInWorker === "function") {
   exprMakers = exprMakers.concat([
     function (d, b) { return makeGlobal(d, b); },
-    function (d, b) { return "evalInWorker(" + uneval(makeScriptForEval(d, b)) + ")"; },
-    function (d, b) { return "evalInWorker(" + uneval(makeScriptForEval(d, b)) + ")"; }
+    function (d, b) { return `evalInWorker(${uneval(makeScriptForEval(d, b))})`; },
+    function (d, b) { return `evalInWorker(${uneval(makeScriptForEval(d, b))})`; }
   ]);
 }
 
 // xpcshell (but not SpiderMonkey shell) has some XPC wrappers available.
 if (typeof XPCNativeWrapper === "function") {
   exprMakers = exprMakers.extend([
-    function (d, b) { return "new XPCNativeWrapper(" + makeExpr(d, b) + ")"; },
-    function (d, b) { return "new XPCSafeJSObjectWrapper(" + makeExpr(d, b) + ")"; }
+    function (d, b) { return `new XPCNativeWrapper(${makeExpr(d, b)})`; },
+    function (d, b) { return `new XPCSafeJSObjectWrapper(${makeExpr(d, b)})`; }
   ]);
 }
 
@@ -1003,13 +1003,13 @@ function makeNewGlobalArg (d, b) { /* eslint-disable-line require-jsdoc */
 
   // Make an options object to pass to the |newGlobal| shell builtin.
   var propStrs = [];
-  if (rnd(2)) { propStrs.push("newCompartment: " + makeBoolean(d - 1, b)); }
-  if (rnd(2)) { propStrs.push("sameCompartmentAs: " + makeExpr(d - 1, b)); }
-  if (rnd(2)) { propStrs.push("sameZoneAs: " + makeExpr(d - 1, b)); }
-  if (rnd(2)) { propStrs.push("cloneSingletons: " + makeBoolean(d - 1, b)); }
-  if (rnd(2)) { propStrs.push("disableLazyParsing: " + makeBoolean(d - 1, b)); }
-  if (rnd(2)) { propStrs.push("invisibleToDebugger: " + makeBoolean(d - 1, b)); }
-  return "{ " + propStrs.join(", ") + " }";
+  if (rnd(2)) { propStrs.push(`newCompartment: ${makeBoolean(d - 1, b)}`); }
+  if (rnd(2)) { propStrs.push(`sameCompartmentAs: ${makeExpr(d - 1, b)}`); }
+  if (rnd(2)) { propStrs.push(`sameZoneAs: ${makeExpr(d - 1, b)}`); }
+  if (rnd(2)) { propStrs.push(`cloneSingletons: ${makeBoolean(d - 1, b)}`); }
+  if (rnd(2)) { propStrs.push(`disableLazyParsing: ${makeBoolean(d - 1, b)}`); }
+  if (rnd(2)) { propStrs.push(`invisibleToDebugger: ${makeBoolean(d - 1, b)}`); }
+  return `{ ${propStrs.join(", ")} }`;
 }
 
 function makeGlobal (d, b) { /* eslint-disable-line require-jsdoc */
@@ -1022,23 +1022,23 @@ function makeGlobal (d, b) { /* eslint-disable-line require-jsdoc */
     /* eslint-disable no-multi-spaces */
     case 0:  gs = "evalcx('')"; break;
     case 1:  gs = "evalcx('lazy')"; break;
-    default: gs = "newGlobal(" + makeNewGlobalArg(d - 1, b) + ")"; break;
+    default: gs = `newGlobal(${makeNewGlobalArg(d - 1, b)})`; break;
     /* eslint-enable no-multi-spaces */
   }
 
-  if (rnd(2)) { gs = "fillShellSandbox(" + gs + ")"; }
+  if (rnd(2)) { gs = `fillShellSandbox(${gs})`; }
 
   return gs;
 }
 
 if (xpcshell) {
   exprMakers = exprMakers.concat([
-    function (d, b) { var n = rnd(4); return "newGeckoSandbox(" + n + ")"; },
-    function (d, b) { var n = rnd(4); return "s" + n + " = newGeckoSandbox(" + n + ")"; },
+    function (d, b) { var n = rnd(4); return `newGeckoSandbox(${n})`; },
+    function (d, b) { var n = rnd(4); return `s${n} = newGeckoSandbox(${n})`; },
     // FIXME: Doesn't this need to be Components.utils.evalInSandbox?
-    function (d, b) { var n = rnd(4); return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", newGeckoSandbox(" + n + "))"; },
-    function (d, b) { var n = rnd(4); return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", s" + n + ")"; },
-    function (d, b) { return "evalInSandbox(" + uneval(makeStatement(d, b)) + ", " + makeExpr(d, b) + ")"; },
+    function (d, b) { var n = rnd(4); return `evalInSandbox(${uneval(makeStatement(d, b))}, newGeckoSandbox(${n}))`; },
+    function (d, b) { var n = rnd(4); return `evalInSandbox(${uneval(makeStatement(d, b))}, s${n})`; },
+    function (d, b) { return `evalInSandbox(${uneval(makeStatement(d, b))}, ${makeExpr(d, b)})`; },
     function (d, b) { return "(Components.classes ? quit() : gc()); }"; }
   ]);
 }
@@ -1047,7 +1047,7 @@ function makeShapeyConstructor (d, b) { /* eslint-disable-line require-jsdoc */
   if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
   var argName = uniqueVarName();
   var t = rnd(4) ? "this" : argName;
-  var funText = "function shapeyConstructor(" + argName + "){" + directivePrologue();
+  var funText = `function shapeyConstructor(${argName}){${directivePrologue()}`;
   var bp = b.concat([argName]);
 
   var nPropNames = rnd(6) + 1;
@@ -1059,32 +1059,32 @@ function makeShapeyConstructor (d, b) { /* eslint-disable-line require-jsdoc */
   var nStatements = rnd(11);
   for (var j = 0; j < nStatements; ++j) {
     var propName = Random.index(propNames);
-    var tprop = t + "[" + propName + "]";
+    var tprop = `${t}[${propName}]`;
     if (rnd(5) === 0) {
-      funText += "if (" + (rnd(2) ? argName : makeExpr(d, bp)) + ") ";
+      funText += `if (${rnd(2) ? argName : makeExpr(d, bp)}) `;
     }
     switch (rnd(8)) {
       /* eslint-disable no-multi-spaces */
-      case 0:  funText += "delete " + tprop + ";"; break;
-      case 1:  funText += "Object.defineProperty(" + t + ", " + (rnd(2) ? propName : makePropertyName(d, b)) + ", " + makePropertyDescriptor(d, bp) + ");"; break;
-      case 2:  funText += "{ " + makeStatement(d, bp) + " } "; break;
-      case 3:  funText += tprop + " = " + makeExpr(d, bp)        + ";"; break;
-      case 4:  funText += tprop + " = " + makeFunction(d, bp)    + ";"; break;
-      case 5:  funText += "for (var ytq" + uniqueVarName() + " in " + t + ") { }"; break;
-      case 6:  funText += "Object." + Random.index(["preventExtensions", "seal", "freeze"]) + "(" + t + ");"; break;
-      default: funText += tprop + " = " + makeShapeyValue(d, bp) + ";"; break;
+      case 0:  funText += `delete ${tprop};`; break;
+      case 1:  funText += `Object.defineProperty(${t}, ${rnd(2) ? propName : makePropertyName(d, b)}, ${makePropertyDescriptor(d, bp)});`; break;
+      case 2:  funText += `{ ${makeStatement(d, bp)} } `; break;
+      case 3:  funText += `${tprop} = ${makeExpr(d, bp)};`; break;
+      case 4:  funText += `${tprop} = ${makeFunction(d, bp)};`; break;
+      case 5:  funText += `for (var ytq${uniqueVarName()} in ${t}) { }`; break;
+      case 6:  funText += `Object.${Random.index(["preventExtensions", "seal", "freeze"])}(${t});`; break;
+      default: funText += `${tprop} = ${makeShapeyValue(d, bp)};`; break;
       /* eslint-enable no-multi-spaces */
     }
   }
-  funText += "return " + t + "; }";
+  funText += `return ${t}; }`;
   return funText;
 }
 
 var propertyNameMakers = Random.weighted([
   { w: 1, v: function (d, b) { return makeExpr(d - 1, b); } },
   { w: 1, v: function (d, b) { return maybeNeg() + rnd(20); } },
-  { w: 1, v: function (d, b) { return '"' + maybeNeg() + rnd(20) + '"'; } },
-  { w: 1, v: function (d, b) { return "new String(" + '"' + maybeNeg() + rnd(20) + '"' + ")"; } },
+  { w: 1, v: function (d, b) { return `"${maybeNeg()}${rnd(20)}"`; } },
+  { w: 1, v: function (d, b) { return `new String("${maybeNeg()}${rnd(20)}")`; } },
   { w: 5, v: function (d, b) { return simpleSource(Random.index(specialProperties)); } },
   { w: 1, v: function (d, b) { return simpleSource(makeId(d - 1, b)); } },
   { w: 5, v: function (d, b) { return simpleSource(Random.index(allMethodNames)); } }
@@ -1104,12 +1104,12 @@ function makeShapeyConstructorLoop (d, b) { /* eslint-disable-line require-jsdoc
   var v2 = uniqueVarName(d, b);
   var bvv = b.concat([v, v2]);
   return makeShapeyConstructor(d - 1, b) +
-    "/*tLoopC*/for (let " + v + " of " + a + ") { " +
+    `/*tLoopC*/for (let ${v} of ${a}) { ` +
      "try{" +
-       "let " + v2 + " = " + Random.index(["new ", ""]) + "shapeyConstructor(" + v + "); print('EETT'); " +
-       // "print(uneval(" + v2 + "));" +
+      `let ${v2} = ${Random.index(["new ", ""])}shapeyConstructor(${v}); print('EETT'); ` +
+      // `print(uneval(${v2}));` +
        makeStatement(d - 2, bvv) +
-     "}catch(e){print('TTEE ' + e); }" +
+     `}catch(e){print('TTEE ' + e); }` +
   " }";
 }
 
@@ -1121,19 +1121,19 @@ function makePropertyDescriptor (d, b) { /* eslint-disable-line require-jsdoc */
   switch (rnd(3)) {
     case 0:
     // Data descriptor. Can have 'value' and 'writable'.
-      if (rnd(2)) s += "value: " + makeExpr(d, b) + ", ";
-      if (rnd(2)) s += "writable: " + makeBoolean(d, b) + ", ";
+      if (rnd(2)) s += `value: ${makeExpr(d, b)}, `;
+      if (rnd(2)) s += `writable: ${makeBoolean(d, b)}, `;
       break;
     case 1:
     // Accessor descriptor. Can have 'get' and 'set'.
-      if (rnd(2)) s += "get: " + makeFunction(d, b) + ", ";
-      if (rnd(2)) s += "set: " + makeFunction(d, b) + ", ";
+      if (rnd(2)) s += `get: ${makeFunction(d, b)}, `;
+      if (rnd(2)) s += `set: ${makeFunction(d, b)}, `;
       break;
     default:
   }
 
-  if (rnd(2)) s += "configurable: " + makeBoolean(d, b) + ", ";
-  if (rnd(2)) s += "enumerable: " + makeBoolean(d, b) + ", ";
+  if (rnd(2)) s += `configurable: ${makeBoolean(d, b)}, `;
+  if (rnd(2)) s += `enumerable: ${makeBoolean(d, b)}, `;
 
   // remove trailing comma
   if (s.length > 2) { s = s.substr(0, s.length - 2); }
@@ -1149,7 +1149,7 @@ function makeBoolean (d, b) { /* eslint-disable-line require-jsdoc */
     case 0:   return "true";
     case 1:   return "false";
     case 2:   return makeExpr(d - 2, b);
-    default:  var m = loopModulo(); return "(" + Random.index(b) + " % " + m + Random.index([" == ", " != "]) + rnd(m) + ")";
+    default:  var m = loopModulo(); return `(${Random.index(b)} % ${m}${Random.index([" == ", " != "])}${rnd(m)})`;
     /* eslint-enable no-multi-spaces */
   }
 }
@@ -1164,7 +1164,7 @@ function makeObjLiteralPart (d, b) { /* eslint-disable-line require-jsdoc */
     case 2: return cat([" get ", makeObjLiteralName(d, b), maybeName(d, b), "(", makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)]);
     case 3: return cat([" set ", makeObjLiteralName(d, b), maybeName(d, b), "(", makeFormalArgList(d - 1, b), ")", makeFunctionBody(d, b)]);
 
-    case 4: return "/*toXFun*/" + cat([Random.index(["toString", "valueOf"]), ": ", makeToXFunction(d - 1, b)]);
+    case 4: return `/*toXFun*/${cat([Random.index(["toString", "valueOf"]), ": ", makeToXFunction(d - 1, b)])}`;
 
     default: return cat([makeObjLiteralName(d, b), ": ", makeExpr(d, b)]);
   }
@@ -1175,7 +1175,7 @@ function makeToXFunction (d, b) { /* eslint-disable-line require-jsdoc */
 
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */
-    case 0:  return "function() { return " + makeExpr(d, b) + "; }";
+    case 0:  return `function() { return ${makeExpr(d, b)}; }`;
     case 1:  return "function() { return this; }";
     case 2:  return makeEvilCallback(d, b);
     default: return makeFunction(d, b);
@@ -1210,7 +1210,7 @@ function makeFunction (d, b) { /* eslint-disable-line require-jsdoc */
 }
 
 function maybeName (d, b) { /* eslint-disable-line require-jsdoc */
-  if (rnd(2) === 0) { return " " + makeId(d, b) + " "; } else { return ""; }
+  if (rnd(2) === 0) { return ` ${makeId(d, b)} `; } else { return ""; }
 }
 
 function directivePrologue () { /* eslint-disable-line require-jsdoc */
@@ -1229,7 +1229,7 @@ function makeFunctionBody (d, b) { /* eslint-disable-line require-jsdoc */
     case 1:  return cat([" { ", directivePrologue(), "return ", makeExpr(d, b), " } "]);
     case 2:  return cat([" { ", directivePrologue(), "yield ",  makeExpr(d, b), " } "]);
     case 3:  return cat([" { ", directivePrologue(), "await ",  makeExpr(d, b), " } "]);
-    case 4:  return '"use asm"; ' + asmJSInterior([]);
+    case 4:  return `"use asm"; ${asmJSInterior([])}`;
     default: return makeExpr(d, b); // make an "expression closure"
     /* eslint-enable no-multi-spaces */
   }
@@ -1263,44 +1263,44 @@ var functionMakers = [
   /* eslint-enable no-multi-spaces */
 
   // The identity function
-  function (d, b) { return functionPrefix() + "(q) { " + directivePrologue() + "return q; }"; },
+  function (d, b) { return `${functionPrefix()}(q) { ${directivePrologue()}return q; }`; },
   function (d, b) { return "q => q"; },
 
   // A function that does something
-  function (d, b) { return functionPrefix() + "(y) { " + directivePrologue() + makeStatement(d, b.concat(["y"])) + " }"; },
+  function (d, b) { return `${functionPrefix()}(y) { ${directivePrologue()}${makeStatement(d, b.concat(["y"]))} }`; },
 
   // A function that computes something
-  function (d, b) { return functionPrefix() + "(y) { " + directivePrologue() + "return " + makeExpr(d, b.concat(["y"])) + " }"; },
+  function (d, b) { return `${functionPrefix()}(y) { ${directivePrologue()}return ${makeExpr(d, b.concat(["y"]))} }`; },
 
   // A generator that does something
-  function (d, b) { return "function(y) { " + directivePrologue() + "yield y; " + makeStatement(d, b.concat(["y"])) + "; yield y; }"; },
-  function (d, b) { return "function*(y) { " + directivePrologue() + "yield y; " + makeStatement(d, b.concat(["y"])) + "; yield y; }"; },
+  function (d, b) { return `function(y) { ${directivePrologue()}yield y; ${makeStatement(d, b.concat(["y"]))}; yield y; }`; },
+  function (d, b) { return `function*(y) { ${directivePrologue()}yield y; ${makeStatement(d, b.concat(["y"]))}; yield y; }`; },
 
   // An async function that does something
-  function (d, b) { return "async function (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
+  function (d, b) { return `async function (y) { ${directivePrologue()}await y; ${makeStatement(d, b.concat(["y"]))}; await y; }`; },
 
   // An async generator that does something
-  function (d, b) { return "async function* (y) { " + directivePrologue() + "await y; " + makeStatement(d, b.concat(["y"])) + "; await y; }"; },
-  function (d, b) { return "async function* (y) { " + directivePrologue() + "yield y; await y; " + makeStatement(d, b.concat(["y"])) + "; yield y; await y; }"; },
+  function (d, b) { return `async function* (y) { ${directivePrologue()}await y; ${makeStatement(d, b.concat(["y"]))}; await y; }`; },
+  function (d, b) { return `async function* (y) { ${directivePrologue()}yield y; await y; ${makeStatement(d, b.concat(["y"]))}; yield y; await y; }`; },
 
   // A simple wrapping pattern
-  function (d, b) { return "/*wrap1*/(" + functionPrefix() + "(){ " + directivePrologue() + makeStatement(d, b) + "return " + makeFunction(d, b) + "})()"; },
+  function (d, b) { return `/*wrap1*/(${functionPrefix()}(){ ${directivePrologue()}${makeStatement(d, b)}return ${makeFunction(d, b)}})()`; },
 
   // Wrapping with upvar: escaping, may or may not be modified
-  function (d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return "/*wrap2*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; var " + v2 + " = " + makeFunction(d, b.concat([v1])) + "; return " + v2 + ";})()"; },
+  function (d, b) { var v1 = uniqueVarName(); var v2 = uniqueVarName(); return `/*wrap2*/(${functionPrefix()}(){ ${directivePrologue()}var ${v1} = ${makeExpr(d, b)}; var ${v2} = ${makeFunction(d, b.concat([v1]))}; return ${v2};})()`; },
 
   /* eslint-disable no-multi-spaces */
   // Wrapping with upvar: non-escaping
-  function (d, b) { var v1 = uniqueVarName();                           return "/*wrap3*/(" + functionPrefix() + "(){ " + directivePrologue() + "var " + v1 + " = " + makeExpr(d, b) + "; (" + makeFunction(d, b.concat([v1])) + ")(); })"; },
+  function (d, b) { var v1 = uniqueVarName();                           return `/*wrap3*/(${functionPrefix()}(){ ${directivePrologue()}var ${v1} = ${makeExpr(d, b)}; (${makeFunction(d, b.concat([v1]))})(); })`; },
   /* eslint-enable no-multi-spaces */
 
   // Apply, call
-  function (d, b) { return "(" + makeFunction(d - 1, b) + ").apply"; },
-  function (d, b) { return "(" + makeFunction(d - 1, b) + ").call"; },
+  function (d, b) { return `(${makeFunction(d - 1, b)}).apply`; },
+  function (d, b) { return `(${makeFunction(d - 1, b)}).call`; },
 
   // Bind
-  function (d, b) { return "(" + makeFunction(d - 1, b) + ").bind"; },
-  function (d, b) { return "(" + makeFunction(d - 1, b) + ").bind(" + makeActualArgList(d, b) + ")"; },
+  function (d, b) { return `(${makeFunction(d - 1, b)}).bind`; },
+  function (d, b) { return `(${makeFunction(d - 1, b)}).bind(${makeActualArgList(d, b)})`; },
 
   // Methods with known names
   function (d, b) { return cat([makeExpr(d, b), ".", Random.index(allMethodNames)]); },
@@ -1309,7 +1309,7 @@ var functionMakers = [
   function (d, b) { return "eval"; }, // eval is interesting both for its "no indirect calls" feature and for the way it's implemented in spidermonkey (a special bytecode).
   function (d, b) { return "(let (e=eval) e)"; },
   function (d, b) { return "new Function"; }, // this won't be interpreted the same way for each caller of makeFunction, but that's ok
-  function (d, b) { return "(new Function(" + uneval(makeStatement(d, b)) + "))"; },
+  function (d, b) { return `(new Function(${uneval(makeStatement(d, b))}))`; },
   function (d, b) { return "Function"; }, // without "new"
   function (d, b) { return "decodeURI"; },
   function (d, b) { return "decodeURIComponent"; },
@@ -1359,18 +1359,18 @@ function makeTypedArrayStatements (d, b) { /* eslint-disable-line require-jsdoc 
   var numExtraStatements = rnd(d) + 1;
   var buffer = uniqueVarName();
   var bufferSize = (1 + rnd(2)) * (1 + rnd(2)) * (1 + rnd(2)) * rnd(5);
-  var statements = "var " + buffer + " = new " + arrayBufferType() + "(" + bufferSize + "); ";
+  var statements = `var ${buffer} = new ${arrayBufferType()}(${bufferSize}); `;
   var bv = b.concat([buffer]);
   for (var j = 0; j < numViews; ++j) {
-    var view = buffer + "_" + j;
+    var view = `${buffer}_${j}`;
     var type = Random.index(typedArrayConstructors);
-    statements += "var " + view + " = new " + type + "(" + buffer + "); ";
+    statements += `var ${view} = new ${type}(${buffer}); `;
     bv.push(view);
-    var viewZero = view + "[0]";
+    var viewZero = `${view}[0]`;
     bv.push(viewZero);
-    if (rnd(3) === 0) { statements += "print(" + viewZero + "); "; }
-    if (rnd(3)) { statements += viewZero + " = " + makeNumber(d - 2, b) + "; "; }
-    bv.push(view + "[" + rnd(11) + "]");
+    if (rnd(3) === 0) { statements += `print(${viewZero}); `; }
+    if (rnd(3)) { statements += `${viewZero} = ${makeNumber(d - 2, b)}; `; }
+    bv.push(`${view}[${rnd(11)}]`);
   }
   for (var k = 0; k < numExtraStatements; ++k) {
     statements += makeStatement(d - numExtraStatements, bv);
@@ -1386,10 +1386,10 @@ function makeNumber (d, b) { /* eslint-disable-line require-jsdoc */
   switch (rnd(60)) {
     /* eslint-disable no-multi-spaces */
     case 0:  return makeExpr(d - 2, b);
-    case 1:  return signStr + "0";
-    case 2:  return signStr + (rnd(1000) / 1000);
-    case 3:  return signStr + (rnd(0xffffffff) / 2);
-    case 4:  return signStr + rnd(0xffffffff);
+    case 1:  return `${signStr}0`;
+    case 2:  return `${signStr}${rnd(1000) / 1000}`;
+    case 3:  return `${signStr}${rnd(0xffffffff) / 2}`;
+    case 4:  return `${signStr}${rnd(0xffffffff)}`;
     case 5:  return Random.index(["0.1", ".2", "3", "1.3", "4.", "5.0000000000000000000000",
       "1.2e3", "1e81", "1e+81", "1e-81", "1e4", "0", "-0", "(-0)", "-1", "(-1)", "0x99", "033",
       "3.141592653589793", "3/0", "-3/0", "0/0", "0x2D413CCC", "0x5a827999", "0xB504F332",
@@ -1410,8 +1410,8 @@ function makeNumber (d, b) { /* eslint-disable-line require-jsdoc */
       // See bug 1350097
       "0.000000000000001", "1.7976931348623157e308"
     ]);
-    case 6:  return signStr + (Math.pow(2, rnd(66)) + (rnd(3) - 1));
-    default: return signStr + rnd(30);
+    case 6:  return `${signStr}${Math.pow(2, rnd(66)) + (rnd(3) - 1)}`;
+    default: return `${signStr}${rnd(30)}`;
     /* eslint-enable no-multi-spaces */
   }
 }
@@ -1435,7 +1435,7 @@ function makeLetHeadItem (d, b) { /* eslint-disable-line require-jsdoc */
 
   d = d - 1;
 
-  if (d < 0 || rnd(2) === 0) { return rnd(2) ? uniqueVarName() : makeId(d, b); } else if (rnd(5) === 0) { return makeDestructuringLValue(d, b) + " = " + makeExpr(d, b); } else { return makeId(d, b) + " = " + makeExpr(d, b); }
+  if (d < 0 || rnd(2) === 0) { return rnd(2) ? uniqueVarName() : makeId(d, b); } else if (rnd(5) === 0) { return `${makeDestructuringLValue(d, b)} = ${makeExpr(d, b)}`; } else { return `${makeId(d, b)} = ${makeExpr(d, b)}`; }
 }
 
 function makeActualArgList (d, b) { /* eslint-disable-line require-jsdoc */
@@ -1447,7 +1447,7 @@ function makeActualArgList (d, b) { /* eslint-disable-line require-jsdoc */
 
   var argList = makeExpr(d, b);
 
-  for (var i = 1; i < nArgs; ++i) { argList += ", " + makeExpr(d - i, b); }
+  for (var i = 1; i < nArgs; ++i) { argList += `, ${makeExpr(d - i, b)}`; }
 
   return argList;
 }
@@ -1464,7 +1464,7 @@ function makeFormalArgList (d, b) { /* eslint-disable-line require-jsdoc */
 
   if (rnd(5) === 0) {
     // https://developer.mozilla.org/en-US/docs/JavaScript/Reference/rest_parameters
-    argList.push("..." + makeId(d, b));
+    argList.push(`...${makeId(d, b)}`);
   }
 
   return argList.join(", ");
@@ -1475,7 +1475,7 @@ function makeFormalArg (d, b) { /* eslint-disable-line require-jsdoc */
 
   if (rnd(8) === 1) { return makeDestructuringLValue(d, b); }
 
-  return makeId(d, b) + (rnd(5) ? "" : " = " + makeExpr(d, b));
+  return makeId(d, b) + (rnd(5) ? "" : ` = ${makeExpr(d, b)}`);
 }
 
 function makeNewId (d, b) { /* eslint-disable-line require-jsdoc */
@@ -1503,7 +1503,7 @@ function makeId (d, b) { /* eslint-disable-line require-jsdoc */
     // but that's annoying, and some of these cause lots of syntax errors.
       return Random.index(["get", "set", "getter", "setter", "delete", "let", "yield", "await", "of"]);
     case 11: case 12: case 13:
-      return "this." + makeId(d, b);
+      return `this.${makeId(d, b)}`;
     case 14: case 15: case 16:
       return makeObjLiteralName(d - 1, b);
     case 17: case 18:
@@ -1568,7 +1568,7 @@ var lvalueMakers = [
 
   // Destructuring
   function (d, b) { return makeDestructuringLValue(d, b); },
-  function (d, b) { return "(" + makeDestructuringLValue(d, b) + ")"; },
+  function (d, b) { return `(${makeDestructuringLValue(d, b)})`; },
 
   // Certain functions can act as lvalues!  See JS_HAS_LVALUE_RETURN in js engine source.
   function (d, b) { return cat([makeId(d, b), "(", makeExpr(d, b), ")"]); },
@@ -1581,7 +1581,7 @@ var lvalueMakers = [
   // Arguments object, which can alias named parameters to the function
   function (d, b) { return "arguments"; },
   function (d, b) { return cat(["arguments", "[", makePropertyName(d, b), "]"]); },
-  function (d, b) { return makeFunOnCallChain(d, b) + ".arguments"; }, // read-only arguments object
+  function (d, b) { return `${makeFunOnCallChain(d, b)}.arguments`; }, // read-only arguments object
 
   // Property access / index into array
   function (d, b) { return cat([makeExpr(d, b), ".", makeId(d, b)]); },
@@ -1720,7 +1720,7 @@ function makeCrazyToken () { /* eslint-disable-line require-jsdoc */
     // Some of this is from reading jsscan.h.
 
     // Comments; comments hiding line breaks.
-    "//", UNTERMINATED_COMMENT, (UNTERMINATED_COMMENT + "\n"), "/*\n*/",
+    "//", UNTERMINATED_COMMENT, (`${UNTERMINATED_COMMENT}\n`), "/*\n*/",
 
     // groupers (which will usually be unmatched if they come from here ;)
     "[", "]",
@@ -1871,7 +1871,7 @@ function makeMixedTypeArray (d, b) { /* eslint-disable-line require-jsdoc */
     }
   }
 
-  return "/*MARR*/" + "[" + c.join(", ") + "]";
+  return `/*MARR*/[${c.join(", ")}]`;
 }
 
 function makeArrayLiteral (d, b) { /* eslint-disable-line require-jsdoc */
@@ -1881,7 +1881,7 @@ function makeArrayLiteral (d, b) { /* eslint-disable-line require-jsdoc */
 
   var elems = [];
   while (rnd(5)) elems.push(makeArrayLiteralElem(d, b));
-  return "/*FARR*/" + "[" + elems.join(", ") + "]";
+  return `/*FARR*/[${elems.join(", ")}]`;
 }
 
 function makeArrayLiteralElem (d, b) { /* eslint-disable-line require-jsdoc */
@@ -1889,7 +1889,7 @@ function makeArrayLiteralElem (d, b) { /* eslint-disable-line require-jsdoc */
 
   switch (rnd(5)) {
     /* eslint-disable no-multi-spaces */
-    case 0:  return "..." + makeIterable(d - 1, b); // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Spread_operator
+    case 0:  return `...${makeIterable(d - 1, b)}`; // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Spread_operator
     case 1:  return ""; // hole
     default: return makeExpr(d - 1, b);
     /* eslint-enable no-multi-spaces */
@@ -1906,25 +1906,25 @@ function makeIterable (d, b) { /* eslint-disable-line require-jsdoc */
 
 var iterableExprMakers = Random.weighted([
   // Arrays
-  { w: 1, v: function (d, b) { return "new Array(" + makeNumber(d, b) + ")"; } },
+  { w: 1, v: function (d, b) { return `new Array(${makeNumber(d, b)})`; } },
   { w: 8, v: makeArrayLiteral },
 
   // Array comprehensions (JavaScript 1.7)
   { w: 1, v: function (d, b) { return cat(["[", makeExpr(d, b), makeComprehension(d, b), "]"]); } },
 
   // A generator that yields once
-  { w: 1, v: function (d, b) { return "(function() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },
-  { w: 1, v: function (d, b) { return "(function*() { " + directivePrologue() + "yield " + makeExpr(d - 1, b) + "; } })()"; } },
+  { w: 1, v: function (d, b) { return `(function() { ${directivePrologue()}yield ${makeExpr(d - 1, b)}; } })()`; } },
+  { w: 1, v: function (d, b) { return `(function*() { ${directivePrologue()}yield ${makeExpr(d - 1, b)}; } })()`; } },
   // A pass-through generator
-  { w: 1, v: function (d, b) { return "/*PTHR*/(function() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
-  { w: 1, v: function (d, b) { return "/*PTHR*/(function*() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
+  { w: 1, v: function (d, b) { return `/*PTHR*/(function() { ${directivePrologue()}for (var i of ${makeIterable(d - 1, b)}) { yield i; } })()`; } },
+  { w: 1, v: function (d, b) { return `/*PTHR*/(function*() { ${directivePrologue()}for (var i of ${makeIterable(d - 1, b)}) { yield i; } })()`; } },
 
   // An async function that awaits once
-  { w: 1, v: function (d, b) { return "(async function() { " + directivePrologue() + "await " + makeExpr(d - 1, b) + "; } })()"; } },
+  { w: 1, v: function (d, b) { return `(async function() { ${directivePrologue()}await ${makeExpr(d - 1, b)}; } })()`; } },
 
   // A pass-through async generator
-  { w: 1, v: function (d, b) { return "/*PTHR*/(async function*() { " + directivePrologue() + "for (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
-  { w: 1, v: function (d, b) { return "/*PTHR*/(async function*() { " + directivePrologue() + "for await (var i of " + makeIterable(d - 1, b) + ") { yield i; } })()"; } },
+  { w: 1, v: function (d, b) { return `/*PTHR*/(async function*() { ${directivePrologue()}for (var i of ${makeIterable(d - 1, b)}) { yield i; } })()`; } },
+  { w: 1, v: function (d, b) { return `/*PTHR*/(async function*() { ${directivePrologue()}for await (var i of ${makeIterable(d - 1, b)}) { yield i; } })()`; } },
 
   { w: 1, v: makeFunction },
   { w: 1, v: makeExpr }
@@ -1944,12 +1944,12 @@ function makeAsmJSModule (d, b) { /* eslint-disable-line require-jsdoc */
   if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior([]);
-  return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })";
+  return `(function(stdlib, foreign, heap){ "use asm"; ${interior} })`;
 }
 
 function makeAsmJSFunction (d, b) { /* eslint-disable-line require-jsdoc */
   if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
   var interior = asmJSInterior(["ff"]);
-  return '(function(stdlib, foreign, heap){ "use asm"; ' + interior + " })(this, {ff: " + makeFunction(d - 2, b) + "}, new " + arrayBufferType() + "(4096))";
+  return `(function(stdlib, foreign, heap){ "use asm"; ${interior} })(this, {ff: ${makeFunction(d - 2, b)}}, new ${arrayBufferType()}(4096))`;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-math.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-math.js
@@ -77,7 +77,7 @@ function makeMathFunction (d, b, i) { /* eslint-disable-line require-jsdoc */
     // Also use variables from the enclosing scope
     ivars = ivars.concat(b);
   }
-  return "(function(x, y) { " + directivePrologue() + "return " + makeMathExpr(d, ivars, i) + "; })";
+  return `(function(x, y) { ${directivePrologue()}return ${makeMathExpr(d, ivars, i)}; })`;
 }
 
 function makeMathExpr (d, b, i) { /* eslint-disable-line require-jsdoc */
@@ -101,10 +101,10 @@ function makeMathExpr (d, b, i) { /* eslint-disable-line require-jsdoc */
   function mc (expr) { /* eslint-disable-line require-jsdoc */
     switch (rnd(3) ? commonCoercion : rnd(10)) {
       /* eslint-disable no-multi-spaces */
-      case 0:  return "(" + " + " + expr + ")";     // f64 (asm.js)
-      case 1:  return "Math.fround(" + expr + ")";  // f32
-      case 2:  return "(" + expr + " | 0)";         // i32 (asm.js)
-      case 3:  return "(" + expr + " >>> 0)";       // u32
+      case 0:  return `( + ${expr})`;          // f64 (asm.js)
+      case 1:  return `Math.fround(${expr})`;  // f32
+      case 2:  return `(${expr} | 0)`;         // i32 (asm.js)
+      case 3:  return `(${expr} >>> 0)`;       // u32
       default: return expr;
       /* eslint-enable no-multi-spaces */
     }
@@ -112,19 +112,19 @@ function makeMathExpr (d, b, i) { /* eslint-disable-line require-jsdoc */
 
   if (i > 0 && rnd(10) === 0) {
     // Call a *lower-numbered* mathy function. (This avoids infinite recursion.)
-    return mc("mathy" + rnd(i) + "(" + mc(r()) + ", " + mc(r()) + ")");
+    return mc(`mathy${rnd(i)}(${mc(r())}, ${mc(r())})`);
   }
 
   if (rnd(20) === 0) {
-    return mc("(" + mc(r()) + " ? " + mc(r()) + " : " + mc(r()) + ")");
+    return mc(`(${mc(r())} ? ${mc(r())} : ${mc(r())})`);
   }
 
   switch (rnd(4)) {
     /* eslint-disable no-multi-spaces */
-    case 0:  return mc("(" + mc(r()) + Random.index(binaryMathOps) + mc(r()) + ")");
-    case 1:  return mc("(" + Random.index(leftUnaryMathOps) + mc(r()) + ")");
-    case 2:  return mc("Math." + Random.index(unaryMathFunctions) + "(" + mc(r()) + ")");
-    default: return mc("Math." + Random.index(binaryMathFunctions) + "(" + mc(r()) + ", " + mc(r()) + ")");
+    case 0:  return mc(`(${mc(r())}${Random.index(binaryMathOps)}${mc(r())})`);
+    case 1:  return mc(`(${Random.index(leftUnaryMathOps)}${mc(r())})`);
+    case 2:  return mc(`Math.${Random.index(unaryMathFunctions)}(${mc(r())})`);
+    default: return mc(`Math.${Random.index(binaryMathFunctions)}(${mc(r())}, ${mc(r())})`);
     /* eslint-enable no-multi-spaces */
   }
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-proxy.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-proxy.js
@@ -107,7 +107,7 @@ function makeProxyHandlerFactory (d, b) { /* eslint-disable-line require-jsdoc *
           /* eslint-enable no-multi-spaces */
         }
       }
-      handlerFactoryText += p + ": " + funText + ", ";
+      handlerFactoryText += `${p}: ${funText}, `;
     }
 
     handlerFactoryText += "}; })";
@@ -119,12 +119,12 @@ function makeProxyHandlerFactory (d, b) { /* eslint-disable-line require-jsdoc *
 }
 
 function proxyMunge (funText, p) { /* eslint-disable-line require-jsdoc */
-  // funText = funText.replace(/\{/, "{ var yum = 'PCAL'; dumpln(yum + 'LED: " + p + "');");
+  // funText = funText.replace(/\{/, `{ var yum = 'PCAL'; dumpln(yum + 'LED: ${p}');`);
   return funText;
 }
 
 function makeProxyHandler (d, b) { /* eslint-disable-line require-jsdoc */
   if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
-  return makeProxyHandlerFactory(d, b) + "(" + makeExpr(d - 3, b) + ")";
+  return `${makeProxyHandlerFactory(d, b)}(${makeExpr(d - 3, b)})`;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-recursion.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-recursion.js
@@ -44,28 +44,28 @@ var recursiveFunctions = [
   {
     text: "(function factorial_tail(N, Acc) { @; if (N == 0) { @; return Acc; } @; return factorial_tail(N - 1, Acc * N); @ })",
     vars: ["N", "Acc"],
-    args: function (d, b) { return singleRecursionDepth(d, b) + ", 1"; },
+    args: function (d, b) { return `${singleRecursionDepth(d, b)}, 1`; },
     test: function (f) { return f(10, 1) === 3628800; }
   },
   {
     // two recursive calls
     text: "(function fibonacci(N) { @; if (N <= 1) { @; return 1; } @; return fibonacci(N - 1) + fibonacci(N - 2); @ })",
     vars: ["N"],
-    args: function (d, b) { return "" + rnd(8); },
+    args: function (d, b) { return `${rnd(8)}`; },
     test: function (f) { return f(6) === 13; }
   },
   {
     // do *anything* while indexing over mixed-type arrays
     text: "(function a_indexing(array, start) { @; if (array.length == start) { @; return EXPR1; } var thisitem = array[start]; var recval = a_indexing(array, start + 1); STATEMENT1 })",
     vars: ["array", "start", "thisitem", "recval"],
-    args: function (d, b) { return makeMixedTypeArray(d - 1, b) + ", 0"; },
+    args: function (d, b) { return `${makeMixedTypeArray(d - 1, b)}, 0`; },
     testSub: function (text) { return text.replace(/EXPR1/, "0").replace(/STATEMENT1/, "return thisitem + recval;"); },
     randSub: function (text, varMap, d, b) {
       /* eslint-disable indent, no-multi-spaces */
       var expr1 =      makeExpr(d, b.concat([varMap["array"], varMap["start"]]));
       var statement1 = rnd(2) ?
                                  makeStatement(d, b.concat([varMap["thisitem"], varMap["recval"]]))        :
-                          "return " + makeExpr(d, b.concat([varMap["thisitem"], varMap["recval"]])) + ";";
+                          `return ${makeExpr(d, b.concat([varMap["thisitem"], varMap["recval"]]))};`;
 
       return (text.replace(/EXPR1/,      expr1)
                   .replace(/STATEMENT1/, statement1)
@@ -78,7 +78,7 @@ var recursiveFunctions = [
     // this lets us play a little with mixed-type arrays
     text: "(function sum_indexing(array, start) { @; return array.length == start ? 0 : array[start] + sum_indexing(array, start + 1); })",
     vars: ["array", "start"],
-    args: function (d, b) { return makeMixedTypeArray(d - 1, b) + ", 0"; },
+    args: function (d, b) { return `${makeMixedTypeArray(d - 1, b)}, 0`; },
     test: function (f) { return f([1, 2, 3, "4", 5, 6, 7], 0) === "123418"; }
   },
   {
@@ -91,12 +91,12 @@ var recursiveFunctions = [
 
 function singleRecursionDepth (d, b) { /* eslint-disable-line require-jsdoc */
   if (rnd(2) === 0) {
-    return "" + rnd(4);
+    return `${rnd(4)}`;
   }
   if (rnd(10) === 0) {
     return makeExpr(d - 2, b);
   }
-  return "" + rnd(100000);
+  return `${rnd(100000)}`;
 }
 
 (function testAllRecursiveFunctions () {
@@ -105,7 +105,7 @@ function singleRecursionDepth (d, b) { /* eslint-disable-line require-jsdoc */
     var text = a.text;
     if (a.testSub) text = a.testSub(text);
     var f = eval(text.replace(/@/g, "")); /* eslint-disable-line no-eval */
-    if (!a.test(f)) { throw new Error("Failed test of: " + a.text); }
+    if (!a.test(f)) { throw new Error(`Failed test of: ${a.text}`); }
   }
 })();
 
@@ -121,9 +121,9 @@ function makeImmediateRecursiveCall (d, b, cheat1, cheat2) { /* eslint-disable-l
     s = s.replace(new RegExp(prettyName, "g"), varMap[prettyName]);
   }
   var actualArgs = cheat2 == null ? a.args(d, b) : cheat2;
-  s = s + "(" + actualArgs + ")";
+  s = `${s}(${actualArgs})`;
   s = s.replace(/@/g, function () { if (rnd(4) === 0) return makeStatement(d - 2, b); return ""; });
   if (a.randSub) s = a.randSub(s, varMap, d, b);
-  s = "(" + s + ")";
+  s = `(${s})`;
   return s;
 }

--- a/src/funfuzz/js/jsfunfuzz/gen-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-regex.js
@@ -56,9 +56,9 @@ var regexMakers =
     function (dr) { return regexQuantified(dr, "?", 0, 1); },
     function (dr) { return regexQuantified(dr, "+?", 1, 1); },
     function (dr) { return regexQuantified(dr, "*?", 0, 1); },
-    function (dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + "}", x, x); },
-    function (dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, "{" + x + ",}", x, x + rnd(10)); },
-    function (dr) { var min = regexNumberOfMatches(); var max = min + regexNumberOfMatches(); return regexQuantified(dr, "{" + min + "," + max + "}", min, max); }
+    function (dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, `{${x}}`, x, x); },
+    function (dr) { var x = regexNumberOfMatches(); return regexQuantified(dr, `{${x},}`, x, x + rnd(10)); },
+    function (dr) { var min = regexNumberOfMatches(); var max = min + regexNumberOfMatches(); return regexQuantified(dr, `{${min},${max}}`, min, max); }
   ],
   [
     // Combinations: concatenation, disjunction
@@ -113,7 +113,7 @@ function regexDisjunction (dr) { /* eslint-disable-line require-jsdoc */
     var chance = rnd(100);
     if (chance < 10) { newStrings[i] = ""; } else if (chance < 20) { newStrings[i] = Random.index(strings1) + Random.index(strings2); } else if (chance < 60) { newStrings[i] = strings1[i]; } else { newStrings[i] = strings2[i]; }
   }
-  return [re1 + "|" + re2, newStrings];
+  return [`${re1}|${re2}`, newStrings];
 }
 
 function regexGrouped (prefix, dr, postfix) { /* eslint-disable-line require-jsdoc */
@@ -148,7 +148,7 @@ function regexCharCode () { /* eslint-disable-line require-jsdoc */
 var regexCharacterMakers = Random.weighted([
   // Possibly incorrect
   { w: 20, v: function () { var cc = regexCharCode(); return [String.fromCharCode(cc), cc]; } }, // literal that doesn't need to be escaped (OR wrong)
-  { w: 4, v: function () { var cc = regexCharCode(); return ["\\" + String.fromCharCode(cc), cc]; } }, // escaped special character OR unnecessary escape (OR wrong)
+  { w: 4, v: function () { var cc = regexCharCode(); return [`\\${String.fromCharCode(cc)}`, cc]; } }, // escaped special character OR unnecessary escape (OR wrong)
   { w: 1, v: function () { return ["\\0", 0]; } }, // null [ignoring the "do not follow this with another digit" rule which would turn it into an octal escape]
   { w: 1, v: function () { return ["\\B", 66]; } }, // literal B -- ONLY within a character class. (Elsewhere, it's a "zero-width non-word boundary".)
   { w: 1, v: function () { return ["\\b", 8]; } }, // backspace -- ONLY within a character class. (Elsewhere, it's a "zero-width word boundary".)
@@ -159,11 +159,11 @@ var regexCharacterMakers = Random.weighted([
   { w: 1, v: function () { return ["\\v", 11]; } }, // vertical tab
   { w: 1, v: function () { return ["\\f", 12]; } }, // form feed
   { w: 1, v: function () { return ["\\r", 13]; } }, // carriage return
-  { w: 5, v: function () { var controlCharacterCode = rnd(26) + 1; return ["\\c" + String.fromCharCode(64 + controlCharacterCode), controlCharacterCode]; } },
-  // { w: 5, v: function() { var cc = regexCharCode(); return ["\\0" + cc.toString(8), cc] } }, // octal escape
-  { w: 5, v: function () { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\x" + twoHex, parseInt(twoHex, 16)]; } },
-  { w: 5, v: function () { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return ["\\u00" + twoHex, parseInt(twoHex, 16)]; } },
-  { w: 5, v: function () { var fourHex = Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits); return ["\\u" + fourHex, parseInt(fourHex, 16)]; } }
+  { w: 5, v: function () { var controlCharacterCode = rnd(26) + 1; return [`\\c${String.fromCharCode(64 + controlCharacterCode)}`, controlCharacterCode]; } },
+  // { w: 5, v: function() { var cc = regexCharCode(); return [`\\0${cc.toString(8)}`, cc] } }, // octal escape
+  { w: 5, v: function () { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return [`\\x${twoHex}`, parseInt(twoHex, 16)]; } },
+  { w: 5, v: function () { var twoHex = Random.index(hexDigits) + Random.index(hexDigits); return [`\\u00${twoHex}`, parseInt(twoHex, 16)]; } },
+  { w: 5, v: function () { var fourHex = Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits) + Random.index(hexDigits); return [`\\u${fourHex}`, parseInt(fourHex, 16)]; } }
 ]);
 
 function regexCharacter () { /* eslint-disable-line require-jsdoc */
@@ -263,7 +263,7 @@ function regexCharacterClass () { /* eslint-disable-line require-jsdoc */
         [lo, hi] = [b, a];
       }
 
-      re += lo[0] + "-" + hi[0];
+      re += `${lo[0]}-${hi[0]}`;
       charBucket.push(String.fromCharCode(lo[1] + rnd(3) - 1));
       charBucket.push(String.fromCharCode(hi[1] + rnd(3) - 1));
       charBucket.push(String.fromCharCode(lo[1] + rnd(Math.max(hi[1] - lo[1], 1)))); // something in the middle

--- a/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-stomp-on-registers.js
@@ -13,15 +13,15 @@ function makeRegisterStompFunction (d, b, pure) { /* eslint-disable-line require
   var args = [];
   var nArgs = (rnd(10) ? rnd(20) : rnd(100)) + 1;
   for (var i = 0; i < nArgs; ++i) {
-    args.push("a" + i);
+    args.push(`a${i}`);
   }
 
   var bv = b.concat(args);
 
   return (
-    "(function(" + args.join(", ") + ") { " +
+    `(function(${args.join(", ")}) { ` +
       makeRegisterStompBody(d, bv, pure) +
-      "return " + Random.index(bv) + "; " +
+      `return ${Random.index(bv)}; ` +
     "})"
   );
 }
@@ -32,7 +32,7 @@ function makeRegisterStompBody (d, b, pure) { /* eslint-disable-line require-jsd
   var s = "";
 
   function value () { /* eslint-disable-line require-jsdoc */
-    return rnd(3) && bv.length ? Random.index(bv) : "" + rnd(10);
+    return rnd(3) && bv.length ? Random.index(bv) : `${rnd(10)}`;
   }
 
   function expr () { /* eslint-disable-line require-jsdoc */
@@ -41,14 +41,14 @@ function makeRegisterStompBody (d, b, pure) { /* eslint-disable-line require-jsd
 
   while (rnd(100)) {
     if (bv.length === 0 || rnd(4)) {
-      var newVar = "r" + lastRVar;
+      var newVar = `r${lastRVar}`;
       ++lastRVar;
-      s += "var " + newVar + " = " + expr() + "; ";
+      s += `var ${newVar} = ${expr()}; `;
       bv.push(newVar);
     } else if (rnd(5) === 0 && !pure) {
-      s += "print(" + Random.index(bv) + "); ";
+      s += `print(${Random.index(bv)}); `;
     } else {
-      s += Random.index(bv) + " = " + expr() + "; ";
+      s += `${Random.index(bv)} = ${expr()}; `;
     }
   }
 

--- a/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
+++ b/src/funfuzz/js/jsfunfuzz/gen-type-aware-code.js
@@ -26,8 +26,8 @@ var makeEvilCallback;
       /* eslint-disable no-multi-spaces */
       case 0:  return m("v");
       case 1:  return makeExpr(d - 1, b);
-      case 2:  return "({valueOf: function() { " + makeStatement(d, b) + "return " + rnd(ARRAY_SIZE) + "; }})";
-      default: return "" + rnd(ARRAY_SIZE);
+      case 2:  return `({valueOf: function() { ${makeStatement(d, b)}return ${rnd(ARRAY_SIZE)}; }})`;
+      default: return `${rnd(ARRAY_SIZE)}`;
       /* eslint-enable no-multi-spaces */
     }
   }
@@ -40,10 +40,10 @@ var makeEvilCallback;
     switch (rnd(24)) {
       /* eslint-disable no-multi-spaces */
       case 0:  return m("o");
-      case 1:  return m("o") + "." + name;
+      case 1:  return `${m("o")}.${name}`;
       case 2:  return m("g");
-      case 3:  return m("g") + "." + name;
-      case 4:  return "this." + name;
+      case 3:  return `${m("g")}.${name}`;
+      case 4:  return `this.${name}`;
       default: return name;
       /* eslint-enable no-multi-spaces */
     }
@@ -62,13 +62,13 @@ var makeEvilCallback;
       /* eslint-disable no-multi-spaces */
       case 0:  return (
         "Object.defineProperty(" +
-        (rnd(8) ? "this" : m("og")) + ", " +
-        simpleSource(m(t)) + ", " +
-        "{ " + propertyDescriptorPrefix(d - 1, b) + " get: function() { " + (rnd(8) ? "" : makeBuilderStatement(d - 1, b)) + " return " + rhs + "; } }" +
+        `${rnd(8) ? "this" : m("og")}, ` +
+        `${simpleSource(m(t))}, ` +
+        `{ ${propertyDescriptorPrefix(d - 1, b)} get: function() { ${rnd(8) ? "" : makeBuilderStatement(d - 1, b)} return ${rhs}; } }` +
       ");"
       );
-      case 1:  return Random.index(varBinder) + m(t) + " = " + rhs + ";";
-      default: return m(t) + " = " + rhs + ";";
+      case 1:  return `${Random.index(varBinder) + m(t)} = ${rhs};`;
+      default: return `${m(t)} = ${rhs};`;
       /* eslint-enable no-multi-spaces */
     }
   }
@@ -79,13 +79,13 @@ var makeEvilCallback;
     var infrequently = infrequentCondition(v, 10);
     return (
       "(function mcc_() { " +
-        "var " + v + " = 0; " +
+        `var ${v} = 0; ` +
         "return function() { " +
-          "++" + v + "; " +
+          `++${v}; ` +
             (rnd(3) ?
-              "if (" + infrequently + ") { dumpln('hit!'); " + makeBuilderStatements(d, b) + " } " +
-              "else { dumpln('miss!'); " + makeBuilderStatements(d, b) + " } " :
-              m("f") + "(" + infrequently + ");"
+              `if (${infrequently}) { dumpln('hit!'); ${makeBuilderStatements(d, b)} } ` +
+              `else { dumpln('miss!'); ${makeBuilderStatements(d, b)} } ` :
+              `${m("f")}(${infrequently});`
             ) +
         "};" +
       "})()");
@@ -94,27 +94,27 @@ var makeEvilCallback;
   function fdecl (d, b) { /* eslint-disable-line require-jsdoc */
     var argName = m();
     var bv = b.concat([argName]);
-    return "function " + m("f") + "(" + argName + ") " + makeFunctionBody(d, bv);
+    return `function ${m("f")}(${argName}) ${makeFunctionBody(d, bv)}`;
   }
 
   function makeBuilderStatements (d, b) { /* eslint-disable-line require-jsdoc */
     var s = "";
     var extras = rnd(4);
     for (var i = 0; i < extras; ++i) {
-      s += "try { " + makeBuilderStatement(d - 2, b) + " } catch(e" + i + ") { } ";
+      s += `try { ${makeBuilderStatement(d - 2, b)} } catch(e${i}) { } `;
     }
     s += makeBuilderStatement(d - 1, b);
     return s;
   }
 
   var builderFunctionMakers = Random.weighted([
-    { w: 9, v: function (d, b) { return "(function() { " + makeBuilderStatements(d, b) + " return " + m() + "; })"; } },
-    { w: 1, v: function (d, b) { return "(function() { " + makeBuilderStatements(d, b) + " throw " + m() + "; })"; } },
-    { w: 1, v: function (d, b) { return "(function(j) { " + m("f") + "(j); })"; } }, // a function that just makes one call is begging to be inlined
+    { w: 9, v: function (d, b) { return `(function() { ${makeBuilderStatements(d, b)} return ${m()}; })`; } },
+    { w: 1, v: function (d, b) { return `(function() { ${makeBuilderStatements(d, b)} throw ${m()}; })`; } },
+    { w: 1, v: function (d, b) { return `(function(j) { ${m("f")}(j); })`; } }, // a function that just makes one call is begging to be inlined
     // The following pair create and use boolean-using functions.
-    { w: 4, v: function (d, b) { return "(function(j) { if (j) { " + makeBuilderStatements(d, b) + " } else { " + makeBuilderStatements(d, b) + " } })"; } },
-    { w: 4, v: function (d, b) { return "(function() { for (var j=0;j<" + loopCount() + ";++j) { " + m("f") + "(j%" + (2 + rnd(4)) + "==" + rnd(2) + "); } })"; } },
-    { w: 1, v: function (d, b) { return Random.index(builtinFunctions) + ".bind(" + m() + ")"; } },
+    { w: 4, v: function (d, b) { return `(function(j) { if (j) { ${makeBuilderStatements(d, b)} } else { ${makeBuilderStatements(d, b)} } })`; } },
+    { w: 4, v: function (d, b) { return `(function() { for (var j=0;j<${loopCount()};++j) { ${m("f")}(j%${2 + rnd(4)}==${rnd(2)}); } })`; } },
+    { w: 1, v: function (d, b) { return `${Random.index(builtinFunctions)}.bind(${m()})`; } },
     { w: 5, v: function (d, b) { return m("f"); } },
     { w: 3, v: makeCounterClosure },
     { w: 2, v: makeFunction },
@@ -149,8 +149,8 @@ var makeEvilCallback;
       .replace(/Z/g, function () {
         switch (rnd(20)) {
           /* eslint-disable no-multi-spaces */
-          case 0:  return "return " + m();
-          case 1:  return "throw " + m();
+          case 0:  return `return ${m()}`;
+          case 1:  return `throw ${m()}`;
           default: return makeBuilderStatement(d - 2, b);
           /* eslint-enable no-multi-spaces */
         }
@@ -158,7 +158,7 @@ var makeEvilCallback;
   }
 
   function propertyDescriptorPrefix (d, b) { /* eslint-disable-line require-jsdoc */
-    return "configurable: " + makeBoolean(d, b) + ", " + "enumerable: " + makeBoolean(d, b) + ", ";
+    return `configurable: ${makeBoolean(d, b)}, enumerable: ${makeBoolean(d, b)}, `;
   }
 
   function strToEval (d, b) { /* eslint-disable-line require-jsdoc */
@@ -173,18 +173,18 @@ var makeEvilCallback;
 
   function evaluateFlags (d, b) { /* eslint-disable-line require-jsdoc */
     // Options are in js.cpp: Evaluate() and ParseCompileOptions()
-    return ("({ global: " + m("g") +
-      ", fileName: " + Random.index(["'evaluate.js'", "null"]) +
+    return (`({ global: ${m("g")}` +
+      `, fileName: ${Random.index(["'evaluate.js'", "null"])}` +
       ", lineNumber: 42" +
-      ", isRunOnce: " + makeBoolean(d, b) +
-      ", noScriptRval: " + makeBoolean(d, b) +
-      ", saveIncrementalBytecode: " + makeBoolean(d, b) +
-      ", sourceIsLazy: " + makeBoolean(d, b) +
-      ", catchTermination: " + makeBoolean(d, b) +
+      `, isRunOnce: ${makeBoolean(d, b)}` +
+      `, noScriptRval: ${makeBoolean(d, b)}` +
+      `, saveIncrementalBytecode: ${makeBoolean(d, b)}` +
+      `, sourceIsLazy: ${makeBoolean(d, b)}` +
+      `, catchTermination: ${makeBoolean(d, b)}` +
       ((rnd(5) === 0) ? (
-        ((rnd(2) === 0) ? (", element: " + m("o")) : "") +
-        ((rnd(2) === 0) ? (", elementAttributeName: " + m("s")) : "") +
-        ((rnd(2) === 0) ? (", sourceMapURL: " + m("s")) : "")
+        ((rnd(2) === 0) ? `, element: ${m("o")}` : "") +
+        ((rnd(2) === 0) ? `, elementAttributeName: ${m("s")}` : "") +
+        ((rnd(2) === 0) ? `, sourceMapURL: ${m("s")}` : "")
       ) : ""
       ) +
     " })");
@@ -197,17 +197,17 @@ var makeEvilCallback;
 
     var s = "";
     for (var i = 0; i < OBJECTS_PER_TYPE; ++i) {
-      s += "a" + i + " = []; ";
-      s += "o" + i + " = {}; ";
-      s += "s" + i + " = ''; ";
-      s += "r" + i + " = /x/; ";
-      s += "g" + i + " = " + makeGlobal(d, b) + "; ";
-      s += "f" + i + " = function(){}; ";
-      s += "m" + i + " = new WeakMap; ";
-      s += "e" + i + " = new Set; ";
-      s += "v" + i + " = null; ";
-      s += "b" + i + " = new ArrayBuffer(64); ";
-      s += "t" + i + " = new Uint8ClampedArray; ";
+      s += `a${i} = []; `;
+      s += `o${i} = {}; `;
+      s += `s${i} = ''; `;
+      s += `r${i} = /x/; `;
+      s += `g${i} = ${makeGlobal(d, b)}; `;
+      s += `f${i} = function(){}; `;
+      s += `m${i} = new WeakMap; `;
+      s += `e${i} = new Set; `;
+      s += `v${i} = null; `;
+      s += `b${i} = new ArrayBuffer(64); `;
+      s += `t${i} = new Uint8ClampedArray; `;
       // nothing for iterators, handlers
     }
     return s;
@@ -227,9 +227,9 @@ var makeEvilCallback;
     // Emit a method call expression
     switch (rnd(4)) {
       /* eslint-disable no-multi-spaces */
-      case 0:  return clazz + ".prototype." + meth + ".apply(" + obj + ", [" + arglist.join(", ") + "])";
-      case 1:  return clazz + ".prototype." + meth + ".call(" + [obj].concat(arglist).join(", ") + ")";
-      default: return obj + "." + meth + "(" + arglist.join(", ") + ")";
+      case 0:  return `${clazz}.prototype.${meth}.apply(${obj}, [${arglist.join(", ")}])`;
+      case 1:  return `${clazz}.prototype.${meth}.call(${[obj].concat(arglist).join(", ")})`;
+      default: return `${obj}.${meth}(${arglist.join(", ")})`;
       /* eslint-enable no-multi-spaces */
     }
   }
@@ -248,35 +248,35 @@ var makeEvilCallback;
     { w: 1, v: function (d, b) { return assign(d, b, "a", "[]"); } },
     { w: 1, v: function (d, b) { return assign(d, b, "a", "new Array"); } },
     { w: 1, v: function (d, b) { return assign(d, b, "a", makeIterable(d, b)); } },
-    { w: 1, v: function (d, b) { return m("a") + ".length = " + arrayIndex(d, b) + ";"; } },
-    { w: 8, v: function (d, b) { return assign(d, b, "v", m("at") + ".length"); } },
-    { w: 4, v: function (d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + " = " + val(d, b) + ";"; } },
-    { w: 4, v: function (d, b) { return val(d, b) + " = " + m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
-    { w: 1, v: function (d, b) { return assign(d, b, "a", makeFunOnCallChain(d, b) + ".arguments"); } }, // a read-only arguments object
+    { w: 1, v: function (d, b) { return `${m("a")}.length = ${arrayIndex(d, b)};`; } },
+    { w: 8, v: function (d, b) { return assign(d, b, "v", `${m("at")}.length`); } },
+    { w: 4, v: function (d, b) { return `${m("at")}[${arrayIndex(d, b)}] = ${val(d, b)};`; } },
+    { w: 4, v: function (d, b) { return `${val(d, b)} = ${m("at")}[${arrayIndex(d, b)}];`; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "a", `${makeFunOnCallChain(d, b)}.arguments`); } }, // a read-only arguments object
     { w: 1, v: function (d, b) { return assign(d, b, "a", "arguments"); } }, // a read-write arguments object
 
     // Array indexing
-    { w: 3, v: function (d, b) { return m("at") + "[" + arrayIndex(d, b) + "]" + ";"; } },
-    { w: 3, v: function (d, b) { return m("at") + "[" + arrayIndex(d, b) + "] = " + makeExpr(d, b) + ";"; } },
-    { w: 1, v: function (d, b) { return "/*ADP-1*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
-    { w: 1, v: function (d, b) { return "/*ADP-2*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
-    { w: 1, v: function (d, b) { return "/*ADP-3*/Object.defineProperty(" + m("a") + ", " + arrayIndex(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
+    { w: 3, v: function (d, b) { return `${m("at")}[${arrayIndex(d, b)}];`; } },
+    { w: 3, v: function (d, b) { return `${m("at")}[${arrayIndex(d, b)}] = ${makeExpr(d, b)};`; } },
+    { w: 1, v: function (d, b) { return `/*ADP-1*/Object.defineProperty(${m("a")}, ${arrayIndex(d, b)}, ${makePropertyDescriptor(d, b)});`; } },
+    { w: 1, v: function (d, b) { return `/*ADP-2*/Object.defineProperty(${m("a")}, ${arrayIndex(d, b)}, { ${propertyDescriptorPrefix(d, b)}get: ${makeEvilCallback(d, b)}, set: ${makeEvilCallback(d, b)} });`; } },
+    { w: 1, v: function (d, b) { return `/*ADP-3*/Object.defineProperty(${m("a")}, ${arrayIndex(d, b)}, { ${propertyDescriptorPrefix(d, b)}writable: ${makeBoolean(d, b)}, value: ${val(d, b)} });`; } },
 
     // Array mutators
-    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "push", severalargs(function () { return val(d, b); })) + ";"; } },
-    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "pop", []) + ";"; } },
-    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "unshift", severalargs(function () { return val(d, b); })) + ";"; } },
-    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "shift", []) + ";"; } },
-    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "reverse", []) + ";"; } },
-    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "sort", [makeEvilCallback(d, b)]) + ";"; } },
-    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "splice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b)]) + ";"; } },
+    { w: 5, v: function (d, b) { return `${method(d, b, "Array", m("a"), "push", severalargs(function () { return val(d, b); }))};`; } },
+    { w: 5, v: function (d, b) { return `${method(d, b, "Array", m("a"), "pop", [])};`; } },
+    { w: 5, v: function (d, b) { return `${method(d, b, "Array", m("a"), "unshift", severalargs(function () { return val(d, b); }))};`; } },
+    { w: 5, v: function (d, b) { return `${method(d, b, "Array", m("a"), "shift", [])};`; } },
+    { w: 5, v: function (d, b) { return `${method(d, b, "Array", m("a"), "reverse", [])};`; } },
+    { w: 5, v: function (d, b) { return `${method(d, b, "Array", m("a"), "sort", [makeEvilCallback(d, b)])};`; } },
+    { w: 5, v: function (d, b) { return `${method(d, b, "Array", m("a"), "splice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b)])};`; } },
     // Array accessors
     { w: 1, v: function (d, b) { return assign(d, b, "s", method(d, b, "Array", m("a"), "join", [m("s")])); } },
     { w: 1, v: function (d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "concat", severalargs(function () { return m("at"); }))); } },
     { w: 1, v: function (d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "slice", [arrayIndex(d, b) - arrayIndex(d, b), arrayIndex(d, b) - arrayIndex(d, b)])); } },
 
     // Array iterators
-    { w: 5, v: function (d, b) { return method(d, b, "Array", m("a"), "forEach", [makeEvilCallback(d, b)]) + ";"; } },
+    { w: 5, v: function (d, b) { return `${method(d, b, "Array", m("a"), "forEach", [makeEvilCallback(d, b)])};`; } },
     { w: 1, v: function (d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "map", [makeEvilCallback(d, b)])); } },
     { w: 1, v: function (d, b) { return assign(d, b, "a", method(d, b, "Array", m("a"), "filter", [makeEvilCallback(d, b)])); } },
     { w: 1, v: function (d, b) { return assign(d, b, "v", method(d, b, "Array", m("a"), "some", [makeEvilCallback(d, b)])); } },
@@ -289,133 +289,133 @@ var makeEvilCallback;
     // Typed Objects (aka Binary Data)
     // http://wiki.ecmascript.org/doku.php?id=harmony:typed_objects (does not match what's in spidermonkey as of 2014-02-11)
     // Do I need to keep track of 'types', 'objects of those types', and 'arrays of objects of those types'?
-    // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".flatten()"); } },
-    // { w: 1,  v: function(d, b) { return assign(d, b, "d", m("d") + ".partition(" + (rnd(2)?m("v"):rnd(10)) + ")"); } },
+    // { w: 1,  v: function(d, b) { return assign(d, b, "d", `${m("d")}.flatten()`); } },
+    // { w: 1,  v: function(d, b) { return assign(d, b, "d", `${m("d")}.partition(${rnd(2) ? m("v") : rnd(10)})`); } },
 
     // o: Object
     { w: 1, v: function (d, b) { return assign(d, b, "o", "{}"); } },
     { w: 1, v: function (d, b) { return assign(d, b, "o", "new Object"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "o", "Object.create(" + val(d, b) + ")"); } },
-    { w: 3, v: function (d, b) { return "selectforgc(" + m("o") + ");"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "o", `Object.create(${val(d, b)})`); } },
+    { w: 3, v: function (d, b) { return `selectforgc(${m("o")});`; } },
 
     // s: String
     { w: 1, v: function (d, b) { return assign(d, b, "s", "''"); } },
     { w: 1, v: function (d, b) { return assign(d, b, "s", "new String"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "s", "new String(" + m() + ")"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "s", m("s") + ".charAt(" + arrayIndex(d, b) + ")"); } },
-    { w: 5, v: function (d, b) { return m("s") + " += 'x';"; } },
-    { w: 5, v: function (d, b) { return m("s") + " += " + m("s") + ";"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "s", `new String(${m()})`); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "s", `${m("s")}.charAt(${arrayIndex(d, b)})`); } },
+    { w: 5, v: function (d, b) { return `${m("s")} += 'x';`; } },
+    { w: 5, v: function (d, b) { return `${m("s")} += ${m("s")};`; } },
     // Should add substr, substring, replace
 
     // m: Map, WeakMap
     { w: 1, v: function (d, b) { return assign(d, b, "m", "new Map"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "m", "new Map(" + m() + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "m", `new Map(${m()})`); } },
     { w: 1, v: function (d, b) { return assign(d, b, "m", "new WeakMap"); } },
-    { w: 5, v: function (d, b) { return m("m") + ".has(" + val(d, b) + ");"; } },
-    { w: 4, v: function (d, b) { return m("m") + ".get(" + val(d, b) + ");"; } },
-    { w: 1, v: function (d, b) { return assign(d, b, null, m("m") + ".get(" + val(d, b) + ")"); } },
-    { w: 5, v: function (d, b) { return m("m") + ".set(" + val(d, b) + ", " + val(d, b) + ");"; } },
-    { w: 3, v: function (d, b) { return m("m") + ".delete(" + val(d, b) + ");"; } },
+    { w: 5, v: function (d, b) { return `${m("m")}.has(${val(d, b)});`; } },
+    { w: 4, v: function (d, b) { return `${m("m")}.get(${val(d, b)});`; } },
+    { w: 1, v: function (d, b) { return assign(d, b, null, `${m("m")}.get(${val(d, b)})`); } },
+    { w: 5, v: function (d, b) { return `${m("m")}.set(${val(d, b)}, ${val(d, b)});`; } },
+    { w: 3, v: function (d, b) { return `${m("m")}.delete(${val(d, b)});`; } },
 
     // e: Set
     { w: 1, v: function (d, b) { return assign(d, b, "e", "new Set"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "e", "new Set(" + m() + ")"); } },
-    { w: 5, v: function (d, b) { return m("e") + ".has(" + val(d, b) + ");"; } },
-    { w: 5, v: function (d, b) { return m("e") + ".add(" + val(d, b) + ");"; } },
-    { w: 3, v: function (d, b) { return m("e") + ".delete(" + val(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "e", `new Set(${m()})`); } },
+    { w: 5, v: function (d, b) { return `${m("e")}.has(${val(d, b)});`; } },
+    { w: 5, v: function (d, b) { return `${m("e")}.add(${val(d, b)});`; } },
+    { w: 3, v: function (d, b) { return `${m("e")}.delete(${val(d, b)});`; } },
 
     // b: Buffer
-    { w: 1, v: function (d, b) { return assign(d, b, "b", "new " + arrayBufferType() + "(" + bufsize() + ")"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "b", m("t") + ".buffer"); } },
-    { w: 1, v: function (d, b) { return "neuter(" + m("b") + ", " + (rnd(2) ? '"same-data"' : '"change-data"') + ");"; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "b", `new ${arrayBufferType()}(${bufsize()})`); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "b", `${m("t")}.buffer`); } },
+    { w: 1, v: function (d, b) { return `neuter(${m("b")}, ${rnd(2) ? '"same-data"' : '"change-data"'});`; } },
 
     // t: Typed arrays, aka ArrayBufferViews
     // Can be constructed using a length, typed array, sequence (e.g. array), or buffer with optional offsets!
-    { w: 1, v: function (d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + arrayIndex(d, b) + ")"); } },
-    { w: 3, v: function (d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + m("abt") + ")"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "t", "new " + Random.index(typedArrayConstructors) + "(" + m("b") + ", " + bufsize() + ", " + arrayIndex(d, b) + ")"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ")"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "t", m("t") + ".subarray(" + arrayIndex(d, b) + ", " + arrayIndex(d, b) + ")"); } },
-    { w: 3, v: function (d, b) { return m("t") + ".set(" + m("at") + ", " + arrayIndex(d, b) + ");"; } },
-    { w: 1, v: function (d, b) { return assign(d, b, "v", m("tb") + ".byteLength"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "v", m("t") + ".byteOffset"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "v", m("t") + ".BYTES_PER_ELEMENT"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "t", `new ${Random.index(typedArrayConstructors)}(${arrayIndex(d, b)})`); } },
+    { w: 3, v: function (d, b) { return assign(d, b, "t", `new ${Random.index(typedArrayConstructors)}(${m("abt")})`); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "t", `new ${Random.index(typedArrayConstructors)}(${m("b")}, ${bufsize()}, ${arrayIndex(d, b)})`); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "t", `${m("t")}.subarray(${arrayIndex(d, b)})`); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "t", `${m("t")}.subarray(${arrayIndex(d, b)}, ${arrayIndex(d, b)})`); } },
+    { w: 3, v: function (d, b) { return `${m("t")}.set(${m("at")}, ${arrayIndex(d, b)});`; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", `${m("tb")}.byteLength`); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", `${m("t")}.byteOffset`); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", `${m("t")}.BYTES_PER_ELEMENT`); } },
 
     // h: proxy handler
     { w: 1, v: function (d, b) { return assign(d, b, "h", "{}"); } },
     { w: 1, v: function (d, b) { return assign(d, b, "h", forwardingHandler(d, b)); } },
-    { w: 1, v: function (d, b) { return "delete " + m("h") + "." + Random.index(handlerTraps) + ";"; } },
-    { w: 4, v: function (d, b) { return m("h") + "." + Random.index(handlerTraps) + " = " + makeEvilCallback(d, b) + ";"; } },
-    { w: 4, v: function (d, b) { return m("h") + "." + Random.index(handlerTraps) + " = " + m("f") + ";"; } },
-    { w: 1, v: function (d, b) { return assign(d, b, null, "Proxy.create(" + m("h") + ", " + m() + ")"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "f", "Proxy.createFunction(" + m("h") + ", " + m("f") + ", " + m("f") + ")"); } },
+    { w: 1, v: function (d, b) { return `delete ${m("h")}.${Random.index(handlerTraps)};`; } },
+    { w: 4, v: function (d, b) { return `${m("h")}.${Random.index(handlerTraps)} = ${makeEvilCallback(d, b)};`; } },
+    { w: 4, v: function (d, b) { return `${m("h")}.${Random.index(handlerTraps)} = ${m("f")};`; } },
+    { w: 1, v: function (d, b) { return assign(d, b, null, `Proxy.create(${m("h")}, ${m()})`); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "f", `Proxy.createFunction(${m("h")}, ${m("f")}, ${m("f")})`); } },
 
     // r: regexp
     // The separate regex code is better at matching strings with regexps, but this is better at reusing the objects.
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=808245 for why it is important to reuse regexp objects.
     { w: 1, v: function (d, b) { return assign(d, b, "r", makeRegex(d, b)); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "a", m("r") + ".exec(" + m("s") + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "a", `${m("r")}.exec(${m("s")})`); } },
     { w: 3, v: function (d, b) { return makeRegexUseBlock(d, b, m("r")); } },
     { w: 3, v: function (d, b) { return makeRegexUseBlock(d, b, m("r"), m("s")); } },
-    { w: 3, v: function (d, b) { return assign(d, b, "v", m("r") + "." + Random.index(builtinObjects["RegExp.prototype"])); } },
+    { w: 3, v: function (d, b) { return assign(d, b, "v", `${m("r")}.${Random.index(builtinObjects["RegExp.prototype"])}`); } },
 
     // g: global or sandbox
     { w: 1, v: function (d, b) { return assign(d, b, "g", makeGlobal(d, b)); } },
-    { w: 5, v: function (d, b) { return assign(d, b, "v", m("g") + ".eval(" + strToEval(d, b) + ")"); } },
-    { w: 5, v: function (d, b) { return assign(d, b, "v", "evalcx(" + strToEval(d, b) + ", " + m("g") + ")"); } },
-    { w: 5, v: function (d, b) { return assign(d, b, "v", "evaluate(" + strToEval(d, b) + ", " + evaluateFlags(d, b) + ")"); } },
-    { w: 2, v: function (d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ");"; } },
-    { w: 3, v: function (d, b) { return m("g") + ".offThreadCompileScript(" + strToEval(d, b) + ", " + evaluateFlags(d, b) + ");"; } },
-    { w: 5, v: function (d, b) { return assign(d, b, "v", m("g") + ".runOffThreadScript()"); } },
-    { w: 3, v: function (d, b) { return "(void schedulegc(" + m("g") + "));"; } },
+    { w: 5, v: function (d, b) { return assign(d, b, "v", `${m("g")}.eval(${strToEval(d, b)})`); } },
+    { w: 5, v: function (d, b) { return assign(d, b, "v", `evalcx(${strToEval(d, b)}, ${m("g")})`); } },
+    { w: 5, v: function (d, b) { return assign(d, b, "v", `evaluate(${strToEval(d, b)}, ${evaluateFlags(d, b)})`); } },
+    { w: 2, v: function (d, b) { return `${m("g")}.offThreadCompileScript(${strToEval(d, b)});`; } },
+    { w: 3, v: function (d, b) { return `${m("g")}.offThreadCompileScript(${strToEval(d, b)}, ${evaluateFlags(d, b)});`; } },
+    { w: 5, v: function (d, b) { return assign(d, b, "v", `${m("g")}.runOffThreadScript()`); } },
+    { w: 3, v: function (d, b) { return `(void schedulegc(${m("g")}));`; } },
 
     // Mix builtins between globals
-    { w: 3, v: function (d, b) { return "/*MXX1*/" + assign(d, b, "o", m("g") + "." + Random.index(builtinProperties)); } },
-    { w: 3, v: function (d, b) { return "/*MXX2*/" + m("g") + "." + Random.index(builtinProperties) + " = " + m() + ";"; } },
-    { w: 3, v: function (d, b) { var prop = Random.index(builtinProperties); return "/*MXX3*/" + m("g") + "." + prop + " = " + m("g") + "." + prop + ";"; } },
+    { w: 3, v: function (d, b) { return `/*MXX1*/${assign(d, b, "o", m("g") + "." + Random.index(builtinProperties))}`; } },
+    { w: 3, v: function (d, b) { return `/*MXX2*/${m("g")}.${Random.index(builtinProperties)} = ${m()};`; } },
+    { w: 3, v: function (d, b) { var prop = Random.index(builtinProperties); return `/*MXX3*/${m("g")}.${prop} = ${m("g")}.${prop};`; } },
 
     // f: function (?)
     // Could probably do better with args / b
     { w: 1, v: function (d, b) { return assign(d, b, "f", makeEvilCallback(d, b)); } },
     { w: 1, v: fdecl },
-    { w: 2, v: function (d, b) { return m("f") + "(" + m() + ");"; } },
+    { w: 2, v: function (d, b) { return `${m("f")}(${m()});`; } },
 
     // v: Primitive
     { w: 2, v: function (d, b) { return assign(d, b, "v", Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"])); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "v", "new Number(" + Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"]) + ")"); } },
-    { w: 1, v: function (d, b) { return assign(d, b, "v", "new Number(" + m() + ")"); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", `new Number(${Random.index(["4", "4.2", "NaN", "0", "-0", "Infinity", "-Infinity"])})`); } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", `new Number(${m()})`); } },
     { w: 1, v: function (d, b) { return assign(d, b, "v", makeBoolean(d, b)); } },
     { w: 2, v: function (d, b) { return assign(d, b, "v", Random.index(["undefined", "null", "true", "false"])); } },
 
     // evil things we can do to any object property
-    { w: 1, v: function (d, b) { return "/*ODP-1*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", " + makePropertyDescriptor(d, b) + ");"; } },
-    { w: 1, v: function (d, b) { return "/*ODP-2*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "get: " + makeEvilCallback(d, b) + ", set: " + makeEvilCallback(d, b) + " });"; } },
-    { w: 1, v: function (d, b) { return "/*ODP-3*/Object.defineProperty(" + m() + ", " + makePropertyName(d, b) + ", { " + propertyDescriptorPrefix(d, b) + "writable: " + makeBoolean(d, b) + ", value: " + val(d, b) + " });"; } },
-    { w: 1, v: function (d, b) { return "delete " + m() + "[" + makePropertyName(d, b) + "];"; } },
-    { w: 1, v: function (d, b) { return assign(d, b, "v", m() + "[" + makePropertyName(d, b) + "]"); } },
-    { w: 1, v: function (d, b) { return m() + "[" + makePropertyName(d, b) + "] = " + val(d, b) + ";"; } },
+    { w: 1, v: function (d, b) { return `/*ODP-1*/Object.defineProperty(${m()}, ${makePropertyName(d, b)}, ${makePropertyDescriptor(d, b)});`; } },
+    { w: 1, v: function (d, b) { return `/*ODP-2*/Object.defineProperty(${m()}, ${makePropertyName(d, b)}, { ${propertyDescriptorPrefix(d, b)}get: ${makeEvilCallback(d, b)}, set: ${makeEvilCallback(d, b)} });`; } },
+    { w: 1, v: function (d, b) { return `/*ODP-3*/Object.defineProperty(${m()}, ${makePropertyName(d, b)}, { ${propertyDescriptorPrefix(d, b)}writable: ${makeBoolean(d, b)}, value: ${val(d, b)} });`; } },
+    { w: 1, v: function (d, b) { return `delete ${m()}[${makePropertyName(d, b)}];`; } },
+    { w: 1, v: function (d, b) { return assign(d, b, "v", `${m()}[${makePropertyName(d, b)}]`); } },
+    { w: 1, v: function (d, b) { return `${m()}[${makePropertyName(d, b)}] = ${val(d, b)};`; } },
 
     // evil things we can do to any object
-    { w: 5, v: function (d, b) { return "print(" + m() + ");"; } },
-    { w: 5, v: function (d, b) { return "print(uneval(" + m() + "));"; } },
-    { w: 5, v: function (d, b) { return m() + ".toString = " + makeEvilCallback(d, b) + ";"; } },
-    { w: 5, v: function (d, b) { return m() + ".valueOf = " + makeEvilCallback(d, b) + ";"; } },
-    { w: 1, v: function (d, b) { return m() + " = " + m() + ";"; } },
-    { w: 1, v: function (d, b) { return m() + " = " + m("g") + ".createIsHTMLDDA();"; } },
-    { w: 10, v: function (d, b) { return m("o") + " = " + m() + ".__proto__;"; } },
-    { w: 20, v: function (d, b) { return m() + ".__proto__ = {};"; } },
-    { w: 20, v: function (d, b) { return m() + ".__proto__ = " + m() + ";"; } },
-    { w: 10, v: function (d, b) { return "for (var p in " + m() + ") { " + makeBuilderStatements(d, b) + " }"; } },
-    { w: 10, v: function (d, b) { return "for (var v of " + m() + ") { " + makeBuilderStatements(d, b) + " }"; } },
-    { w: 10, v: function (d, b) { return m() + " + " + m() + ";"; } }, // valueOf
-    { w: 10, v: function (d, b) { return m() + " + '';"; } }, // toString
-    { w: 10, v: function (d, b) { return m("v") + " = (" + m() + " instanceof " + m() + ");"; } },
-    { w: 10, v: function (d, b) { return m("v") + " = Object.prototype.isPrototypeOf.call(" + m() + ", " + m() + ");"; } },
-    { w: 2, v: function (d, b) { return "Object." + Random.index(["preventExtensions", "seal", "freeze"]) + "(" + m() + ");"; } },
+    { w: 5, v: function (d, b) { return `print(${m()});`; } },
+    { w: 5, v: function (d, b) { return `print(uneval(${m()}));`; } },
+    { w: 5, v: function (d, b) { return `${m()}.toString = ${makeEvilCallback(d, b)};`; } },
+    { w: 5, v: function (d, b) { return `${m()}.valueOf = ${makeEvilCallback(d, b)};`; } },
+    { w: 1, v: function (d, b) { return `${m()} = ${m()};`; } },
+    { w: 1, v: function (d, b) { return `${m()} = ${m("g")}.createIsHTMLDDA();`; } },
+    { w: 10, v: function (d, b) { return `${m("o")} = ${m()}.__proto__;`; } },
+    { w: 20, v: function (d, b) { return `${m()}.__proto__ = {};`; } },
+    { w: 20, v: function (d, b) { return `${m()}.__proto__ = ${m()};`; } },
+    { w: 10, v: function (d, b) { return `for (var p in ${m()}) { ${makeBuilderStatements(d, b)} }`; } },
+    { w: 10, v: function (d, b) { return `for (var v of ${m()}) { ${makeBuilderStatements(d, b)} }`; } },
+    { w: 10, v: function (d, b) { return `${m()} + ${m()};`; } }, // valueOf
+    { w: 10, v: function (d, b) { return `${m()} + '';`; } }, // toString
+    { w: 10, v: function (d, b) { return `${m("v")} = (${m()} instanceof ${m()});`; } },
+    { w: 10, v: function (d, b) { return `${m("v")} = Object.prototype.isPrototypeOf.call(${m()}, ${m()});`; } },
+    { w: 2, v: function (d, b) { return `Object.${Random.index(["preventExtensions", "seal", "freeze"])}(${m()});`; } },
 
     // Be promiscuous with the rest of jsfunfuzz
-    { w: 1, v: function (d, b) { return m() + " = x;"; } },
-    { w: 1, v: function (d, b) { return "x = " + m() + ";"; } },
+    { w: 1, v: function (d, b) { return `${m()} = x;`; } },
+    { w: 1, v: function (d, b) { return `x = ${m()};`; } },
     { w: 5, v: makeStatement },
 
     // Stick in empty for-loops
@@ -432,8 +432,8 @@ function infrequentCondition (v, n) { /* eslint-disable-line require-jsdoc */
   switch (rnd(20)) {
     case 0: return true;
     case 1: return false;
-    case 2: return v + " > " + rnd(n);
-    default: var mod = rnd(n) + 2; var target = rnd(mod); return "/*ICCD*/" + v + " % " + mod + (rnd(8) ? " == " : " != ") + target;
+    case 2: return `${v} > ${rnd(n)}`;
+    default: var mod = rnd(n) + 2; var target = rnd(mod); return `/*ICCD*/${v} % ${mod}${rnd(8) ? " == " : " != "}${target}`;
   }
 }
 

--- a/src/funfuzz/js/jsfunfuzz/mess-grammar.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-grammar.js
@@ -46,7 +46,7 @@ function testEachMaker()
       try {
         var r = f(8, ["A", "B"]);
         if (typeof r != "string")
-          throw ("Got a " + typeof r);
+          throw (`Got a ${typeof r}`);
         dumpln(r);
       } catch(e) {
         dumpln("");

--- a/src/funfuzz/js/jsfunfuzz/mess-tokens.js
+++ b/src/funfuzz/js/jsfunfuzz/mess-tokens.js
@@ -35,7 +35,7 @@ function cat (toks) { /* eslint-disable-line require-jsdoc */
     //   return "/*foo*/" + ...
     // Unary plus in the first one coerces the string that follows to number!
     if (typeof (toks[i]) !== "string") {
-      dumpln("Strange item in the array passed to cat: typeof toks[" + i + "] == " + typeof (toks[i]));
+      dumpln(`Strange item in the array passed to cat: typeof toks[${i}] == ${typeof (toks[i])}`);
       dumpln(cat.caller);
       dumpln(cat.caller.caller);
     }
@@ -54,7 +54,7 @@ function cat (toks) { /* eslint-disable-line require-jsdoc */
           s += maybeSpace() + totallyRandom(2, ["x"]) + maybeSpace();
           break;
         case 5:
-          s = "(" + s + ")"; // randomly parenthesize some *prefix* of it.
+          s = `(${s})`; // randomly parenthesize some *prefix* of it.
           break;
         case 6:
           s = ""; // throw away everything before this point
@@ -87,7 +87,7 @@ function catNice(toks)
   var i;
   for (i=0; i<toks.length; ++i) {
     if(typeof(toks[i]) != "string")
-      confused("Strange toks[i]: " + toks[i]);
+      confused(`Strange toks[i]: ${toks[i]}`);
 
     s += toks[i];
   }

--- a/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
+++ b/src/funfuzz/js/jsfunfuzz/run-in-sandbox.js
@@ -42,11 +42,11 @@ function fillShellSandbox (sandbox) { /* eslint-disable-line require-jsdoc */
   for (var i = 0; i < safeFuns.length; ++i) {
     var fn = safeFuns[i];
     if (sandbox[fn]) {
-      // print("Target already has " + fn);
+      // print(`Target already has ${fn}`);
     } else if (this[fn]) { // FIXME: strict mode compliance requires passing glob around
       sandbox[fn] = this[fn].bind(this);
     } else {
-      // print("Source is missing " + fn);
+      // print(`Source is missing ${fn}`);
     }
   }
 
@@ -72,7 +72,7 @@ function useSpidermonkeyShellSandbox (sandboxType) { /* eslint-disable-line requ
     try {
       evalcx(code, primarySandbox);
     } catch (e) {
-      dumpln("Running in sandbox threw " + errorToString(e));
+      dumpln(`Running in sandbox threw ${errorToString(e)}`);
     }
   };
 }
@@ -82,7 +82,7 @@ function useSpidermonkeyShellSandbox (sandboxType) { /* eslint-disable-line requ
 // * Test interaction between sandboxes with same or different principals.
 function newGeckoSandbox (n) { /* eslint-disable-line require-jsdoc */
   var t = (typeof n === "number") ? n : 1;
-  var s = Components.utils.Sandbox("http://x" + t + ".example.com/"); /* eslint-disable-line no-undef */
+  var s = Components.utils.Sandbox(`http://x${t}.example.com/`); /* eslint-disable-line no-undef */
 
   // Allow the sandbox to do a few things
   s.newGeckoSandbox = newGeckoSandbox;

--- a/src/funfuzz/js/jsfunfuzz/run.js
+++ b/src/funfuzz/js/jsfunfuzz/run.js
@@ -26,7 +26,7 @@ function tryRunningDirectly (f, code, wtt) { /* eslint-disable-line require-jsdo
 
   if (count % 23 === 4) {
     dumpln("About to recompile, using eval hack.");
-    f = directEvalC("(function(){" + code + "});");
+    f = directEvalC(`(function(){${code}});`);
   }
 
   try {
@@ -36,7 +36,7 @@ function tryRunningDirectly (f, code, wtt) { /* eslint-disable-line require-jsdo
   } catch (runError) {
     if (verbose) { dumpln("Running threw!  About to toString to error."); }
     var err = errorToString(runError);
-    dumpln("Running threw: " + err);
+    dumpln(`Running threw: ${err}`);
   }
 
   tryEnsureSanity();
@@ -65,7 +65,7 @@ function tryEnsureSanity () { /* eslint-disable-line require-jsdoc */
 
   // At least one bug in the past has put exceptions in strange places.  This also catches "eval getter" issues.
   try { eval(""); } catch (e) { /* eslint-disable-line no-eval */
-    dumpln("That really shouldn't have thrown: " + errorToString(e));
+    dumpln(`That really shouldn't have thrown: ${errorToString(e)}`);
   }
 
   if (!this) {
@@ -91,7 +91,7 @@ function tryEnsureSanity () { /* eslint-disable-line require-jsdoc */
     this.uneval = realUneval;
     this.toString = realToString;
   } catch (e) {
-    confused("tryEnsureSanity failed: " + errorToString(e));
+    confused(`tryEnsureSanity failed: ${errorToString(e)}`);
   }
 
   // These can fail if the page creates a getter for "eval", for example.
@@ -105,7 +105,7 @@ function tryItOut (code) { /* eslint-disable-line require-jsdoc */
 
   // SpiderMonkey shell does not schedule GC on its own.  Help it not use too much memory.
   if (count % 1000 === 0) {
-    dumpln("Paranoid GC (count=" + count + ")!");
+    dumpln(`Paranoid GC (count=${count})!`);
     realGC();
   }
 
@@ -115,13 +115,13 @@ function tryItOut (code) { /* eslint-disable-line require-jsdoc */
 
   code = code.replace(/\/\*DUPTRY\d+\*\//, function (k) { var n = parseInt(k.substr(8), 10); dumpln(n); return strTimes("try{}catch(e){}", n); });
 
-  if (jsStrictMode) { code = "'use strict'; " + code; } // ES5 10.1.1: new Function does not inherit strict mode
+  if (jsStrictMode) { code = `'use strict'; ${code}`; } // ES5 10.1.1: new Function does not inherit strict mode
 
   var f;
   try {
     f = new Function(code); /* eslint-disable-line no-new-func */
   } catch (compileError) {
-    dumpln("Compiling threw: " + errorToString(compileError));
+    dumpln(`Compiling threw: ${errorToString(compileError)}`);
   }
 
   if (f && wtt.allowExec && wtt.expectConsistentOutput && wtt.expectConsistentOutputAcrossJITs) {
@@ -136,8 +136,8 @@ function tryItOut (code) { /* eslint-disable-line require-jsdoc */
       // But leave some things out of function(){} because some bugs are only detectable at top-level, and
       // pure jsfunfuzz doesn't test top-level at all.
       // (This is a good reason to use compare_jit even if I'm not interested in finding JIT bugs!)
-      if (nCode.indexOf("return") !== -1 || nCode.indexOf("yield") !== -1 || nCode.indexOf("const") !== -1 || failsToCompileInTry(nCode)) { nCode = "(function(){" + nCode + "})()"; }
-      dumpln(cookie1 + cookie2 + " try { " + nCode + " } catch(e) { }");
+      if (nCode.indexOf("return") !== -1 || nCode.indexOf("yield") !== -1 || nCode.indexOf("const") !== -1 || failsToCompileInTry(nCode)) { nCode = `(function(){${nCode}})()`; }
+      dumpln(`${cookie1 + cookie2} try { ${nCode} } catch(e) { }`);
     }
   }
 

--- a/src/funfuzz/js/jsfunfuzz/test-asm.js
+++ b/src/funfuzz/js/jsfunfuzz/test-asm.js
@@ -65,7 +65,7 @@ var compareAsm = (function () {
       var fr = f(x);
       var gr = g(x);
       if (!isSameNumber(fr, gr)) {
-        foundABug("asm mismatch", "(" + uneval(x) + ") -> " + uneval(fr) + " vs " + uneval(gr));
+        foundABug("asm mismatch", `(${uneval(x)}) -> ${uneval(fr)} vs ${uneval(gr)}`);
       }
     }
   }
@@ -78,7 +78,7 @@ var compareAsm = (function () {
         var fr = f(x, y);
         var gr = g(x, y);
         if (!isSameNumber(fr, gr)) {
-          foundABug("asm mismatch", "(" + uneval(x) + ", " + uneval(y) + ") -> " + uneval(fr) + " vs " + uneval(gr));
+          foundABug("asm mismatch", `(${uneval(x)}, ${uneval(y)}) -> ${uneval(fr)} vs ${uneval(gr)}`);
         }
       }
     }
@@ -106,11 +106,11 @@ var pureForeign = {
 };
 
 for (let f in unaryMathFunctions) {
-  pureForeign["Math_" + unaryMathFunctions[f]] = Math[unaryMathFunctions[f]];
+  pureForeign[`Math_${unaryMathFunctions[f]}`] = Math[unaryMathFunctions[f]];
 }
 
 for (let f in binaryMathFunctions) {
-  pureForeign["Math_" + binaryMathFunctions[f]] = Math[binaryMathFunctions[f]];
+  pureForeign[`Math_${binaryMathFunctions[f]}`] = Math[binaryMathFunctions[f]];
 }
 
 var pureMathNames = Object.keys(pureForeign);
@@ -126,7 +126,7 @@ function testAsmDifferential (stdlib, interior) { /* eslint-disable-line require
     return;
   }
 
-  var asmJs = "(function(stdlib, foreign, heap) { 'use asm'; " + interior + " })";
+  var asmJs = `(function(stdlib, foreign, heap) { 'use asm'; ${interior} })`;
   var asmModule = eval(asmJs); /* eslint-disable-line no-eval */
 
   if (isAsmJSModule(asmModule)) {
@@ -136,7 +136,7 @@ function testAsmDifferential (stdlib, interior) { /* eslint-disable-line require
 
     var normalHeap = new ArrayBuffer(4096);
     (new Int32Array(normalHeap))[0] = 0x12345678;
-    var normalJs = "(function(stdlib, foreign, heap) { " + interior + " })";
+    var normalJs = `(function(stdlib, foreign, heap) { ${interior} })`;
     var normalModule = eval(normalJs); /* eslint-disable-line no-eval */
     var normalFun = normalModule(stdlib, pureForeign, normalHeap);
 
@@ -147,7 +147,7 @@ function testAsmDifferential (stdlib, interior) { /* eslint-disable-line require
 // Call this instead of start() to run asm-differential tests
 function startAsmDifferential () { /* eslint-disable-line require-jsdoc */
   var asmFuzzSeed = Math.floor(Math.random() * Math.pow(2, 28));
-  dumpln("asmFuzzSeed: " + asmFuzzSeed);
+  dumpln(`asmFuzzSeed: ${asmFuzzSeed}`);
   Random.init(asmFuzzSeed);
 
   while (true) {

--- a/src/funfuzz/js/jsfunfuzz/test-consistency.js
+++ b/src/funfuzz/js/jsfunfuzz/test-consistency.js
@@ -22,19 +22,19 @@ function sandboxResult (code, zone) { /* eslint-disable-line require-jsdoc */
     result = evalcx(code, sandbox);
     if (typeof result !== "object") {
       // Avoid cross-compartment excitement if it has a toString
-      resultStr = "" + result;
+      resultStr = `${result}`;
     }
   } catch (e) {
-    result = "Error: " + errorToString(e);
+    result = `Error: ${errorToString(e)}`;
   }
-  // print("resultStr: " + resultStr);
+  // print(`resultStr: ${resultStr}`);
   return resultStr;
 }
 
 function nestingConsistencyTest (code) { /* eslint-disable-line require-jsdoc */
   // Inspired by bug 676343
   // This only makes sense if |code| is an expression (or an expression followed by a semicolon). Oh well.
-  function nestExpr (e) { return "(function() { return " + code + "; })()"; } /* eslint-disable-line require-jsdoc */
+  function nestExpr (e) { return `(function() { return ${code}; })()`; } /* eslint-disable-line require-jsdoc */
   var codeNestedOnce = nestExpr(code);
   var codeNestedDeep = code;
   var depth = (count % 7) + 14; // 16 might be special
@@ -46,11 +46,11 @@ function nestingConsistencyTest (code) { /* eslint-disable-line require-jsdoc */
   var resultO = sandboxResult(codeNestedOnce, null); var resultD = sandboxResult(codeNestedDeep, null);
 
   // if (resultO != "" && resultO != "undefined" && resultO != "use strict")
-  //   print("NestTest: " + resultO);
+  //   print(`NestTest: ${resultO}`);
 
   if (resultO !== resultD) {
     foundABug("NestTest mismatch",
-      "resultO: " + resultO + "\n" +
-      "resultD: " + resultD);
+      `resultO: ${resultO}\n` +
+      `resultD: ${resultD}`);
   }
 }

--- a/src/funfuzz/js/jsfunfuzz/test-math.js
+++ b/src/funfuzz/js/jsfunfuzz/test-math.js
@@ -102,9 +102,9 @@ function makeMathyFunAndTest (d, b) { /* eslint-disable-line require-jsdoc */
 
   if (rnd(5)) {
     if (rnd(8)) {
-      s += "mathy" + i + " = " + makeMathFunction(6, b, i) + "; ";
+      s += `mathy${i} = ${makeMathFunction(6, b, i)}; `;
     } else {
-      s += "mathy" + i + " = " + makeAsmJSFunction(6, b) + "; ";
+      s += `mathy${i} = ${makeAsmJSFunction(6, b)}; `;
     }
   }
 
@@ -113,12 +113,12 @@ function makeMathyFunAndTest (d, b) { /* eslint-disable-line require-jsdoc */
     switch (rnd(8)) {
       /* eslint-disable no-multi-spaces */
       case 0:  inputsStr = makeMixedTypeArray(d - 1, b); break;
-      case 1:  inputsStr = "[" + Random.shuffled(confusableVals).join(", ") + "]"; break;
-      default: inputsStr = "[" + Random.shuffled(numericVals).join(", ") + "]"; break;
+      case 1:  inputsStr = `[${Random.shuffled(confusableVals).join(", ")}]`; break;
+      default: inputsStr = `[${Random.shuffled(numericVals).join(", ")}]`; break;
       /* eslint-enable no-multi-spaces */
     }
 
-    s += "testMathyFunction(mathy" + i + ", " + inputsStr + "); ";
+    s += `testMathyFunction(mathy${i}, ${inputsStr}); `;
   }
 
   return s;
@@ -127,5 +127,5 @@ function makeMathyFunAndTest (d, b) { /* eslint-disable-line require-jsdoc */
 function makeMathyFunRef (d, b) { /* eslint-disable-line require-jsdoc */
   if (rnd(TOTALLY_RANDOM) === 2) return totallyRandom(d, b);
 
-  return "mathy" + rnd(NUM_MATH_FUNCTIONS);
+  return `mathy${rnd(NUM_MATH_FUNCTIONS)}`;
 }

--- a/src/funfuzz/js/jsfunfuzz/test-misc.js
+++ b/src/funfuzz/js/jsfunfuzz/test-misc.js
@@ -37,7 +37,7 @@ function optionalTests (f, code, wtt) { /* eslint-disable-line require-jsdoc */
 }
 
 function testExpressionDecompiler (code) { /* eslint-disable-line require-jsdoc */
-  var fullCode = "(function() { try { \n" + code + "\n; throw 1; } catch(exx) { this.nnn.nnn } })()";
+  var fullCode = `(function() { try { \n${code}\n; throw 1; } catch(exx) { this.nnn.nnn } })()`;
 
   try {
     eval(fullCode); /* eslint-disable-line no-eval */
@@ -60,19 +60,19 @@ function tryHalves (code) { /* eslint-disable-line require-jsdoc */
 
   try {
     firstHalf = code.substr(0, code.length / 2);
-    if (verbose) { dumpln("First half: " + firstHalf); }
+    if (verbose) { dumpln(`First half: ${firstHalf}`); }
     f = new Function(firstHalf); /* eslint-disable-line no-new-func */
-    void ("" + f);
+    void (`${f}`);
   } catch (e) {
-    if (verbose) { dumpln("First half compilation error: " + e); }
+    if (verbose) { dumpln(`First half compilation error: ${e}`); }
   }
 
   try {
     secondHalf = code.substr(code.length / 2, code.length);
-    if (verbose) { dumpln("Second half: " + secondHalf); }
+    if (verbose) { dumpln(`Second half: ${secondHalf}`); }
     f = new Function(secondHalf); /* eslint-disable-line no-new-func */
-    void ("" + f);
+    void (`${f}`);
   } catch (e) {
-    if (verbose) { dumpln("Second half compilation error: " + e); }
+    if (verbose) { dumpln(`Second half compilation error: ${e}`); }
   }
 }

--- a/src/funfuzz/js/jsfunfuzz/test-regex.js
+++ b/src/funfuzz/js/jsfunfuzz/test-regex.js
@@ -21,8 +21,8 @@ function randomRegexFlags () { /* eslint-disable-line require-jsdoc */
 
 function toRegexSource (rexpat) { /* eslint-disable-line require-jsdoc */
   return (rnd(2) === 0 && rexpat.charAt(0) !== "*") ?
-    "/" + rexpat + "/" + randomRegexFlags() :
-    "new RegExp(" + simpleSource(rexpat) + ", " + simpleSource(randomRegexFlags()) + ")";
+    `/${rexpat}/${randomRegexFlags()}` :
+    `new RegExp(${simpleSource(rexpat)}, ${simpleSource(randomRegexFlags())})`;
 }
 
 function makeRegexUseBlock (d, b, rexExpr, strExpr) { /* eslint-disable-line require-jsdoc */
@@ -35,21 +35,21 @@ function makeRegexUseBlock (d, b, rexExpr, strExpr) { /* eslint-disable-line req
 
   var bv = b.concat(["s", "r"]);
 
-  return ("/*RXUB*/var r = " + rexExpr + "; " +
-          "var s = " + strExpr + "; " +
-          "print(" +
-            Random.index([
-              "r.exec(s)",
-              "uneval(r.exec(s))",
-              "r.test(s)",
-              "s.match(r)",
-              "uneval(s.match(r))",
-              "s.search(r)",
-              "s.replace(r, " + makeReplacement(d, bv) + (rnd(3) ? "" : ", " + simpleSource(randomRegexFlags())) + ")",
-              "s.split(r)"
-            ]) +
-          "); " +
-          (rnd(3) ? "" : "print(r.lastIndex); ")
+  return (`/*RXUB*/var r = ${rexExpr}; ` +
+      `var s = ${strExpr}; ` +
+      "print(" +
+      Random.index([
+        "r.exec(s)",
+        "uneval(r.exec(s))",
+        "r.test(s)",
+        "s.match(r)",
+        "uneval(s.match(r))",
+        "s.search(r)",
+        `s.replace(r, ${makeReplacement(d, bv)}${rnd(3) ? "" : `, ${simpleSource(randomRegexFlags())}`})`,
+        "s.split(r)"
+      ]) +
+      "); " +
+      (rnd(3) ? "" : "print(r.lastIndex); ")
   );
 }
 
@@ -61,7 +61,7 @@ function makeRegexUseExpr (d, b) { /* eslint-disable-line require-jsdoc */
   var rexExpr = rnd(10) === 0 ? makeExpr(d - 1, b) : toRegexSource(rexpat);
   var strExpr = rnd(10) === 0 ? makeExpr(d - 1, b) : simpleSource(str);
 
-  return "/*RXUE*/" + rexExpr + ".exec(" + strExpr + ")";
+  return `/*RXUE*/${rexExpr}.exec(${strExpr})`;
 }
 
 function makeRegex (d, b) { /* eslint-disable-line require-jsdoc */

--- a/src/funfuzz/js/shared/random.js
+++ b/src/funfuzz/js/shared/random.js
@@ -33,7 +33,7 @@ var Random = {
     // Returns an integer in [start, limit]. Uniform distribution.
     if (isNaN(start) || isNaN(limit)) {
       Utils.traceback();
-      throw new TypeError("Random.range() received a non number type: '" + start + "', '" + limit + "')");
+      throw new TypeError(`Random.range() received a non number type: '${start}', '${limit}')`);
     }
     return Random.number(limit - start + 1) + start;
   },
@@ -44,7 +44,7 @@ var Random = {
   index: function (list, emptyr) {
     if (!(list instanceof Array || (typeof list !== "string" && "length" in list))) {
       Utils.traceback();
-      throw new TypeError("Random.index() received a non array type: '" + list + "'");
+      throw new TypeError(`Random.index() received a non array type: '${list}'`);
     }
     if (!list.length) { return emptyr; }
     return list[this.number(list.length)];
@@ -74,14 +74,14 @@ var Random = {
     }
     if (isNaN(limit)) {
       Utils.traceback();
-      throw new TypeError("Random.chance() received a non number type: '" + limit + "'");
+      throw new TypeError(`Random.chance() received a non number type: '${limit}'`);
     }
     return this.number(limit) === 1;
   },
   choose: function (list, flat) {
     if (!(list instanceof Array)) {
       Utils.traceback();
-      throw new TypeError("Random.choose() received a non-array type: '" + list + "'");
+      throw new TypeError(`Random.choose() received a non-array type: '${list}'`);
     }
     var total = 0;
     for (var i = 0; i < list.length; i++) {

--- a/src/funfuzz/js/shared/testing-functions.js
+++ b/src/funfuzz/js/shared/testing-functions.js
@@ -32,24 +32,24 @@ function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) { /* eslint-disabl
     if (levelTwo >= 5) ++levelTwo; // gczeal 5 does not exist, so repurpose it
     if (levelTwo >= 6) ++levelTwo; // gczeal 6 does not exist, so repurpose it
 
-    if (level >= 3) finalLevel = '"' + (++level) + ";" + levelTwo + '"'; // gczeal 3 does not exist, so repurpose it
-    if (level >= 5) finalLevel = '"' + (++level) + ";" + levelTwo + '"'; // gczeal 5 does not exist, so repurpose it
-    if (level >= 6) finalLevel = '"' + (++level) + ";" + levelTwo + '"'; // gczeal 6 does not exist, so repurpose it
+    if (level >= 3) finalLevel = `"${++level};${levelTwo}"`; // gczeal 3 does not exist, so repurpose it
+    if (level >= 5) finalLevel = `"${++level};${levelTwo}"`; // gczeal 5 does not exist, so repurpose it
+    if (level >= 6) finalLevel = `"${++level};${levelTwo}"`; // gczeal 6 does not exist, so repurpose it
 
     var period = numberOfAllocs();
-    return prefix + "gczeal" + "(" + finalLevel + ", " + period + ");";
+    return `${prefix}gczeal(${finalLevel}, ${period});`;
   }
 
   function callSetGCCallback () { /* eslint-disable-line require-jsdoc */
     // https://dxr.mozilla.org/mozilla-central/source/js/src/shell/js.cpp - SetGCCallback
     var phases = Random.index(["both", "begin", "end"]);
-    var actionAndOptions = rnd(2) ? 'action: "majorGC", depth: ' + rnd(17) : 'action: "minorGC"';
-    var arg = "{ " + actionAndOptions + ", phases: \"" + phases + "\" }";
-    return prefix + "setGCCallback(" + arg + ");";
+    var actionAndOptions = rnd(2) ? `action: "majorGC", depth: ${rnd(17)}` : 'action: "minorGC"';
+    var arg = `{ ${actionAndOptions}, phases: "${phases}" }`;
+    return `${prefix}setGCCallback(${arg});`;
   }
 
   function tryCatch (statement) { /* eslint-disable-line require-jsdoc */
-    return "try { " + statement + " } catch(e) { }";
+    return `try { ${statement} } catch(e) { }`;
   }
 
   function setGcparam () { /* eslint-disable-line require-jsdoc */
@@ -64,7 +64,7 @@ function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) { /* eslint-disabl
 
     function _set (name, value) { /* eslint-disable-line require-jsdoc */
       // try..catch because gcparam sets may throw, depending on GC state (see bug 973571)
-      return tryCatch(prefix + "gcparam" + "('" + name + "', " + value + ");");
+      return tryCatch(`${prefix}gcparam('${name}', ${value});`);
     }
   }
 
@@ -73,29 +73,29 @@ function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) { /* eslint-disabl
   var sharedTestingFunctions = [
     /* eslint-disable no-multi-spaces */
     // Force garbage collection (global or specific compartment)
-    { w: 10, v: function (d, b) { return "void " + prefix + "gc" + "("                                            + ");"; } },
-    { w: 10, v: function (d, b) { return "void " + prefix + "gc" + "(" + "'compartment'" + maybeCommaShrinking() + ");"; } },
-    { w: 5,  v: function (d, b) { return "void " + prefix + "gc" + "(" + fGlobal(d, b)   + maybeCommaShrinking() + ");"; } },
+    { w: 10, v: function (d, b) { return `void ${prefix}gc();`; } },
+    { w: 10, v: function (d, b) { return `void ${prefix}gc('compartment'${maybeCommaShrinking()});`; } },
+    { w: 5,  v: function (d, b) { return `void ${prefix}gc(${fGlobal(d, b)}${maybeCommaShrinking()});`; } },
     /* eslint-enable no-multi-spaces */
 
     // Run a minor garbage collection on the nursery.
-    { w: 20, v: function (d, b) { return prefix + "minorgc" + "(false);"; } },
-    { w: 20, v: function (d, b) { return prefix + "minorgc" + "(true);"; } },
+    { w: 20, v: function (d, b) { return `${prefix}minorgc(false);`; } },
+    { w: 20, v: function (d, b) { return `${prefix}minorgc(true);`; } },
 
     // Start, continue, or abort incremental garbage collection.
     // startgc can throw: "Incremental GC already in progress"
-    { w: 20, v: function (d, b) { return tryCatch(prefix + "startgc" + "(" + gcSliceSize() + maybeCommaShrinking() + ");"); } },
-    { w: 20, v: function (d, b) { return prefix + "gcslice" + "(" + gcSliceSize() + ");"; } },
-    { w: 10, v: function (d, b) { return prefix + "abortgc" + "(" + ");"; } },
+    { w: 20, v: function (d, b) { return tryCatch(`${prefix}startgc(${gcSliceSize()}${maybeCommaShrinking()});`); } },
+    { w: 20, v: function (d, b) { return `${prefix}gcslice(${gcSliceSize()});`; } },
+    { w: 10, v: function (d, b) { return `${prefix}abortgc();`; } },
 
     // Schedule the given objects to be marked in the next GC slice.
-    { w: 10, v: function (d, b) { return prefix + "selectforgc" + "(" + fObject(d, b) + ");"; } },
+    { w: 10, v: function (d, b) { return `${prefix}selectforgc(${fObject(d, b)});`; } },
 
     // Add a compartment to the next garbage collection.
-    { w: 10, v: function (d, b) { return "void " + prefix + "schedulegc" + "(" + fGlobal(d, b) + ");"; } },
+    { w: 10, v: function (d, b) { return `void ${prefix}schedulegc(${fGlobal(d, b)});`; } },
 
     // Schedule a GC for after N allocations.
-    { w: 10, v: function (d, b) { return "void " + prefix + "schedulegc" + "(" + numberOfAllocs() + ");"; } },
+    { w: 10, v: function (d, b) { return `void ${prefix}schedulegc(${numberOfAllocs()});`; } },
 
     // Change a GC parameter.
     { w: 10, v: setGcparam },
@@ -103,63 +103,63 @@ function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) { /* eslint-disabl
     // Verify write barriers. This functions is effective in pairs.
     // The first call sets up the start barrier, the second call sets up the end barrier.
     // Nothing happens when there is only one call.
-    { w: 10, v: function (d, b) { return prefix + "verifyprebarriers" + "();"; } },
+    { w: 10, v: function (d, b) { return `${prefix}verifyprebarriers();`; } },
 
     // hasChild(parent, child): Return true if |child| is a child of |parent|, as determined by a call to TraceChildren.
     // We ignore the return value because hasChild can be used to see which WeakMap entries have been GCed.
-    { w: 1, v: function (d, b) { return "void " + prefix + "hasChild(" + fObject(d, b) + ", " + fObject(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return `void ${prefix}hasChild(${fObject(d, b)}, ${fObject(d, b)});`; } },
 
     // Various validation functions (toggles)
-    { w: 5, v: function (d, b) { return prefix + "fullcompartmentchecks" + "(false);"; } },
-    { w: 1, v: function (d, b) { return prefix + "fullcompartmentchecks" + "(true);"; } },
-    { w: 5, v: function (d, b) { return prefix + "setIonCheckGraphCoherency" + "(false);"; } },
-    { w: 1, v: function (d, b) { return prefix + "setIonCheckGraphCoherency" + "(true);"; } },
-    { w: 1, v: function (d, b) { return prefix + "enableOsiPointRegisterChecks" + "();"; } },
+    { w: 5, v: function (d, b) { return `${prefix}fullcompartmentchecks(false);`; } },
+    { w: 1, v: function (d, b) { return `${prefix}fullcompartmentchecks(true);`; } },
+    { w: 5, v: function (d, b) { return `${prefix}setIonCheckGraphCoherency(false);`; } },
+    { w: 1, v: function (d, b) { return `${prefix}setIonCheckGraphCoherency(true);`; } },
+    { w: 1, v: function (d, b) { return `${prefix}enableOsiPointRegisterChecks();`; } },
 
     // Various validation functions (immediate)
-    { w: 1, v: function (d, b) { return prefix + "assertJitStackInvariants" + "();"; } },
+    { w: 1, v: function (d, b) { return `${prefix}assertJitStackInvariants();`; } },
 
     // Run-time equivalents to --baseline-eager, --baseline-warmup-threshold, --ion-eager, --ion-warmup-threshold
-    { w: 1, v: function (d, b) { return prefix + "setJitCompilerOption" + "('baseline.warmup.trigger', " + rnd(20) + ");"; } },
-    { w: 1, v: function (d, b) { return prefix + "setJitCompilerOption" + "('ion.warmup.trigger', " + rnd(40) + ");"; } },
+    { w: 1, v: function (d, b) { return `${prefix}setJitCompilerOption('baseline.warmup.trigger', ${rnd(20)});`; } },
+    { w: 1, v: function (d, b) { return `${prefix}setJitCompilerOption('ion.warmup.trigger', ${rnd(40)});`; } },
 
     // Test the baseline compiler
-    { w: 10, v: function (d, b) { return prefix + "baselineCompile" + "();"; } },
+    { w: 10, v: function (d, b) { return `${prefix}baselineCompile();`; } },
 
     // Force inline cache.
-    { w: 1, v: function (d, b) { return prefix + "setJitCompilerOption" + "('ion.forceinlineCaches', " + rnd(2) + ");"; } },
+    { w: 1, v: function (d, b) { return `${prefix}setJitCompilerOption('ion.forceinlineCaches', ${rnd(2)});`; } },
 
     // Run-time equivalents to --no-ion, --no-baseline
     // These can throw: "Can't turn off JITs with JIT code on the stack."
-    { w: 1, v: function (d, b) { return tryCatch(prefix + "setJitCompilerOption" + "('ion.enable', " + rnd(2) + ");"); } },
-    { w: 1, v: function (d, b) { return tryCatch(prefix + "setJitCompilerOption" + "('baseline.enable', " + rnd(2) + ");"); } },
+    { w: 1, v: function (d, b) { return tryCatch(`${prefix}setJitCompilerOption('ion.enable', ${rnd(2)});`); } },
+    { w: 1, v: function (d, b) { return tryCatch(`${prefix}setJitCompilerOption('baseline.enable', ${rnd(2)});`); } },
 
     // Test the built-in profiler.
-    { w: 1, v: function (d, b) { return prefix + "enableGeckoProfiling" + "();"; } },
-    { w: 1, v: function (d, b) { return prefix + "enableGeckoProfilingWithSlowAssertions" + "();"; } },
-    { w: 5, v: function (d, b) { return prefix + "disableGeckoProfiling" + "();"; } },
-    { w: 1, v: function (d, b) { return "void " + prefix + "readGeckoProfilingStack" + "();"; } },
+    { w: 1, v: function (d, b) { return `${prefix}enableGeckoProfiling();`; } },
+    { w: 1, v: function (d, b) { return `${prefix}enableGeckoProfilingWithSlowAssertions();`; } },
+    { w: 5, v: function (d, b) { return `${prefix}disableGeckoProfiling();`; } },
+    { w: 1, v: function (d, b) { return `void ${prefix}readGeckoProfilingStack();`; } },
 
     // I'm not sure what this does in the shell.
-    { w: 5, v: function (d, b) { return prefix + "deterministicgc" + "(false);"; } },
-    { w: 1, v: function (d, b) { return prefix + "deterministicgc" + "(true);"; } },
+    { w: 5, v: function (d, b) { return `${prefix}deterministicgc(false);`; } },
+    { w: 1, v: function (d, b) { return `${prefix}deterministicgc(true);`; } },
 
     // Causes JIT code to always be preserved by GCs afterwards (see https://bugzilla.mozilla.org/show_bug.cgi?id=750834)
-    { w: 5, v: function (d, b) { return prefix + "gcPreserveCode" + "();"; } },
+    { w: 5, v: function (d, b) { return `${prefix}gcPreserveCode();`; } },
 
     // Generate an LCOV trace (but throw away the returned string)
-    { w: 1, v: function (d, b) { return "void " + prefix + "getLcovInfo" + "();"; } },
-    { w: 1, v: function (d, b) { return "void " + prefix + "getLcovInfo" + "(" + fGlobal(d, b) + ");"; } },
+    { w: 1, v: function (d, b) { return `void ${prefix}getLcovInfo();`; } },
+    { w: 1, v: function (d, b) { return `void ${prefix}getLcovInfo(${fGlobal(d, b)});`; } },
 
     // JIT bailout
-    { w: 5, v: function (d, b) { return prefix + "bailout" + "();"; } },
-    { w: 10, v: function (d, b) { return prefix + "bailAfter" + "(" + numberOfInstructions() + ");"; } },
+    { w: 5, v: function (d, b) { return `${prefix}bailout();`; } },
+    { w: 10, v: function (d, b) { return `${prefix}bailAfter(${numberOfInstructions()});`; } },
 
     // Enable some slow Shape assertions. See bug 1412289
-    { w: 1, v: function (d, b) { return prefix + "enableShapeConsistencyChecks" + "();"; } },
+    { w: 1, v: function (d, b) { return `${prefix}enableShapeConsistencyChecks();`; } },
 
     // Create gray root Array for the current compartment. See bug 1452602
-    { w: 1, v: function (d, b) { return prefix + "grayRoot" + "();"; } }
+    { w: 1, v: function (d, b) { return `${prefix}grayRoot();`; } }
   ];
 
   // Functions only in the SpiderMonkey shell
@@ -167,25 +167,25 @@ function fuzzTestingFunctionsCtor (browser, fGlobal, fObject) { /* eslint-disabl
   var shellOnlyTestingFunctions = [
     // ARM simulator settings
     // These throw when not in the ARM simulator.
-    { w: 1, v: function (d, b) { return tryCatch("(void" + prefix + "disableSingleStepProfiling" + "()" + ")"); } },
-    { w: 1, v: function (d, b) { return tryCatch("(" + prefix + "enableSingleStepProfiling" + "()" + ")"); } },
+    { w: 1, v: function (d, b) { return tryCatch(`(void${prefix}disableSingleStepProfiling())`); } },
+    { w: 1, v: function (d, b) { return tryCatch(`(${prefix}enableSingleStepProfiling())`); } },
 
     // Force garbage collection with function relazification
-    { w: 10, v: function (d, b) { return "void " + prefix + "relazifyFunctions" + "();"; } },
-    { w: 10, v: function (d, b) { return "void " + prefix + "relazifyFunctions" + "('compartment');"; } },
-    { w: 5, v: function (d, b) { return "void " + prefix + "relazifyFunctions" + "(" + fGlobal(d, b) + ");"; } },
+    { w: 10, v: function (d, b) { return `void ${prefix}relazifyFunctions();`; } },
+    { w: 10, v: function (d, b) { return `void ${prefix}relazifyFunctions('compartment');`; } },
+    { w: 5, v: function (d, b) { return `void ${prefix}relazifyFunctions(${fGlobal(d, b)});`; } },
 
     // Test recomputeWrappers - see bug 1492406
-    { w: 10, v: function (d, b) { return prefix + "recomputeWrappers" + "();"; } },
+    { w: 10, v: function (d, b) { return `${prefix}recomputeWrappers();`; } },
     // Also test recomputeWrappers calling newGlobal, see the bug
 
     // [TestingFunctions.cpp, but debug-only and CRASHY]
     // After N js_malloc memory allocations, fail every following allocation
-    { w: 1, v: function (d, b) { return (typeof oomAfterAllocations === "function" && rnd(1000) === 0) ? prefix + "oomAfterAllocations" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
+    { w: 1, v: function (d, b) { return (typeof oomAfterAllocations === "function" && rnd(1000) === 0) ? `${prefix}oomAfterAllocations(${numberOfAllocs() - 1});` : "void 0;"; } },
     // After N js_malloc memory allocations, fail one allocation
-    { w: 1, v: function (d, b) { return (typeof oomAtAllocation === "function" && rnd(100) === 0) ? prefix + "oomAtAllocation" + "(" + (numberOfAllocs() - 1) + ");" : "void 0;"; } },
+    { w: 1, v: function (d, b) { return (typeof oomAtAllocation === "function" && rnd(100) === 0) ? `${prefix}oomAtAllocation(${numberOfAllocs() - 1});` : "void 0;"; } },
     // Reset either of the above
-    { w: 1, v: function (d, b) { return (typeof resetOOMFailure === "function") ? "void " + prefix + "resetOOMFailure" + "(" + ");" : "void 0;"; } },
+    { w: 1, v: function (d, b) { return (typeof resetOOMFailure === "function") ? `void ${prefix}resetOOMFailure();` : "void 0;"; } },
 
     // [TestingFunctions.cpp, but SLOW]
     // Make garbage collection extremely frequent

--- a/src/funfuzz/js/shell_flags.py
+++ b/src/funfuzz/js/shell_flags.py
@@ -41,6 +41,8 @@ def add_random_arch_flags(shell_path, input_list=False):
     Returns:
         list: List of flags to be tested, with probable architecture-related flags added.
     """
+    # m-c rev 330353:bb868860dfc3 is the earliest known working revision, so stop testing prior existence of flag
+
     if inspect_shell.queryBuildConfiguration(shell_path, "arm-simulator") and chance(.7):
         # m-c rev 165993:c450eb3abde4, see bug 965247
         input_list.append("--arm-sim-icache-checks")
@@ -53,14 +55,12 @@ def add_random_arch_flags(shell_path, input_list=False):
         # m-c rev 190582:5399dc155c3b, see bug 1028008
         input_list.append("--arm-hwcap=vfp")
 
-    if shell_supports_flag(shell_path, "--enable-avx") and chance(.2):
+    if chance(.2):
         # m-c rev 223959:5e6e959f0043, see bug 1118235
         input_list.append("--enable-avx")
-    elif shell_supports_flag(shell_path, "--no-avx") and chance(.2):
+    elif chance(.2):
         # m-c rev 223959:5e6e959f0043, see bug 1118235
         input_list.append("--no-avx")
-
-    # m-c rev 222786:bcacb5692ad9 is the earliest known working revision, so stop testing prior existence of flag
 
     if chance(.2):  # m-c rev 154600:526ba3ace37a, see bug 935791
         input_list.append("--no-sse" + ("3" if chance(.5) else "4"))
@@ -105,33 +105,34 @@ def add_random_ion_flags(shell_path, input_list=False):  # pylint: disable=too-c
     if shell_supports_flag(shell_path, "--no-bigint") and chance(.2):
         # m-c rev 461970:e262ebb01282, see bug 1527900
         input_list.append("--no-bigint")
-    if shell_supports_flag(shell_path, "--cache-ir-stubs=on") and chance(.2):
+
+    # m-c rev 330353:bb868860dfc3 is the earliest known working revision, so stop testing prior existence of flag
+
+    if chance(.2):
         # m-c rev 308931:1c5b92144e1e, see bug 1292659
         input_list.append("--cache-ir-stubs=" + ("on" if chance(.1) else "off"))
-    if shell_supports_flag(shell_path, "--ion-pgo=on") and chance(.2):
+    if chance(.2):
         # m-c rev 272274:b0a0ff5fa705, see bug 1209515
         input_list.append("--ion-pgo=" + ("on" if chance(.1) else "off"))
-    if shell_supports_flag(shell_path, "--ion-sincos=on") and chance(.2):
+    if chance(.2):
         # m-c rev 262544:3dec2b935295, see bug 984018
         input_list.append("--ion-sincos=" + ("on" if chance(.5) else "off"))
-    if shell_supports_flag(shell_path, "--ion-instruction-reordering=on") and chance(.2):
+    if chance(.2):
         # m-c rev 259672:59d2f2e62420, see bug 1195545
         input_list.append("--ion-instruction-reordering=" + ("on" if chance(.9) else "off"))
-    if shell_supports_flag(shell_path, "--ion-regalloc=testbed") and chance(.2):
+    if chance(.2):
         # m-c rev 248962:47e92bae09fd, see bug 1170840
         input_list.append("--ion-regalloc=testbed")
 
     forceinline_cmd = '--execute=\"setJitCompilerOption(\\\"ion.forceinlineCaches\\\",1)\"'
     # The only way I could make nested double quotes work with subprocess. See https://stackoverflow.com/a/35913597
     forceinline_shell_cmd = re.findall(r'(?:[^\s,"]|"(?:\\.|[^"])*")+', forceinline_cmd)[0]
-    if shell_supports_flag(shell_path, forceinline_shell_cmd) and chance(.2):
+    if chance(.2):
         # m-c rev 247709:ea9608e33abe, see bug 923717
         input_list.append(forceinline_shell_cmd)
-    if shell_supports_flag(shell_path, "--ion-extra-checks") and chance(.2):
+    if chance(.2):
         # m-c rev 234228:cdf93416b39a, see bug 1139152
         input_list.append("--ion-extra-checks")
-
-    # m-c rev 222786:bcacb5692ad9 is the earliest known working revision, so stop testing prior existence of flag
 
     # --ion-sink=on is still not ready to be fuzzed
     # if chance(.2):  # m-c rev 217242:9188c8b7962b, see bug 1093674
@@ -202,7 +203,7 @@ def add_random_wasm_flags(shell_path, input_list=False):
         # m-c rev 387188:b1dc87a94262, see bug 1388785
         input_list.append("--test-wasm-await-tier2")
 
-    # m-c rev 222786:bcacb5692ad9 is the earliest known working revision, so stop testing prior existence of flag
+    # m-c rev 330353:bb868860dfc3 is the earliest known working revision, so stop testing prior existence of flag
 
     if chance(.7):  # m-c rev 124920:b3d85b68449d, see bug 840282
         input_list.append("--no-asmjs")

--- a/src/funfuzz/util/sm_compile_helpers.py
+++ b/src/funfuzz/util/sm_compile_helpers.py
@@ -149,58 +149,6 @@ def get_lock_dir_path(cache_dir_base, repo_dir, tbox_id=""):
     return ensure_cache_dir(cache_dir_base) / lockdir_name
 
 
-def icu_m4_undo(tree):
-    """Reverse-replaces a change for a local mozilla repository tree, needed to compile on Linux systems with sed >= 4.3
-
-    Note that has only been tested to work on Linux sed, not macOS BSD sed.
-
-    Args:
-        tree (Path): Local mozilla repository tree
-    """
-    assert platform.system() == "Linux"
-    icu_m4 = tree / "build" / "autoconf" / "icu.m4"
-
-    # Read icu.m4 into memory
-    with io.open(str(icu_m4), "r", encoding="utf-8", errors="replace") as f:
-        contents = f.readlines()
-
-    # Replace line
-    with io.open(str(icu_m4), "w", encoding="utf-8", errors="replace") as f:
-        for line in contents:
-            if "version=`sed -n 's/^[[[:space:]]]*#[[:space:]]*define[[:space:]][[:space:]]*" in line:
-                f.write("    version=`sed -n 's/^[[:space:]]*#[[:space:]]*define[[:space:]][[:space:]]*"
-                        "U_ICU_VERSION_MAJOR_NUM[[:space:]][[:space:]]*\\([0-9][0-9]*\\)[[:space:]]*$/\\1/p' "
-                        '"$icudir/common/unicode/uvernum.h"`\n')
-            else:
-                f.write(line)
-
-
-def icu_m4_replace(tree):
-    """Replaces a change for a local mozilla repository tree, needed to compile on Linux systems with sed >= 4.3
-
-    Note that has only been tested to work on Linux sed, not macOS BSD sed.
-
-    Args:
-        tree (Path): Local mozilla repository tree
-    """
-    assert platform.system() == "Linux"
-    icu_m4 = tree / "build" / "autoconf" / "icu.m4"
-
-    # Read icu.m4 into memory
-    with io.open(str(icu_m4), "r", encoding="utf-8", errors="replace") as f:
-        contents = f.readlines()
-
-    # Replace line
-    with io.open(str(icu_m4), "w", encoding="utf-8", errors="replace") as f:
-        for line in contents:
-            if "version=`sed -n 's/^[[:space:]]*#[[:space:]]*define[[:space:]][[:space:]]*" in line:
-                f.write("    version=`sed -n 's/^[[[:space:]]]*#[[:space:]]*define[[:space:]][[:space:]]*"
-                        "U_ICU_VERSION_MAJOR_NUM[[:space:]][[:space:]]*\\([0-9][0-9]*\\)[[:space:]]*$/\\1/p' "
-                        '"$icudir/common/unicode/uvernum.h"`\n')
-            else:
-                f.write(line)
-
-
 def verify_full_win_pageheap(shell_path):
     """Turn on full page heap verification on Windows.
 


### PR DESCRIPTION
Here's the first iteration of moving jsfunfuzz entirely to template literals.

In the harness, I have had to bump the earliest known working revision with stable template literal support to [mozilla-central rev bb868860dfc3](https://hg.mozilla.org/mozilla-central/rev/bb868860dfc3).

It should still be possible (manually, on a separate branch), to still bisect back to [current earliest working rev bcacb5692ad9](https://hg.mozilla.org/mozilla-central/rev/bcacb5692ad9) when the testcase is minimized and does not have any template literals left. However, we tend not to need to bisect back that far (in the timeframe of 2015-2017) for most testcases anymore.

I did most of the conversions using WebStorm's "template literal" suggested replacements via Alt-Enter shortcut, plus `eslint` runs during tests, so the changes should be fairly mechanical to review.